### PR TITLE
fix: close stale-read race window in Obsidian file-watcher (Issue #6)

### DIFF
--- a/docs/FORMAL_VERIFICATION.md
+++ b/docs/FORMAL_VERIFICATION.md
@@ -1,0 +1,950 @@
+# Formal Verification of the Syncline Synchronization Protocol
+
+This document describes how to formally verify the Syncline synchronization protocol using [TLA+](https://lamport.azurewebsites.net/tla/tla.html) — a formal specification language designed by Leslie Lamport for modeling concurrent and distributed systems.
+
+## 1. Why Formal Verification?
+
+Syncline's synchronization protocol is deceptively complex. While the _Yjs/Yrs_ CRDT library is formally proven to converge, the **system around it** — message ordering, server relay, broadcast channels, offline reconnection, compaction, the index document, and critically the **diff layer** that converts file content to CRDT operations — introduces many places where bugs can hide:
+
+| Risk Area             | Example Bug                                                                                     |
+| --------------------- | ----------------------------------------------------------------------------------------------- |
+| **Message relay**     | Server echoes updates back to the sender → infinite feedback loop (Issue #2)                    |
+| **Channel lifecycle** | New doc updates are dropped if no broadcast channel exists yet (fuzzer-found divergence bug)    |
+| **Diff layer**        | Stale file content fed into `dissimilar::diff` generates DELETE ops for valid data (Issue #6)   |
+| **Client divergence** | Obsidian's `ignoreChanges` timeout vs folder client's sync-before-apply lead to different races |
+| **Compaction**        | Client reconnects after history was compacted → applies update against missing base state       |
+| **Index document**    | Concurrent insertions into `__index__` from multiple connections corrupt the doc list           |
+
+Testing catches many of these, but testing only explores specific execution traces. **TLA+ exhaustively explores _all_ possible interleavings**, including rare race conditions that are impractical to trigger in tests.
+
+### What TLA+ Will and Won't Verify
+
+**In scope** (what TLA+ can verify):
+
+- Convergence: all clients eventually reach the same document state
+- No message duplication: updates are not echoed back to the sender
+- No lost updates: every update is eventually delivered to all connected clients
+- Server persistence: all accepted updates are persisted before broadcast
+- Compaction safety: compacted documents remain equivalent to the full history
+- Index consistency: the `__index__` document accurately reflects all known documents
+- **Diff-layer safety**: stale file reads fed into the differ never cause data loss
+- **Cross-client equivalence**: both Obsidian and folder clients reach the same state under identical scenarios
+
+**Out of scope** (better verified by other means):
+
+- Yrs CRDT merge correctness (proven by the Yjs/YATA literature)
+- The correctness of `dissimilar::diff` itself (it is a well-tested Myers diff library)
+- Binary encoding correctness (`protocol.rs` — unit tests are sufficient)
+- WebSocket transport reliability (handled by the transport layer)
+- SQLite transactional guarantees (handled by SQLite itself)
+
+---
+
+## 2. TLA+ Primer
+
+For team members unfamiliar with TLA+, here is a minimal introduction.
+
+### Core Concepts
+
+| Concept               | Description                                                               |
+| --------------------- | ------------------------------------------------------------------------- |
+| **State**             | A snapshot of all variable values at a point in time                      |
+| **Behavior**          | An infinite sequence of states (a "trace")                                |
+| **Action**            | A relation between a current state and a next state (a state transition)  |
+| **Specification**     | A formula that constrains the set of valid behaviors                      |
+| **Invariant**         | A predicate that must hold in _every_ reachable state                     |
+| **Temporal Property** | A predicate about the _sequence_ of states (e.g., "eventually X happens") |
+
+### Tooling
+
+| Tool                                                                                           | Purpose                                                                   |
+| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| [TLA+ Toolbox](https://lamport.azurewebsites.net/tla/toolbox.html)                             | IDE with integrated model checker                                         |
+| [TLC](https://lamport.azurewebsites.net/tla/tools.html)                                        | Explicit-state model checker — exhaustively explores all reachable states |
+| [Apalache](https://apalache.informal.systems/)                                                 | Symbolic model checker — uses SMT solvers, better for unbounded models    |
+| [VS Code extension](https://marketplace.visualstudio.com/items?itemName=alygin.vscode-tlaplus) | Syntax highlighting, parse/check integration                              |
+
+### Getting Started
+
+```bash
+# Install the TLA+ Toolbox (Java-based)
+brew install --cask tla-plus-toolbox
+
+# Or use the VS Code extension (recommended for daily use)
+code --install-extension alygin.vscode-tlaplus
+```
+
+---
+
+## 3. System Model
+
+The TLA+ specification models Syncline as a distributed system with the following components.
+Critically, the model must capture the **three-tier architecture** of each client: the CRDT document, the file on disk, and the diff layer that bridges them.
+
+```
+┌──────────────────────┐                           ┌──────────────────────┐
+│ Client A (Obsidian)  │                           │ Client B (Folder)    │
+│                      │                           │                      │
+│  ┌────────────────┐  │     WebSocket              │  ┌────────────────┐  │
+│  │  Obsidian API  │  │  ◄──────────────►         │  │  fs::read/write│  │
+│  │  vault.modify()│  │                           │  │  notify watcher│  │
+│  └───────┬────────┘  │       ┌─────────┐         │  └───────┬────────┘  │
+│          │ debounce   │       │  Server │         │          │ debounce  │
+│     ┌────▼─────┐     │       │         │         │     ┌────▼─────┐    │
+│     │   diff   │     │ ◄───► │   DB    │ ◄─────► │     │   diff   │    │
+│     │dissimilar│     │       │ Channels│         │     │dissimilar│    │
+│     └────┬─────┘     │       └─────────┘         │     └────┬─────┘    │
+│     ┌────▼─────┐     │                           │     ┌────▼─────┐    │
+│     │ Yrs CRDT │     │                           │     │ Yrs CRDT │    │
+│     │ (WASM)   │     │                           │     │ (.bin)   │    │
+│     └──────────┘     │                           │     └──────────┘    │
+└──────────────────────┘                           └──────────────────────┘
+```
+
+### 3.1 Constants and Parameters
+
+```tla
+CONSTANTS
+    Clients,          \* Set of client identifiers, e.g., {"A", "B", "C"}
+    DocIds,           \* Set of document identifiers, e.g., {"doc1", "doc2"}
+    MaxUpdates,       \* Bound on total updates (for finite model checking)
+    CompactionThreshold  \* Number of updates before server compacts
+```
+
+To keep the state space tractable for TLC, we recommend starting with:
+
+- `Clients = {"A", "B"}` (2 clients)
+- `DocIds = {"d1"}` (1 document)
+- `MaxUpdates = 4` (4 total updates)
+- `CompactionThreshold = 3`
+
+This is sufficient to explore all interesting interleavings. The number of clients and documents can be increased later once the base spec is validated.
+
+### 3.2 Variables
+
+The specification tracks the following state. Notably, each client has **two** representations of each document: the CRDT document and the file on disk. The gap between these two is the source of the most subtle bugs.
+
+```tla
+VARIABLES
+    \* --- Client CRDT State ---
+    clientDoc,        \* [Clients -> [DocIds -> Seq(Update)]]
+                      \*   Each client's local CRDT document, modeled as
+                      \*   the ordered sequence of updates it has applied.
+
+    \* --- Client Disk State (the diff layer) ---
+    clientDisk,       \* [Clients -> [DocIds -> Seq(Update)]]
+                      \*   The content currently written to disk. This may
+                      \*   DIVERGE from clientDoc during the window between
+                      \*   a remote update being applied to the CRDT and
+                      \*   the file being written/read back.
+
+    clientIgnoring,   \* [Clients -> SUBSET DocIds]
+                      \*   The set of docs for which the file-watcher is
+                      \*   suppressed (Obsidian's `ignoreChanges` set, or
+                      \*   the folder client's disk==crdt guard).
+
+    \* --- Client Connection State ---
+    clientConnected,  \* [Clients -> BOOLEAN]
+                      \*   Whether each client has an active WebSocket.
+
+    clientSubscribed, \* [Clients -> SUBSET DocIds]
+                      \*   The set of doc_ids this client has sent
+                      \*   MSG_SYNC_STEP_1 for (i.e., is subscribed to
+                      \*   the broadcast channel on the server).
+
+    clientType,       \* [Clients -> {"obsidian", "folder"}]
+                      \*   Which client variant. This determines the
+                      \*   feedback suppression strategy.
+
+    \* --- Network ---
+    clientToServer,   \* [Clients -> Seq(Message)]
+                      \*   In-flight messages from each client to the server.
+                      \*   Modeled as an ordered queue (FIFO per-connection).
+
+    serverToClient,   \* [Clients -> Seq(Message)]
+                      \*   In-flight messages from the server to each client.
+                      \*   Modeled as an ordered queue.
+
+    \* --- Server State ---
+    serverDB,         \* [DocIds -> Seq(Update)]
+                      \*   Server's persistent storage: ordered log of updates
+                      \*   per document.
+
+    serverChannels,   \* [DocIds -> SUBSET Clients]
+                      \*   Which clients are subscribed to each document's
+                      \*   broadcast channel on the server.
+
+    serverIndex,      \* SUBSET DocIds
+                      \*   The set of doc_ids registered in __index__.
+
+    \* --- Global ---
+    updateCounter     \* Nat
+                      \*   Monotonically increasing counter, used to assign
+                      \*   unique IDs to each update for provenance tracking.
+```
+
+### 3.3 Abstracting CRDTs
+
+The key modeling decision is **how to abstract the CRDT**. We do _not_ model Yrs character-level operations. Instead, we model each update as an **opaque token** with a unique ID. Two documents are "converged" when they have applied the exact same _set_ of updates (regardless of order), because the CRDT guarantees order-independence.
+
+This abstraction is valid because:
+
+1. Yrs is independently proven to be a correct CRDT (commutativity, idempotency, associativity).
+2. We are verifying the _protocol layer_ — whether the right updates reach the right places — not the merge algorithm itself.
+
+```tla
+Update == [id: Nat, origin: Clients, docId: DocIds]
+\* An update is uniquely identified by its `id`, originated from `origin`,
+\* and targets document `docId`.
+```
+
+---
+
+## 4. Actions (State Transitions)
+
+The specification defines the following actions, each corresponding to an event in the real system:
+
+### 4.1 Client Actions
+
+#### `ClientEdit(c, d)`
+
+A client `c` makes a local edit to document `d`.
+
+```tla
+ClientEdit(c, d) ==
+    /\ clientConnected[c]                 \* Must be connected (or offline — see below)
+    /\ updateCounter < MaxUpdates         \* Bound for model checking
+    /\ LET u == [id |-> updateCounter + 1, origin |-> c, docId |-> d]
+       IN /\ clientDoc' = [clientDoc EXCEPT ![c][d] = Append(@, u)]
+          /\ updateCounter' = updateCounter + 1
+          \* If connected, enqueue MSG_UPDATE to server
+          /\ IF clientConnected[c]
+             THEN clientToServer' = [clientToServer EXCEPT
+                    ![c] = Append(@, [type |-> "MSG_UPDATE", docId |-> d, update |-> u])]
+             ELSE UNCHANGED clientToServer
+    /\ UNCHANGED <<clientConnected, clientSubscribed, serverToClient,
+                   serverDB, serverChannels, serverIndex>>
+```
+
+#### `ClientGoOffline(c)`
+
+A client disconnects. Any in-flight messages remain in the queue but the server must detect the close.
+
+```tla
+ClientGoOffline(c) ==
+    /\ clientConnected[c]
+    /\ clientConnected' = [clientConnected EXCEPT ![c] = FALSE]
+    /\ clientSubscribed' = [clientSubscribed EXCEPT ![c] = {}]
+    \* Server removes client from all channels
+    /\ serverChannels' = [d \in DocIds |-> serverChannels[d] \ {c}]
+    /\ UNCHANGED <<clientDoc, clientToServer, serverToClient,
+                   serverDB, serverIndex, updateCounter>>
+```
+
+#### `ClientReconnect(c)`
+
+A client comes back online. It sends `MSG_SYNC_STEP_1` for each document it knows about.
+
+```tla
+ClientReconnect(c) ==
+    /\ ~clientConnected[c]
+    /\ clientConnected' = [clientConnected EXCEPT ![c] = TRUE]
+    \* Enqueue SYNC_STEP_1 for every document the client has locally
+    /\ LET knownDocs == {d \in DocIds : clientDoc[c][d] /= <<>>}
+           syncMsgs == {[type |-> "MSG_SYNC_STEP_1",
+                         docId |-> d,
+                         stateVector |-> UpdateIds(clientDoc[c][d])]
+                        : d \in knownDocs}
+       IN clientToServer' = [clientToServer EXCEPT
+            ![c] = @ \o SetToSeq(syncMsgs)]
+    /\ UNCHANGED <<clientDoc, clientSubscribed, serverToClient,
+                   serverDB, serverChannels, serverIndex, updateCounter>>
+```
+
+#### `ClientReceive(c)`
+
+A client processes the next message in its incoming queue.
+
+```tla
+ClientReceive(c) ==
+    /\ serverToClient[c] /= <<>>
+    /\ LET msg == Head(serverToClient[c])
+       IN CASE msg.type = "MSG_SYNC_STEP_2" ->
+                \* Apply the diff — only updates the client doesn't already have
+                LET newUpdates == {u \in msg.updates : u.id \notin UpdateIds(clientDoc[c][msg.docId])}
+                IN clientDoc' = [clientDoc EXCEPT
+                     ![c][msg.docId] = @ \o SetToSeq(newUpdates)]
+            [] msg.type = "MSG_UPDATE" ->
+                \* Apply the single update if not already applied
+                IF msg.update.id \notin UpdateIds(clientDoc[c][msg.docId])
+                THEN clientDoc' = [clientDoc EXCEPT
+                       ![c][msg.docId] = Append(@, msg.update)]
+                ELSE UNCHANGED clientDoc
+          /\ serverToClient' = [serverToClient EXCEPT ![c] = Tail(@)]
+    /\ UNCHANGED <<clientConnected, clientSubscribed, clientToServer,
+                   serverDB, serverChannels, serverIndex, updateCounter>>
+```
+
+### 4.2 Server Actions
+
+#### `ServerReceiveSyncStep1(c)`
+
+Server processes a `MSG_SYNC_STEP_1` from client `c`.
+
+```tla
+ServerReceiveSyncStep1(c) ==
+    /\ clientToServer[c] /= <<>>
+    /\ Head(clientToServer[c]).type = "MSG_SYNC_STEP_1"
+    /\ LET msg == Head(clientToServer[c])
+           d   == msg.docId
+           sv  == msg.stateVector
+           \* Compute the diff: all server-side updates the client doesn't have
+           diff == {u \in ToSet(serverDB[d]) : u.id \notin sv}
+       IN
+       \* Subscribe the client to the broadcast channel
+       /\ serverChannels' = [serverChannels EXCEPT ![d] = @ \cup {c}]
+       /\ clientSubscribed' = [clientSubscribed EXCEPT ![c] = @ \cup {d}]
+       \* Register doc in __index__ if new
+       /\ serverIndex' = serverIndex \cup {d}
+       \* Send MSG_SYNC_STEP_2 with the diff
+       /\ serverToClient' = [serverToClient EXCEPT
+            ![c] = Append(@, [type |-> "MSG_SYNC_STEP_2", docId |-> d, updates |-> diff])]
+       /\ clientToServer' = [clientToServer EXCEPT ![c] = Tail(@)]
+    /\ UNCHANGED <<clientDoc, clientConnected, serverDB, updateCounter>>
+```
+
+#### `ServerReceiveUpdate(c)`
+
+Server processes a `MSG_UPDATE` from client `c`.
+
+```tla
+ServerReceiveUpdate(c) ==
+    /\ clientToServer[c] /= <<>>
+    /\ Head(clientToServer[c]).type = "MSG_UPDATE"
+    /\ LET msg == Head(clientToServer[c])
+           d   == msg.docId
+           u   == msg.update
+       IN
+       \* 1. Persist BEFORE broadcasting (matches real implementation)
+       /\ serverDB' = [serverDB EXCEPT ![d] = Append(@, u)]
+       \* 2. Register in __index__ if new
+       /\ serverIndex' = serverIndex \cup {d}
+       \* 3. Broadcast to all subscribers EXCEPT the sender
+       /\ LET recipients == serverChannels[d] \ {c}
+          IN serverToClient' = [s \in Clients |->
+               IF s \in recipients
+               THEN Append(serverToClient[s],
+                           [type |-> "MSG_UPDATE", docId |-> d, update |-> u])
+               ELSE serverToClient[s]]
+       /\ clientToServer' = [clientToServer EXCEPT ![c] = Tail(@)]
+    /\ UNCHANGED <<clientDoc, clientConnected, clientSubscribed,
+                   serverChannels, updateCounter>>
+```
+
+#### `ServerCompact(d)`
+
+Server compacts the update log for document `d`.
+
+```tla
+ServerCompact(d) ==
+    /\ Len(serverDB[d]) >= CompactionThreshold
+    \* The compacted representation is a single "snapshot" update
+    \* that contains the merged set of all individual update IDs.
+    /\ LET allIds == {u.id : u \in ToSet(serverDB[d])}
+           snapshot == [id |-> -1, origin |-> "server", docId |-> d,
+                        mergedIds |-> allIds]
+       IN serverDB' = [serverDB EXCEPT ![d] = <<snapshot>>]
+    /\ UNCHANGED <<clientDoc, clientConnected, clientSubscribed,
+                   clientToServer, serverToClient, serverChannels,
+                   serverIndex, updateCounter>>
+```
+
+### 4.3 Next-State Relation
+
+```tla
+Next ==
+    \/ \E c \in Clients, d \in DocIds : ClientEdit(c, d)
+    \/ \E c \in Clients : ClientGoOffline(c)
+    \/ \E c \in Clients : ClientReconnect(c)
+    \/ \E c \in Clients : ClientReceive(c)
+    \/ \E c \in Clients : ServerReceiveSyncStep1(c)
+    \/ \E c \in Clients : ServerReceiveUpdate(c)
+    \/ \E d \in DocIds  : ServerCompact(d)
+```
+
+---
+
+## 5. Properties to Verify
+
+### 5.1 Safety Properties (Invariants)
+
+These must hold in **every** reachable state.
+
+#### `TypeOK` — Type Invariant
+
+Ensures all variables stay within their declared domains. This catches modeling errors early.
+
+```tla
+TypeOK ==
+    /\ clientDoc \in [Clients -> [DocIds -> Seq(Update)]]
+    /\ clientConnected \in [Clients -> BOOLEAN]
+    /\ clientSubscribed \in [Clients -> SUBSET DocIds]
+    /\ serverDB \in [DocIds -> Seq(Update)]
+    /\ serverChannels \in [DocIds -> SUBSET Clients]
+    /\ serverIndex \in SUBSET DocIds
+    /\ updateCounter \in Nat
+```
+
+#### `NoEcho` — Updates Never Echoed Back to Sender
+
+The server must never send an update back to the client that originated it. This was a real bug (Issue #2).
+
+```tla
+NoEcho ==
+    \A c \in Clients :
+        \A i \in 1..Len(serverToClient[c]) :
+            LET msg == serverToClient[c][i]
+            IN msg.type = "MSG_UPDATE" => msg.update.origin /= c
+```
+
+#### `PersistBeforeBroadcast` — Updates Are Persisted Before Broadcasting
+
+The server must persist an update to SQLite _before_ broadcasting it. This ensures no concurrent `SyncStep2` response is missing recent updates.
+
+```tla
+PersistBeforeBroadcast ==
+    \* If a MSG_UPDATE for update u is in any client's serverToClient queue,
+    \* then u must already be in serverDB.
+    \A c \in Clients :
+        \A i \in 1..Len(serverToClient[c]) :
+            LET msg == serverToClient[c][i]
+            IN (msg.type = "MSG_UPDATE") =>
+               msg.update \in ToSet(serverDB[msg.docId])
+```
+
+#### `IndexConsistency` — Index Reflects All Known Documents
+
+Every document that exists in `serverDB` with at least one update must be registered in `serverIndex`.
+
+```tla
+IndexConsistency ==
+    \A d \in DocIds :
+        serverDB[d] /= <<>> => d \in serverIndex
+```
+
+#### `ChannelOnlyForConnected` — Only Connected Clients In Channels
+
+Only connected clients should be subscribed to broadcast channels.
+
+```tla
+ChannelOnlyForConnected ==
+    \A d \in DocIds :
+        \A c \in serverChannels[d] :
+            clientConnected[c]
+```
+
+### 5.2 Liveness Properties (Temporal)
+
+These assert that certain conditions _eventually_ become true, given fairness assumptions.
+
+> **Fairness**: We assume _weak fairness_ on all server processing actions (the server eventually processes any message in its incoming queue) and on `ClientReceive` (clients eventually process incoming messages). We do _not_ assume fairness on `ClientEdit`, `ClientGoOffline`, or `ClientReconnect` — the environment is adversarial.
+
+#### `EventualConvergence` — Eventual Consistency
+
+If all clients are connected and no new edits occur, all clients eventually converge to the same document state.
+
+```tla
+EventualConvergence ==
+    \A d \in DocIds :
+        \* If all clients are connected and all queues are empty...
+        <>( (\A c \in Clients : clientConnected[c])
+            /\ (\A c \in Clients : clientToServer[c] = <<>>)
+            /\ (\A c \in Clients : serverToClient[c] = <<>>)
+            \* ...then all clients have the same set of update IDs
+            => (\A c1, c2 \in Clients :
+                  UpdateIds(clientDoc[c1][d]) = UpdateIds(clientDoc[c2][d])))
+```
+
+#### `EventualDelivery` — No Lost Updates
+
+Every update that enters the server is eventually delivered to all connected and subscribed clients.
+
+```tla
+EventualDelivery ==
+    \A u \in Update, d \in DocIds :
+        \* If u is persisted in the server DB...
+        [](u \in ToSet(serverDB[d]) =>
+            \* ...then for every client subscribed to d, eventually u is applied
+            \A c \in Clients :
+                (c \in serverChannels[d] /\ clientConnected[c]) =>
+                    <>(u.id \in UpdateIds(clientDoc[c][d])))
+```
+
+#### `EventualIndexPropagation` — All Clients Learn About All Documents
+
+Every document registered in `serverIndex` is eventually known to all connected clients.
+
+```tla
+EventualIndexPropagation ==
+    \A d \in DocIds :
+        [](d \in serverIndex =>
+            \A c \in Clients :
+                clientConnected[c] => <>(d \in clientSubscribed[c]))
+```
+
+---
+
+## 6. The Diff Layer
+
+The diff layer is the most critical part of the model that the base CRDT abstraction does _not_ cover. Both clients use `dissimilar::diff(old_content, new_content)` to compute a minimal edit script, then translate each diff chunk into Yrs `insert`/`remove_range` operations. This is the code path in:
+
+- **Folder client**: `apply_diff_to_yrs()` in `syncline/src/client/diff.rs`
+- **Obsidian plugin**: `SynclineClient::update()` in `syncline/src/wasm_client.rs`
+
+The diff layer is **not** just a projection — it is a lossy transformation with timing-dependent behavior:
+
+### 6.1 Why the Diff Layer Matters for Formal Verification
+
+```
+        File on disk          dissimilar::diff()          Yrs CRDT
+        ────────────    ──────────────────────────►    ──────────────
+        "Hel"            diff("Hello", "Hel")           DELETE @ 3..5
+        (stale!)         = [Equal("Hel"), Delete("lo")]  (spurious!)
+```
+
+The diff compares `old_content` (the current CRDT text) against `new_content` (what was read from disk). If the disk content is **stale** — i.e., written at time T₁ but read back at T₂ after the CRDT has received newer updates — the diff will generate DELETE operations for the characters that were added between T₁ and T₂. This is exactly Issue #6.
+
+The key insight: **the diff is always correct for the inputs it receives**, but the inputs can be wrong due to timing. TLA+ can exhaustively check all possible timings.
+
+### 6.2 Modeling the Diff as a State Transition
+
+Instead of modeling the diff algorithm itself, we model the **observable effect**: the diff reads `clientDisk[c][d]` and the current `clientDoc[c][d]`, and produces an update that makes the CRDT match the disk.
+
+```tla
+\* The diff operation: client reads disk, diffs against CRDT, generates update.
+\* This is the CORE action where stale-read bugs manifest.
+ClientDiffFromDisk(c, d) ==
+    /\ clientConnected[c]
+    /\ d \notin clientIgnoring[c]       \* File-watcher is not suppressed
+    /\ clientDisk[c][d] /= clientDoc[c][d]  \* Disk differs from CRDT
+    /\ LET diskIds    == UpdateIds(clientDisk[c][d])
+           crdtIds    == UpdateIds(clientDoc[c][d])
+           \* Updates in CRDT but not on disk → would be DELETED by diff
+           toDelete   == crdtIds \ diskIds
+           \* Updates on disk but not in CRDT → would be INSERTED by diff
+           toInsert   == diskIds \ crdtIds
+       IN
+       \* The diff produces a compound update that:
+       \*   1. Removes content the CRDT has but disk doesn't (DANGEROUS if stale)
+       \*   2. Inserts content the disk has but CRDT doesn't
+       /\ LET u == [id |-> updateCounter + 1, origin |-> c, docId |-> d,
+                    deletes |-> toDelete, inserts |-> toInsert]
+          IN /\ clientDoc' = [clientDoc EXCEPT ![c][d] =
+                    \* Remove deleted IDs, add the new compound update
+                    SelectSeq(@, LAMBDA x : x.id \notin toDelete) \o <<u>>]
+             /\ updateCounter' = updateCounter + 1
+             /\ clientToServer' = [clientToServer EXCEPT
+                  ![c] = Append(@, [type |-> "MSG_UPDATE", docId |-> d, update |-> u])]
+    /\ UNCHANGED <<clientDisk, clientIgnoring, clientConnected, clientSubscribed,
+                   serverToClient, serverDB, serverChannels, serverIndex>>
+```
+
+### 6.3 Modeling Disk Writes (Remote Update → File)
+
+When a remote update arrives, the client writes the merged CRDT content to disk. This is where the `clientDisk` variable diverges from `clientDoc`:
+
+```tla
+\* After applying a remote update, write the CRDT content to disk
+\* and suppress the file-watcher for this document.
+ClientWriteToDisk(c, d) ==
+    /\ clientDoc[c][d] /= clientDisk[c][d]  \* CRDT was updated
+    /\ clientDisk' = [clientDisk EXCEPT ![c][d] = clientDoc[c][d]]
+    \* Suppress file-watcher (Obsidian: ignoreChanges.add; Folder: disk==crdt check)
+    /\ clientIgnoring' = [clientIgnoring EXCEPT ![c] = @ \cup {d}]
+    /\ UNCHANGED <<all other variables>>
+```
+
+### 6.4 Modeling the Ignore Timer Expiry
+
+The `ignoreChanges` suppression eventually expires. In Obsidian, this is a 500ms `setTimeout`. In the folder client, the check is `disk_content != yjs_content`. The TLA+ model abstracts this as a non-deterministic action:
+
+```tla
+\* The file-watcher suppression expires.
+\* In Obsidian: setTimeout(() => ignoreChanges.delete(path), 500)
+\* In Folder: implicit via disk==crdt comparison before diffing
+ClientIgnoreExpires(c, d) ==
+    /\ d \in clientIgnoring[c]
+    /\ clientIgnoring' = [clientIgnoring EXCEPT ![c] = @ \ {d}]
+    /\ UNCHANGED <<all other variables>>
+```
+
+**The bug window**: Between `ClientWriteToDisk` and `ClientIgnoreExpires`, if a _new_ remote update arrives and changes `clientDoc` but the disk still has the old content, then after `ClientIgnoreExpires` fires, `ClientDiffFromDisk` will read the stale disk and generate spurious deletes.
+
+---
+
+## 7. Obsidian vs Folder Client Differences
+
+The two client types have materially different architectures that affect synchronization correctness. The TLA+ model must capture these differences.
+
+### 7.1 Architectural Comparison
+
+| Aspect                       | Obsidian Plugin (`wasm_client.rs` + `main.ts`)                              | Folder Client (`client/app.rs`)                                             |
+| ---------------------------- | --------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| **Change detection**         | `vault.on('modify')` → `debounce(300ms)` → `client.update(uuid, content)`   | `notify` crate → `DebouncedWatcher(300ms)` → `apply_diff_to_yrs()`          |
+| **Diff function**            | `SynclineClient::update()` inline diff in WASM                              | `apply_diff_to_yrs()` in `diff.rs`                                          |
+| **Remote update → disk**     | Callback → `onRemoteUpdate()` → `vault.read()` → compare → `vault.modify()` | Inline in event loop → `fs::read_to_string()` → compare → `fs::write()`     |
+| **Feedback suppression**     | `ignoreChanges: Set<string>` with **500ms timer**                           | Compares `disk_content != yjs_content` **before** diffing                   |
+| **Pre-apply local diff**     | ❌ **Not done** — applies remote first, reads local on next modify          | ✅ Reads disk, applies local diff to CRDT **before** applying remote update |
+| **CRDT persistence**         | In-memory only (lost on Obsidian restart)                                   | Persisted to `.syncline/data/{uuid}.bin`                                    |
+| **Rename detection**         | `vault.on('rename')` event → `set_meta_path()`                              | Content-hash matching across delete+create in watcher batch                 |
+| **Path conflict resolution** | Server UUID wins silently                                                   | `resolve_path_conflict()` → renames local to `(client-name).md`             |
+| **Offline bootstrap**        | Re-registers all vault files on connect, pushes full state as `MSG_UPDATE`  | `bootstrap_offline_changes()` — diffs all files against `.bin` state        |
+
+### 7.2 Implications for the TLA+ Model
+
+The most important difference is the **pre-apply local diff** in the folder client. When the folder client receives a remote update, it:
+
+1. Reads the current disk content
+2. Compares disk content to the current CRDT text
+3. If they differ, applies the local diff to the CRDT **first** (broadcasting the local changes)
+4. Then applies the remote update
+
+The Obsidian client does **not** do this. It applies the remote update directly, then writes the merged result to disk, relying on `ignoreChanges` to suppress the file-watcher echo.
+
+This means the Obsidian client has a vulnerability window that the folder client does not:
+
+```
+Obsidian client timeline:
+  t=0ms   Remote update arrives → CRDT updated to "Hello"
+  t=0ms   vault.modify("Hello") called → ignoreChanges.add(path)
+  t=100ms User types locally → file becomes "Hello World"
+  t=300ms debounced onFileModify fires → reads "Hello World"
+          BUT ignoreChanges still active (500ms timeout)
+          → change is SWALLOWED. "World" is lost.
+  t=500ms ignoreChanges.delete(path)
+  t=600ms Next modify event → "Hello World" is finally diffed and sent
+          (only if the user types again; otherwise the edit is silently lost)
+
+Folder client timeline:
+  t=0ms   Remote update arrives
+  t=0ms   Reads disk → "Hello World" (user typed offline)
+  t=0ms   disk != crdt → applies local diff FIRST (broadcasts "World")
+  t=0ms   Then applies remote update → CRDT = "Hello World" (merged)
+  t=0ms   Writes "Hello World" to disk → disk == crdt, no echo
+```
+
+### 7.3 Modeling Client Types in TLA+
+
+To model these differences, we introduce a `clientType` constant and make the `ClientReceive` and `ClientDiffFromDisk` actions conditional:
+
+```tla
+CONSTANTS
+    ClientTypes  \* Function: Clients -> {"obsidian", "folder"}
+
+\* Folder client: pre-apply local diff before remote update
+FolderClientReceive(c) ==
+    /\ ClientTypes[c] = "folder"
+    /\ serverToClient[c] /= <<>>
+    /\ LET msg == Head(serverToClient[c])
+       IN
+       \* Step 1: If disk differs from CRDT, diff and broadcast FIRST
+       /\ IF clientDisk[c][msg.docId] /= clientDoc[c][msg.docId]
+          THEN \* Generate a local update from disk content
+               LET localU == ... \* diff(crdt, disk)
+               IN /\ clientDoc' = [clientDoc EXCEPT ![c][msg.docId] = <apply local + remote>]
+                  /\ clientToServer' = [clientToServer EXCEPT
+                       ![c] = Append(@, [type |-> "MSG_UPDATE", ...])]
+          ELSE \* Just apply remote update
+               /\ clientDoc' = [clientDoc EXCEPT ![c][msg.docId] = <apply remote>]
+       \* Step 2: Write merged content to disk (no ignore needed — disk == crdt)
+       /\ clientDisk' = [clientDisk EXCEPT ![c][msg.docId] = clientDoc'[c][msg.docId]]
+       /\ serverToClient' = [serverToClient EXCEPT ![c] = Tail(@)]
+
+\* Obsidian client: apply remote, write to disk, set ignore timer
+ObsidianClientReceive(c) ==
+    /\ ClientTypes[c] = "obsidian"
+    /\ serverToClient[c] /= <<>>
+    /\ LET msg == Head(serverToClient[c])
+       IN
+       \* Apply remote update to CRDT (WITHOUT pre-diffing disk)
+       /\ clientDoc' = [clientDoc EXCEPT ![c][msg.docId] = <apply remote>]
+       \* Write to disk and suppress watcher
+       /\ clientDisk' = [clientDisk EXCEPT ![c][msg.docId] = clientDoc'[c][msg.docId]]
+       /\ clientIgnoring' = [clientIgnoring EXCEPT ![c] = @ \cup {msg.docId}]
+       /\ serverToClient' = [serverToClient EXCEPT ![c] = Tail(@)]
+```
+
+### 7.4 Properties Specific to Client Differences
+
+#### `DiskCrdtEventualConsistency` — Disk Eventually Matches CRDT
+
+For every client, the disk content must eventually match the CRDT content (no permanently lost writes).
+
+```tla
+DiskCrdtEventualConsistency ==
+    \A c \in Clients, d \in DocIds :
+        [](clientConnected[c] /\ d \in clientSubscribed[c] =>
+            <>(clientDisk[c][d] = clientDoc[c][d]))
+```
+
+#### `NoSwallowedEdits` — Local Edits Are Never Silently Dropped
+
+If a user makes an edit (disk changes), it must eventually be reflected in the CRDT, even if `ignoreChanges` temporarily suppresses the file-watcher.
+
+```tla
+NoSwallowedEdits ==
+    \A c \in Clients, d \in DocIds :
+        \* If disk has content that CRDT doesn't...
+        [](\E u \in ToSet(clientDisk[c][d]) : u.id \notin UpdateIds(clientDoc[c][d])
+           \* ...then eventually it appears in the CRDT
+           => <>(u.id \in UpdateIds(clientDoc[c][d])))
+```
+
+#### `NoSpuriousDeletes` — Stale Reads Never Cause Data Loss
+
+The most valuable property to verify. A diff that reads stale disk content must never cause a non-local update to be deleted.
+
+```tla
+NoSpuriousDeletes ==
+    \* After ClientDiffFromDisk(c, d), no update originally from another
+    \* client should have been removed from c's CRDT.
+    \A c \in Clients, d \in DocIds :
+        \A u \in Update :
+            (u.origin /= c /\ u.id \in UpdateIds(clientDoc[c][d]))
+            => [](u.id \in UpdateIds(clientDoc[c][d]))
+```
+
+> **Note**: In the real system, `NoSpuriousDeletes` is currently _violated_ by the Obsidian client under the Issue #6 race condition. The TLA+ model should first confirm this violation exists, then verify that proposed fixes (such as epoch-based suppression or the folder client's pre-apply strategy) eliminate it.
+
+---
+
+## 8. Additional Modeling Extensions
+
+Once the base specification (including the diff layer and client types) is validated, consider adding these refinements.
+
+### 8.1 Message Reordering
+
+The base model assumes FIFO channels (matching TCP/WebSocket semantics). To test resilience against out-of-order delivery (e.g., after a disconnection), replace the `Seq(Message)` channels with _sets_ of messages (bag semantics):
+
+```tla
+\* Non-FIFO variant: server picks any pending message, not just the head
+ServerReceiveAny(c) ==
+    /\ clientToServer[c] /= {}
+    /\ \E msg \in clientToServer[c] :
+        \* ... process msg ...
+        /\ clientToServer' = [clientToServer EXCEPT ![c] = @ \ {msg}]
+```
+
+### 8.2 Message Loss
+
+To model unreliable networks (though WebSocket over TCP is reliable, this is useful for testing protocol robustness):
+
+```tla
+MessageDrop(c) ==
+    /\ clientToServer[c] /= <<>>
+    /\ clientToServer' = [clientToServer EXCEPT ![c] = Tail(@)]
+    /\ UNCHANGED <<all other variables>>
+```
+
+### 8.3 Offline Edits and Reconnection Bootstrap
+
+The real Syncline client performs a `bootstrap_offline_changes` step on reconnection — it diffs the local filesystem against the CRDT state and generates updates. Model this by allowing `ClientEdit` when `~clientConnected[c]` and then sending all accumulated updates on `ClientReconnect`.
+
+### 8.4 Rename Propagation
+
+The two clients detect renames differently. The Obsidian client gets a rename event directly from the Obsidian API, while the folder client uses content-hash matching across a batch of delete+create events. Model this as:
+
+```tla
+\* Obsidian: atomic rename — old path removed, new path inserted, same UUID
+ObsidianRename(c, d, newPath) ==
+    /\ ClientTypes[c] = "obsidian"
+    /\ \* Update meta.path in the CRDT, broadcast via observe_update_v1
+    ...
+
+\* Folder: content-matching heuristic — may fail if content was also modified
+FolderRename(c, d, newPath) ==
+    /\ ClientTypes[c] = "folder"
+    /\ \* Match deleted file's CRDT content against new file's disk content
+    /\ \* If they match → treat as rename; if not → treat as delete + create
+    ...
+```
+
+The property to verify: `RenameConvergence` — after a rename on one client, all clients eventually agree on the new path.
+
+---
+
+## 7. Running the Model Checker
+
+### 7.1 TLC Configuration File (`SynclineSync.cfg`)
+
+```
+SPECIFICATION Spec
+
+CONSTANTS
+    Clients = {"A", "B"}
+    DocIds = {"d1"}
+    MaxUpdates = 4
+    CompactionThreshold = 3
+
+INVARIANTS
+    TypeOK
+    NoEcho
+    PersistBeforeBroadcast
+    IndexConsistency
+    ChannelOnlyForConnected
+
+PROPERTIES
+    EventualConvergence
+    EventualDelivery
+```
+
+### 7.2 Running TLC
+
+```bash
+# From the TLA+ Toolbox: Model → New Model → Run
+# Or from command line:
+java -jar tla2tools.jar -config SynclineSync.cfg SynclineSync.tla
+
+# For larger models, increase heap:
+java -Xmx8g -jar tla2tools.jar -workers 8 -config SynclineSync.cfg SynclineSync.tla
+```
+
+### 7.3 Expected State Space
+
+For `Clients = {"A", "B"}, DocIds = {"d1"}, MaxUpdates = 4`:
+
+| Metric                  | Estimated Value |
+| ----------------------- | --------------- |
+| Distinct states         | ~10,000–50,000  |
+| State-space diameter    | ~20–30 steps    |
+| Time on modern hardware | < 1 minute      |
+
+For `Clients = {"A", "B", "C"}, DocIds = {"d1", "d2"}, MaxUpdates = 5`:
+
+| Metric                  | Estimated Value |
+| ----------------------- | --------------- |
+| Distinct states         | ~1,000,000+     |
+| Time on modern hardware | 5–30 minutes    |
+
+### 7.4 Interpreting Results
+
+- **"No violation found"**: The property held across all reachable states. This is a strong guarantee within the bounded model.
+- **"Invariant X violated"**: TLC produces a minimal counterexample trace. This trace shows the exact sequence of actions that leads to the violation — extremely valuable for debugging.
+- **"Temporal property Y violated"**: TLC produces a lasso-shaped counterexample (a prefix + a cycle). This indicates a scenario where the system can loop forever without satisfying the liveness condition.
+
+---
+
+## 9. File Structure
+
+We recommend the following file structure under `docs/tla/`:
+
+```
+docs/tla/
+├── SynclineSync.tla              # Main specification module
+├── SynclineSync.cfg              # TLC model checking configuration
+├── SynclineSyncDiffLayer.tla     # Extension: diff + disk model
+├── SynclineSyncClientTypes.tla   # Extension: Obsidian vs folder client
+├── SynclineSyncCompaction.tla    # Extension: compaction model
+├── SynclineSyncStaleRead.tla     # Extension: stale file-watcher race
+├── SynclineSyncLossy.tla         # Extension: message loss/reordering
+└── README.md                     # Verification results and notes
+```
+
+---
+
+## 10. Mapping TLA+ Actions to Syncline Source Code
+
+Each TLA+ action corresponds to a specific code path in the Rust/TypeScript implementation. This traceability matrix ensures the model accurately reflects reality.
+
+### Server Actions
+
+| TLA+ Action              | Source File                     | Function / Code Path                       |
+| ------------------------ | ------------------------------- | ------------------------------------------ |
+| `ServerReceiveSyncStep1` | `syncline/src/server/server.rs` | `handle_socket` → `MSG_SYNC_STEP_1` branch |
+| `ServerReceiveUpdate`    | `syncline/src/server/server.rs` | `handle_socket` → `MSG_UPDATE` branch      |
+| `ServerCompact`          | Not yet implemented             | See Design Doc §6 (Lazy Compaction)        |
+
+### Folder Client Actions
+
+| TLA+ Action           | Source File                      | Function / Code Path                                                      |
+| --------------------- | -------------------------------- | ------------------------------------------------------------------------- |
+| `ClientEdit`          | `syncline/src/client/app.rs`     | `watcher_rx.recv()` → `apply_diff_to_yrs()` L579                          |
+| `ClientDiffFromDisk`  | `syncline/src/client/diff.rs`    | `apply_diff_to_yrs(doc, text_ref, old, new)` L4                           |
+| `FolderClientReceive` | `syncline/src/client/app.rs`     | `app_rx.recv()` → pre-apply local diff L258–271 → `apply_update` L274–277 |
+| `ClientWriteToDisk`   | `syncline/src/client/app.rs`     | `fs::write(&phys_path, &text_val)` L380                                   |
+| `ClientGoOffline`     | `syncline/src/client/network.rs` | WebSocket close / `Drop for SynclineClient`                               |
+| `ClientReconnect`     | `syncline/src/client/app.rs`     | `bootstrap_offline_changes()` → `MSG_SYNC_STEP_1` L98–124                 |
+| `FolderRename`        | `syncline/src/client/app.rs`     | Batch rename detection L444–508                                           |
+
+### Obsidian Client Actions
+
+| TLA+ Action             | Source File                   | Function / Code Path                                        |
+| ----------------------- | ----------------------------- | ----------------------------------------------------------- |
+| `ClientEdit`            | `obsidian-plugin/main.ts`     | `onFileModify` → `client.update(uuid, content)` L601        |
+| `ClientDiffFromDisk`    | `syncline/src/wasm_client.rs` | `SynclineClient::update()` inline diff L348–387             |
+| `ObsidianClientReceive` | `syncline/src/wasm_client.rs` | `onmessage` → `apply_update()` L131–138                     |
+| `ClientWriteToDisk`     | `obsidian-plugin/main.ts`     | `onRemoteUpdate()` → `vault.modify()` L563                  |
+| `ClientIgnoreExpires`   | `obsidian-plugin/main.ts`     | `setTimeout(() => ignoreChanges.delete(), 500)` L567        |
+| `ClientGoOffline`       | `obsidian-plugin/main.ts`     | WebSocket `onclose` / `disconnect()` L436–447               |
+| `ClientReconnect`       | `obsidian-plugin/main.ts`     | `connect()` → registers all files → `client.connect()` L244 |
+| `ObsidianRename`        | `obsidian-plugin/main.ts`     | `onFileRename` → `set_meta_path()` L634–658                 |
+
+---
+
+## 11. Recommended Verification Roadmap
+
+### Phase 1: Core Protocol (1–2 days)
+
+1. Write the base `SynclineSync.tla` with 2 clients (same type), 1 document, no diff layer.
+2. Verify `TypeOK`, `NoEcho`, `PersistBeforeBroadcast`.
+3. Verify `EventualConvergence` with weak fairness.
+
+### Phase 2: Diff Layer + Disk Model (2–3 days) ⭐ **Highest value**
+
+1. Add `clientDisk`, `clientIgnoring`, and the diff/write/expire actions.
+2. Reproduce Issue #6: verify that `NoSpuriousDeletes` is violated when the ignoreChanges timer expires after a remote update arrives.
+3. Verify proposed mitigations: epoch-based suppression, or the folder client's pre-apply strategy.
+4. Verify `DiskCrdtEventualConsistency` and `NoSwallowedEdits`.
+
+### Phase 3: Client Type Differences (1–2 days)
+
+1. Introduce `clientType` constant. Model `ObsidianClientReceive` vs `FolderClientReceive`.
+2. Run with `ClientTypes = {"A" -> "obsidian", "B" -> "folder"}` to explore cross-client scenarios.
+3. Verify that convergence holds even when one client is Obsidian and the other is folder.
+4. Compare: does the folder client's pre-apply strategy provably prevent Issue #6?
+
+### Phase 4: Multi-Document + Index (1 day)
+
+1. Add `__index__` document and `serverIndex` state.
+2. Verify `IndexConsistency` and `EventualIndexPropagation`.
+3. Increase to 2 documents.
+
+### Phase 5: Compaction (1 day)
+
+1. Add `ServerCompact` action.
+2. Verify that compaction preserves convergence.
+3. Model the `ERR_HISTORY_LOST` recovery: a client that missed compacted history must accept the server snapshot.
+
+### Phase 6: Rename Propagation (1 day)
+
+1. Add `meta.path` updates and the two rename strategies.
+2. Verify `RenameConvergence`: after a rename, all clients eventually agree on the path.
+3. Test cross-client rename: Obsidian renames while folder client is offline, then reconnects.
+
+### Phase 7: Stress Testing (optional)
+
+1. Increase to 3 clients (2 folder + 1 Obsidian), 3 documents, 6 updates.
+2. Add message loss and reordering.
+3. Run overnight with `-workers 8`.
+
+---
+
+## 12. References
+
+- **Lamport, L.** _Specifying Systems_ (2002) — The definitive TLA+ textbook.
+- **Hillel Wayne.** [_Learn TLA+_](https://learntla.com/) — A practical, accessible introduction.
+- **Markus Kuppe.** [_TLA+ Video Course_](https://lamport.azurewebsites.net/video/videos.html) — Leslie Lamport's lecture series.
+- **Shapiro et al.** _Conflict-Free Replicated Data Types_ (2011) — CRDT foundations.
+- **Attiya et al.** _Specification and Complexity of CRDTs_ (2016) — Formal CRDT properties.
+- **Nicolaescu et al.** _Near Real-Time Peer-to-Peer Shared Editing on Extensible Data Types (YATA)_ (2016) — The Yjs algorithm paper.
+- **Amazon / MongoDB / CockroachDB** have all published on using TLA+ for protocol verification in production systems.

--- a/docs/tla/.gitignore
+++ b/docs/tla/.gitignore
@@ -1,0 +1,11 @@
+# TLA+ tools (downloaded, not checked in)
+tla2tools.jar
+
+# TLC state files
+*.states/
+states/
+
+# TLC generated files
+*.dot
+*.dump
+*_TTrace_*.tla

--- a/docs/tla/README.md
+++ b/docs/tla/README.md
@@ -1,0 +1,95 @@
+# Syncline TLA+ Formal Verification
+
+Formal verification of the Syncline synchronization protocol using TLA+ and the TLC model checker.
+
+## Quick Start
+
+```bash
+# Download TLC (one-time)
+curl -L -o tla2tools.jar https://github.com/tlaplus/tlaplus/releases/download/v1.8.0/tla2tools.jar
+
+# Phase 1: Core protocol (all properties pass, ~30s)
+java -XX:+UseParallelGC -Xmx4g -jar tla2tools.jar -config SynclineSync.cfg -workers 4 -nowarning SynclineSync.tla
+
+# Phase 2: Diff layer — REPRODUCES Issue #6 (~1s, expected violation)
+java -XX:+UseParallelGC -jar tla2tools.jar -config SynclineSyncDiffLayerBug.cfg -workers 4 -nowarning SynclineSyncDiffLayer.tla
+
+# Phase 2: Diff layer FIXED — confirms the fix works (~14s)
+java -XX:+UseParallelGC -jar tla2tools.jar -config SynclineSyncDiffLayerFixed.cfg -workers 4 -nowarning SynclineSyncDiffLayerFixed.tla
+```
+
+## Specification Files
+
+### Phase 1: Core Protocol
+
+| File                    | Description                                                   |
+| ----------------------- | ------------------------------------------------------------- |
+| `SynclineSync.tla`      | Core protocol: FIFO channels, server relay, offline/reconnect |
+| `SynclineSync.cfg`      | Full config: 3 updates, queue=4, invariants + liveness (~30s) |
+| `SynclineSyncSmall.cfg` | Smoke test: 2 updates, queue=3, invariants only (~1s)         |
+
+### Phase 2: Diff Layer (Issue #6)
+
+| File                             | Description                                                   |
+| -------------------------------- | ------------------------------------------------------------- |
+| `SynclineSyncDiffLayer.tla`      | Buggy model with non-atomic apply+write — reproduces Issue #6 |
+| `SynclineSyncDiffLayerBug.cfg`   | Config that demonstrates the NoContentLoss violation          |
+| `SynclineSyncDiffLayerFixed.tla` | Fixed model with atomic apply+write — bug eliminated          |
+| `SynclineSyncDiffLayerFixed.cfg` | Config that verifies the fix holds                            |
+
+## Verified Properties
+
+### Phase 1: Safety Invariants
+
+| Property                  | Description                                  | Status  |
+| ------------------------- | -------------------------------------------- | ------- |
+| `TypeOK`                  | All variables stay within declared types     | ✅ Pass |
+| `NoEcho`                  | Server never sends update back to originator | ✅ Pass |
+| `PersistBeforeBroadcast`  | DB written before any client sees the update | ✅ Pass |
+| `ChannelOnlyForConnected` | Only connected clients in broadcast channels | ✅ Pass |
+| `IndexConsistency`        | Every doc with data is in the index          | ✅ Pass |
+| `SubscriptionConsistency` | Client subscriptions match server channels   | ✅ Pass |
+
+### Phase 1: Liveness Properties
+
+| Property              | Description                                             | Status  |
+| --------------------- | ------------------------------------------------------- | ------- |
+| `EventualConvergence` | Connected+subscribed clients converge when queues drain | ✅ Pass |
+
+### Phase 2: Diff Layer Properties
+
+| Property                  | Buggy Model                | Fixed Model |
+| ------------------------- | -------------------------- | ----------- |
+| `NoEcho`                  | ✅ Pass                    | ✅ Pass     |
+| `ChannelOnlyForConnected` | ✅ Pass                    | ✅ Pass     |
+| `NoContentLoss`           | ❌ **VIOLATED** (Issue #6) | ✅ Pass     |
+
+## Issue #6 Counterexample (TLC Trace)
+
+The buggy model produces a 10-step counterexample trace:
+
+| Step | Action                         | State Change                                      |
+| ---- | ------------------------------ | ------------------------------------------------- |
+| 1    | Init                           | Both clients empty                                |
+| 2    | `LocalDiskEdit(A, d1)`         | A edits file → disk=`{1}`, CRDT=`{}`              |
+| 3-5  | Subscribe + Sync               | Both clients subscribe, A syncs                   |
+| 6    | `ClientWatcherFires(A)`        | A's watcher: diff(`{}`, `{1}`) → sends `adds={1}` |
+| 7    | `ServerReceiveUpdate(A)`       | Server persists `{1}`                             |
+| 8    | `ServerReceiveSyncStep1(B)`    | Server sends B `adds={1}`                         |
+| 9    | `ClientApplyRemote(B)`         | B CRDT=`{1}`, **disk still=`{}`**                 |
+| 10   | **`ClientWatcherFires(B)`** 💥 | Stale disk diff: `dels={1}` → **content lost!**   |
+
+**Root cause**: Missing disk write between steps 9-10. The fix (atomic apply+write) eliminates the stale-read window.
+
+## Verification Results
+
+| Spec          | States Generated | Distinct | Depth | Time | Result                    |
+| ------------- | ---------------- | -------- | ----- | ---- | ------------------------- |
+| Phase 1 Small | 133K             | 26K      | 27    | 1s   | ✅ All pass               |
+| Phase 1 Full  | 4.5M             | 860K     | 35    | 34s  | ✅ All pass               |
+| Phase 2 Buggy | 123K             | 34K      | 11    | 1s   | ❌ NoContentLoss violated |
+| Phase 2 Fixed | 10.3M            | 1.7M     | 37    | 14s  | ✅ All pass               |
+
+## Architecture
+
+See [FORMAL_VERIFICATION.md](../FORMAL_VERIFICATION.md) for the full design rationale, action-to-code mapping, and the roadmap for further verification (compaction, 3+ clients).

--- a/docs/tla/README.md
+++ b/docs/tla/README.md
@@ -16,6 +16,9 @@ java -XX:+UseParallelGC -jar tla2tools.jar -config SynclineSyncDiffLayerBug.cfg 
 
 # Phase 2: Diff layer FIXED — confirms the fix works (~14s)
 java -XX:+UseParallelGC -jar tla2tools.jar -config SynclineSyncDiffLayerFixed.cfg -workers 4 -nowarning SynclineSyncDiffLayerFixed.tla
+
+# Phase 3: Cross-client (Obsidian + folder) convergence (~37s)
+java -XX:+UseParallelGC -Xmx4g -jar tla2tools.jar -config SynclineSyncCrossClient.cfg -workers 4 -nowarning SynclineSyncCrossClient.tla
 ```
 
 ## Specification Files
@@ -36,6 +39,13 @@ java -XX:+UseParallelGC -jar tla2tools.jar -config SynclineSyncDiffLayerFixed.cf
 | `SynclineSyncDiffLayerBug.cfg`   | Config that demonstrates the NoContentLoss violation          |
 | `SynclineSyncDiffLayerFixed.tla` | Fixed model with atomic apply+write — bug eliminated          |
 | `SynclineSyncDiffLayerFixed.cfg` | Config that verifies the fix holds                            |
+
+### Phase 3: Cross-Client (Obsidian + Folder)
+
+| File                          | Description                                                            |
+| ----------------------------- | ---------------------------------------------------------------------- |
+| `SynclineSyncCrossClient.tla` | Both client types in one model: Obsidian (fixed) vs folder (pre-apply) |
+| `SynclineSyncCrossClient.cfg` | Config: A=Obsidian, B=Folder, safety + convergence liveness            |
 
 ## Verified Properties
 
@@ -64,6 +74,15 @@ java -XX:+UseParallelGC -jar tla2tools.jar -config SynclineSyncDiffLayerFixed.cf
 | `ChannelOnlyForConnected` | ✅ Pass                    | ✅ Pass     |
 | `NoContentLoss`           | ❌ **VIOLATED** (Issue #6) | ✅ Pass     |
 
+### Phase 3: Cross-Client Properties
+
+| Property                  | Mixed Deployment (A=Obsidian, B=Folder) |
+| ------------------------- | --------------------------------------- |
+| `NoEcho`                  | ✅ Pass                                 |
+| `ChannelOnlyForConnected` | ✅ Pass                                 |
+| `NoContentLoss`           | ✅ Pass                                 |
+| `CrossClientConvergence`  | ✅ Pass (liveness)                      |
+
 ## Issue #6 Counterexample (TLC Trace)
 
 The buggy model produces a 10-step counterexample trace:
@@ -83,13 +102,27 @@ The buggy model produces a 10-step counterexample trace:
 
 ## Verification Results
 
-| Spec          | States Generated | Distinct | Depth | Time | Result                    |
-| ------------- | ---------------- | -------- | ----- | ---- | ------------------------- |
-| Phase 1 Small | 133K             | 26K      | 27    | 1s   | ✅ All pass               |
-| Phase 1 Full  | 4.5M             | 860K     | 35    | 34s  | ✅ All pass               |
-| Phase 2 Buggy | 123K             | 34K      | 11    | 1s   | ❌ NoContentLoss violated |
-| Phase 2 Fixed | 10.3M            | 1.7M     | 37    | 14s  | ✅ All pass               |
+| Spec                 | States Generated | Distinct | Depth | Time | Result                    |
+| -------------------- | ---------------- | -------- | ----- | ---- | ------------------------- |
+| Phase 1 Small        | 133K             | 26K      | 27    | 1s   | ✅ All pass               |
+| Phase 1 Full         | 4.5M             | 860K     | 35    | 34s  | ✅ All pass               |
+| Phase 2 Buggy        | 123K             | 34K      | 11    | 1s   | ❌ NoContentLoss violated |
+| Phase 2 Fixed        | 10.3M            | 1.7M     | 37    | 14s  | ✅ All pass               |
+| Phase 3 Cross-Client | 4.7M             | 811K     | 36    | 37s  | ✅ All pass               |
+
+## Key Insights from Phase 3
+
+The cross-client model revealed an important correctness constraint:
+
+**`ObsidianIgnoreExpires` must not fire before the disk write completes.** The model initially violated NoContentLoss when the ignore timer expired before `ObsidianWriteToDisk` had a chance to run. In the real code, this is guaranteed because:
+
+1. `await vault.modify()` completes before the `setTimeout` starts
+2. The 1000ms timeout far exceeds the time needed for disk I/O
+
+The TLA+ spec encodes this via a precondition: `clientDisk[c][d] = clientDoc[c][d]` on `ObsidianIgnoreExpires`, ensuring the write-before-expire ordering.
+
+The folder client's pre-apply strategy (read disk → apply local diff → apply remote → write atomically) is **provably safe** — it needs no `ignoreChanges` mechanism because disk always matches CRDT after processing.
 
 ## Architecture
 
-See [FORMAL_VERIFICATION.md](../FORMAL_VERIFICATION.md) for the full design rationale, action-to-code mapping, and the roadmap for further verification (compaction, 3+ clients).
+See [FORMAL_VERIFICATION.md](../FORMAL_VERIFICATION.md) for the full design rationale, action-to-code mapping, and the roadmap for further verification (compaction, multi-doc, cross-client).

--- a/docs/tla/SynclineSync.cfg
+++ b/docs/tla/SynclineSync.cfg
@@ -1,0 +1,23 @@
+\* Full TLC config: invariants + liveness, moderate bounds.
+
+SPECIFICATION Spec
+
+CONSTANTS
+    Clients = {"A", "B"}
+    DocIds = {"d1"}
+    MaxUpdates = 3
+    MaxQueueLen = 4
+
+CONSTRAINT
+    StateConstraint
+
+INVARIANTS
+    TypeOK
+    NoEcho
+    PersistBeforeBroadcast
+    ChannelOnlyForConnected
+    IndexConsistency
+    SubscriptionConsistency
+
+PROPERTIES
+    EventualConvergence

--- a/docs/tla/SynclineSync.tla
+++ b/docs/tla/SynclineSync.tla
@@ -1,0 +1,382 @@
+--------------------------- MODULE SynclineSync ---------------------------
+(*
+ * Formal specification of the Syncline synchronization protocol.
+ *
+ * Phase 1: Core protocol — star-topology CRDT sync over WebSockets.
+ *
+ * Abstractions:
+ *   - CRDTs are modeled as sets of opaque update tokens (merge = union).
+ *   - Network channels are FIFO queues (matching TCP/WebSocket).
+ *   - The server is a single process with in-memory channels + persistent DB.
+ *
+ * What this verifies:
+ *   - No echo: updates are never sent back to the originating client.
+ *   - Persist before broadcast: DB written before any client sees the update.
+ *   - Eventual convergence: all connected clients reach the same state.
+ *   - Channel hygiene: only connected clients in broadcast channels.
+ *   - Index consistency: every doc with data is in the index.
+ *
+ * Source: docs/FORMAL_VERIFICATION.md
+ *)
+EXTENDS Naturals, Sequences, FiniteSets, TLC
+
+CONSTANTS
+    Clients,              \* Set of client IDs, e.g. {"A", "B"}
+    DocIds,               \* Set of document IDs, e.g. {"d1"}
+    MaxUpdates,           \* Bound on total updates for finite model checking
+    MaxQueueLen           \* Bound on message queue length per client
+
+(* ===================== HELPER OPERATORS ===================== *)
+
+\* Convert a sequence to the set of its elements
+SeqToSet(s) == {s[i] : i \in 1..Len(s)}
+
+\* Get the set of update IDs from a sequence of updates
+UpdateIds(s) == {s[i].id : i \in 1..Len(s)}
+
+\* Append all elements of a set (as a sequence) to a sequence.
+\* Order doesn't matter for correctness since CRDTs are order-independent.
+AppendAll(seq, set) ==
+    LET F[S \in SUBSET set] ==
+        IF S = {} THEN seq
+        ELSE LET x == CHOOSE x \in S : TRUE
+             IN Append(F[S \ {x}], x)
+    IN F[set]
+
+\* Filter elements from a sequence that satisfy a predicate
+FilterSeq(s, Test(_)) ==
+    LET F[i \in 0..Len(s)] ==
+        IF i = 0 THEN <<>>
+        ELSE IF Test(s[i]) THEN Append(F[i-1], s[i])
+             ELSE F[i-1]
+    IN F[Len(s)]
+
+(* ===================== MESSAGE TYPES ===================== *)
+
+\* Message type constants — matching protocol.rs MsgType enum
+MsgSyncStep1 == "MSG_SYNC_STEP_1"
+MsgSyncStep2 == "MSG_SYNC_STEP_2"
+MsgUpdate    == "MSG_UPDATE"
+
+(* ===================== VARIABLES ===================== *)
+
+VARIABLES
+    \* --- Client State ---
+    clientDoc,            \* [Clients -> [DocIds -> Seq(Update)]]
+    clientConnected,      \* [Clients -> BOOLEAN]
+    clientSubscribed,     \* [Clients -> SUBSET DocIds]
+
+    \* --- Network ---
+    clientToServer,       \* [Clients -> Seq(Message)]
+    serverToClient,       \* [Clients -> Seq(Message)]
+
+    \* --- Server State ---
+    serverDB,             \* [DocIds -> Seq(Update)]
+    serverChannels,       \* [DocIds -> SUBSET Clients]
+    serverIndex,          \* SUBSET DocIds
+
+    \* --- Global ---
+    updateCounter         \* Nat — monotonic counter for unique update IDs
+
+vars == <<clientDoc, clientConnected, clientSubscribed,
+          clientToServer, serverToClient,
+          serverDB, serverChannels, serverIndex,
+          updateCounter>>
+
+(* ===================== STATE CONSTRAINT ===================== *)
+
+\* Bounds the state space so TLC terminates in reasonable time.
+\* This limits how many messages can accumulate in network queues.
+StateConstraint ==
+    /\ \A c \in Clients : Len(clientToServer[c]) <= MaxQueueLen
+    /\ \A c \in Clients : Len(serverToClient[c]) <= MaxQueueLen
+    /\ \A d \in DocIds  : Len(serverDB[d])        <= MaxUpdates
+
+(* ===================== TYPE INVARIANT ===================== *)
+
+Update == [id : Nat, origin : Clients, docId : DocIds]
+
+Message == [type : {MsgSyncStep1, MsgSyncStep2, MsgUpdate},
+            docId : DocIds]
+            \* Plus additional fields depending on type — TLC checks structurally
+
+TypeOK ==
+    /\ clientConnected  \in [Clients -> BOOLEAN]
+    /\ clientSubscribed \in [Clients -> SUBSET DocIds]
+    /\ serverChannels   \in [DocIds  -> SUBSET Clients]
+    /\ serverIndex      \in SUBSET DocIds
+    /\ updateCounter    \in Nat
+
+(* ===================== INITIAL STATE ===================== *)
+
+Init ==
+    /\ clientDoc        = [c \in Clients |-> [d \in DocIds |-> <<>>]]
+    /\ clientConnected  = [c \in Clients |-> TRUE]     \* All start connected
+    /\ clientSubscribed = [c \in Clients |-> {}]
+    /\ clientToServer   = [c \in Clients |-> <<>>]
+    /\ serverToClient   = [c \in Clients |-> <<>>]
+    /\ serverDB         = [d \in DocIds  |-> <<>>]
+    /\ serverChannels   = [d \in DocIds  |-> {}]
+    /\ serverIndex      = {}
+    /\ updateCounter    = 0
+
+(* ===================== CLIENT ACTIONS ===================== *)
+
+(*
+ * ClientEdit(c, d): Client c makes a local edit to document d.
+ * Maps to: app.rs watcher_rx.recv() -> apply_diff_to_yrs()
+ *)
+ClientEdit(c, d) ==
+    /\ clientConnected[c]
+    /\ updateCounter < MaxUpdates
+    /\ LET u == [id     |-> updateCounter + 1,
+                 origin |-> c,
+                 docId  |-> d]
+       IN
+       /\ clientDoc' = [clientDoc EXCEPT ![c][d] = Append(@, u)]
+       /\ updateCounter' = updateCounter + 1
+       \* If subscribed, send update to server
+       /\ IF d \in clientSubscribed[c]
+          THEN clientToServer' = [clientToServer EXCEPT
+                 ![c] = Append(@, [type  |-> MsgUpdate,
+                                   docId |-> d,
+                                   update |-> u])]
+          ELSE UNCHANGED clientToServer
+    /\ UNCHANGED <<clientConnected, clientSubscribed, serverToClient,
+                   serverDB, serverChannels, serverIndex>>
+
+(*
+ * ClientGoOffline(c): Client c disconnects.
+ * Maps to: network.rs WebSocket close
+ *)
+ClientGoOffline(c) ==
+    /\ clientConnected[c]
+    /\ clientConnected' = [clientConnected EXCEPT ![c] = FALSE]
+    /\ clientSubscribed' = [clientSubscribed EXCEPT ![c] = {}]
+    \* Server removes client from all channels
+    /\ serverChannels' = [d \in DocIds |-> serverChannels[d] \ {c}]
+    \* Drop any in-flight messages (connection lost)
+    /\ clientToServer' = [clientToServer EXCEPT ![c] = <<>>]
+    /\ serverToClient' = [serverToClient EXCEPT ![c] = <<>>]
+    /\ UNCHANGED <<clientDoc, serverDB, serverIndex, updateCounter>>
+
+(*
+ * ClientReconnect(c): Client c comes back online and sends SyncStep1
+ * for all documents it has locally.
+ * Maps to: app.rs outer loop -> send MSG_SYNC_STEP_1 for known docs
+ *)
+ClientReconnect(c) ==
+    /\ ~clientConnected[c]
+    /\ clientConnected' = [clientConnected EXCEPT ![c] = TRUE]
+    \* Send SyncStep1 for every document the client has data for
+    /\ LET knownDocs == {d \in DocIds : clientDoc[c][d] /= <<>>}
+           syncMsgs == [d \in knownDocs |->
+                          [type        |-> MsgSyncStep1,
+                           docId       |-> d,
+                           stateVector |-> UpdateIds(clientDoc[c][d])]]
+           \* Build a sequence from the set of messages
+           msgSeq   == AppendAll(<<>>, {syncMsgs[d] : d \in knownDocs})
+       IN clientToServer' = [clientToServer EXCEPT ![c] = @ \o msgSeq]
+    /\ UNCHANGED <<clientDoc, clientSubscribed, serverToClient,
+                   serverDB, serverChannels, serverIndex, updateCounter>>
+
+(*
+ * ClientReceive(c): Client c processes the next message from the server.
+ * Maps to: app.rs app_rx.recv() -> MsgType::SyncStep2 | MsgType::Update
+ *)
+ClientReceive(c) ==
+    /\ clientConnected[c]
+    /\ serverToClient[c] /= <<>>
+    /\ LET msg == Head(serverToClient[c])
+       IN
+       CASE msg.type = MsgSyncStep2 ->
+            \* Apply all updates the client doesn't already have
+            LET myIds      == UpdateIds(clientDoc[c][msg.docId])
+                newUpdates == {u \in SeqToSet(msg.updates) : u.id \notin myIds}
+            IN clientDoc' = [clientDoc EXCEPT
+                 ![c][msg.docId] = AppendAll(@, newUpdates)]
+
+         [] msg.type = MsgUpdate ->
+            \* Apply the single update if not already present
+            IF msg.update.id \notin UpdateIds(clientDoc[c][msg.docId])
+            THEN clientDoc' = [clientDoc EXCEPT
+                   ![c][msg.docId] = Append(@, msg.update)]
+            ELSE UNCHANGED clientDoc
+
+         [] OTHER -> UNCHANGED clientDoc
+
+    /\ serverToClient' = [serverToClient EXCEPT ![c] = Tail(@)]
+    /\ UNCHANGED <<clientConnected, clientSubscribed, clientToServer,
+                   serverDB, serverChannels, serverIndex, updateCounter>>
+
+(*
+ * ClientSubscribe(c, d): Client c sends SyncStep1 for a document d
+ * it hasn't subscribed to yet (e.g., discovered via __index__).
+ * Maps to: app.rs "Discovered new UUID from __index__" path
+ *)
+ClientSubscribe(c, d) ==
+    /\ clientConnected[c]
+    /\ d \notin clientSubscribed[c]
+    /\ clientToServer' = [clientToServer EXCEPT
+         ![c] = Append(@, [type        |-> MsgSyncStep1,
+                           docId       |-> d,
+                           stateVector |-> UpdateIds(clientDoc[c][d])])]
+    /\ UNCHANGED <<clientDoc, clientConnected, clientSubscribed,
+                   serverToClient, serverDB, serverChannels,
+                   serverIndex, updateCounter>>
+
+(* ===================== SERVER ACTIONS ===================== *)
+
+(*
+ * ServerReceiveSyncStep1(c): Server processes MSG_SYNC_STEP_1 from client c.
+ * Maps to: server.rs handle_socket -> MSG_SYNC_STEP_1 branch
+ *
+ * The server:
+ *   1. Subscribes the client to the broadcast channel
+ *   2. Registers the doc in __index__
+ *   3. Computes the diff (updates client doesn't have)
+ *   4. Sends MSG_SYNC_STEP_2 with the diff
+ *)
+ServerReceiveSyncStep1(c) ==
+    /\ clientToServer[c] /= <<>>
+    /\ Head(clientToServer[c]).type = MsgSyncStep1
+    /\ LET msg  == Head(clientToServer[c])
+           d    == msg.docId
+           sv   == msg.stateVector
+           \* Diff: all server-side updates whose IDs the client doesn't have
+           diff == FilterSeq(serverDB[d],
+                     LAMBDA u : u.id \notin sv)
+       IN
+       \* 1. Subscribe client to broadcast channel
+       /\ serverChannels' = [serverChannels EXCEPT ![d] = @ \cup {c}]
+       /\ clientSubscribed' = [clientSubscribed EXCEPT ![c] = @ \cup {d}]
+       \* 2. Register in index
+       /\ serverIndex' = serverIndex \cup {d}
+       \* 3. Send SyncStep2 with the diff
+       /\ serverToClient' = [serverToClient EXCEPT
+            ![c] = Append(@, [type    |-> MsgSyncStep2,
+                              docId   |-> d,
+                              updates |-> diff])]
+       /\ clientToServer' = [clientToServer EXCEPT ![c] = Tail(@)]
+    /\ UNCHANGED <<clientDoc, clientConnected, serverDB, updateCounter>>
+
+(*
+ * ServerReceiveUpdate(c): Server processes MSG_UPDATE from client c.
+ * Maps to: server.rs handle_socket -> MSG_UPDATE branch
+ *
+ * The server:
+ *   1. Persists the update to DB FIRST
+ *   2. Registers in __index__
+ *   3. Broadcasts to all subscribers EXCEPT the sender
+ *)
+ServerReceiveUpdate(c) ==
+    /\ clientToServer[c] /= <<>>
+    /\ Head(clientToServer[c]).type = MsgUpdate
+    /\ LET msg == Head(clientToServer[c])
+           d   == msg.docId
+           u   == msg.update
+       IN
+       \* 1. Persist BEFORE broadcast (critical ordering!)
+       /\ serverDB' = [serverDB EXCEPT ![d] = Append(@, u)]
+       \* 2. Register in index
+       /\ serverIndex' = serverIndex \cup {d}
+       \* 3. Broadcast to subscribers EXCEPT the sender
+       /\ LET recipients == serverChannels[d] \ {c}
+          IN serverToClient' = [s \in Clients |->
+               IF s \in recipients
+               THEN Append(serverToClient[s],
+                           [type   |-> MsgUpdate,
+                            docId  |-> d,
+                            update |-> u])
+               ELSE serverToClient[s]]
+       /\ clientToServer' = [clientToServer EXCEPT ![c] = Tail(@)]
+    /\ UNCHANGED <<clientDoc, clientConnected, clientSubscribed,
+                   serverChannels, updateCounter>>
+
+(* ===================== NEXT-STATE RELATION ===================== *)
+
+Next ==
+    \/ \E c \in Clients, d \in DocIds : ClientEdit(c, d)
+    \/ \E c \in Clients : ClientGoOffline(c)
+    \/ \E c \in Clients : ClientReconnect(c)
+    \/ \E c \in Clients : ClientReceive(c)
+    \/ \E c \in Clients, d \in DocIds : ClientSubscribe(c, d)
+    \/ \E c \in Clients : ServerReceiveSyncStep1(c)
+    \/ \E c \in Clients : ServerReceiveUpdate(c)
+
+(* ===================== FAIRNESS ===================== *)
+
+\* Weak fairness on server processing — the server eventually processes
+\* any message in its incoming queue.
+Fairness ==
+    /\ \A c \in Clients : WF_vars(ServerReceiveSyncStep1(c))
+    /\ \A c \in Clients : WF_vars(ServerReceiveUpdate(c))
+    /\ \A c \in Clients : WF_vars(ClientReceive(c))
+
+Spec == Init /\ [][Next]_vars /\ Fairness
+
+(* ===================== SAFETY PROPERTIES ===================== *)
+
+(*
+ * NoEcho: The server never sends an update back to the client that
+ * originated it. This was a real bug (Issue #2).
+ *)
+NoEcho ==
+    \A c \in Clients :
+        \A i \in 1..Len(serverToClient[c]) :
+            LET msg == serverToClient[c][i]
+            IN msg.type = MsgUpdate => msg.update.origin /= c
+
+(*
+ * PersistBeforeBroadcast: If a MSG_UPDATE for update u is in any
+ * client's incoming queue, then u is already in serverDB.
+ *
+ * This ensures no SyncStep2 response can miss recent updates.
+ *)
+PersistBeforeBroadcast ==
+    \A c \in Clients :
+        \A i \in 1..Len(serverToClient[c]) :
+            LET msg == serverToClient[c][i]
+            IN (msg.type = MsgUpdate) =>
+               msg.update \in SeqToSet(serverDB[msg.docId])
+
+(*
+ * ChannelOnlyForConnected: Only connected clients should be in
+ * broadcast channels.
+ *)
+ChannelOnlyForConnected ==
+    \A d \in DocIds :
+        \A c \in serverChannels[d] :
+            clientConnected[c]
+
+(*
+ * IndexConsistency: Every document with data in serverDB is in the index.
+ *)
+IndexConsistency ==
+    \A d \in DocIds :
+        serverDB[d] /= <<>> => d \in serverIndex
+
+(*
+ * SubscriptionConsistency: If a client is subscribed to a doc,
+ * it must be in that doc's server channel (and vice versa).
+ *)
+SubscriptionConsistency ==
+    \A c \in Clients, d \in DocIds :
+        (d \in clientSubscribed[c]) <=> (c \in serverChannels[d])
+
+(* ===================== LIVENESS PROPERTIES ===================== *)
+
+(*
+ * EventualConvergence: If all clients are connected, subscribed to doc d,
+ * and all queues are empty, then all clients have the same set of update IDs.
+ *)
+EventualConvergence ==
+    \A d \in DocIds :
+      <>( /\ \A c \in Clients : clientConnected[c]
+          /\ \A c \in Clients : d \in clientSubscribed[c]
+          /\ \A c \in Clients : clientToServer[c] = <<>>
+          /\ \A c \in Clients : serverToClient[c] = <<>>
+          => \A c1, c2 \in Clients :
+               UpdateIds(clientDoc[c1][d]) = UpdateIds(clientDoc[c2][d]))
+
+=============================================================================

--- a/docs/tla/SynclineSyncCrossClient.cfg
+++ b/docs/tla/SynclineSyncCrossClient.cfg
@@ -1,0 +1,24 @@
+\* Phase 3: Cross-client verification.
+\* Client A = Obsidian (with fix), Client B = Folder client.
+\* All safety invariants and CrossClientConvergence liveness pass.
+
+SPECIFICATION Spec
+
+CONSTANTS
+    Clients = {"A", "B"}
+    DocIds = {"d1"}
+    MaxUpdates = 3
+    MaxQueueLen = 3
+    ObsidianClients = {"A"}
+    FolderClients = {"B"}
+
+CONSTRAINT
+    StateConstraint
+
+INVARIANTS
+    NoEcho
+    ChannelOnlyForConnected
+    NoContentLoss
+
+PROPERTIES
+    CrossClientConvergence

--- a/docs/tla/SynclineSyncCrossClient.tla
+++ b/docs/tla/SynclineSyncCrossClient.tla
@@ -1,0 +1,480 @@
+--------------------- MODULE SynclineSyncCrossClient ----------------------
+(*
+ * Phase 3: Cross-client specification.
+ *
+ * Models BOTH client architectures in the same system:
+ *
+ *   Obsidian (fixed):
+ *     1. Remote update → apply to CRDT
+ *     2. Write to disk + set ignoreChanges    (separate step, can interleave)
+ *     3. ignoreChanges expires after timeout
+ *     - Watcher blocked while ignoreChanges is set
+ *     - Watcher re-checks ignoreChanges after async read (post-read guard)
+ *     - Watcher compares disk vs CRDT before diffing (content comparison)
+ *
+ *   Folder client:
+ *     1. Remote update arrives
+ *     2. Read disk; if disk ≠ CRDT → apply local diff FIRST, broadcast it
+ *     3. Apply remote update
+ *     4. Write merged result to disk (synchronous, no ignore needed)
+ *     - Watcher fires normally; debounced but no suppression mechanism
+ *
+ * What this verifies:
+ *   - Cross-client convergence: Obsidian + folder clients reach the same
+ *     state after all messages are processed.
+ *   - NoContentLoss holds for BOTH client types in a mixed deployment.
+ *   - The folder client's pre-apply strategy is strictly safe.
+ *   - The fixed Obsidian client doesn't lose content either.
+ *
+ * Source: docs/FORMAL_VERIFICATION.md §7
+ *)
+EXTENDS Naturals, Sequences, FiniteSets, TLC
+
+CONSTANTS
+    Clients,          \* Set of client IDs
+    DocIds,           \* Set of document IDs
+    MaxUpdates,       \* Bound on total updates
+    MaxQueueLen,      \* Bound on message queue length
+    ObsidianClients,  \* SUBSET Clients that are Obsidian plugin
+    FolderClients     \* SUBSET Clients that are folder clients
+
+\* Helper predicates for client type dispatch
+IsObsidian(c) == c \in ObsidianClients
+IsFolder(c)   == c \in FolderClients
+
+(* ===================== VARIABLES ===================== *)
+
+VARIABLES
+    clientDoc,          \* [Clients -> [DocIds -> SUBSET Nat]] — effective CRDT content
+    clientDisk,         \* [Clients -> [DocIds -> SUBSET Nat]] — file content on disk
+    clientIgnoring,     \* [Clients -> SUBSET DocIds] — watcher suppressed (Obsidian only)
+    clientConnected,    \* [Clients -> BOOLEAN]
+    clientSubscribed,   \* [Clients -> SUBSET DocIds]
+    clientToServer,     \* [Clients -> Seq(Message)]
+    serverToClient,     \* [Clients -> Seq(Message)]
+    serverDB,           \* [DocIds -> SUBSET Nat]
+    serverChannels,     \* [DocIds -> SUBSET Clients]
+    serverIndex,        \* SUBSET DocIds
+    updateCounter,      \* Nat
+    updateOrigin,       \* Function: update ID -> originating client
+    receivedRemote      \* [Clients -> [DocIds -> SUBSET Nat]] — ghost variable
+
+vars == <<clientDoc, clientDisk, clientIgnoring,
+          clientConnected, clientSubscribed,
+          clientToServer, serverToClient,
+          serverDB, serverChannels, serverIndex,
+          updateCounter, updateOrigin, receivedRemote>>
+
+(* ===================== STATE CONSTRAINT ===================== *)
+
+StateConstraint ==
+    /\ \A c \in Clients : Len(clientToServer[c]) <= MaxQueueLen
+    /\ \A c \in Clients : Len(serverToClient[c]) <= MaxQueueLen
+    /\ updateCounter <= MaxUpdates
+
+(* ===================== MESSAGE TYPES ===================== *)
+
+MsgS1 == "S1"
+MsgS2 == "S2"
+MsgU  == "U"
+
+(* ===================== INITIAL STATE ===================== *)
+
+Init ==
+    /\ clientDoc        = [c \in Clients |-> [d \in DocIds |-> {}]]
+    /\ clientDisk       = [c \in Clients |-> [d \in DocIds |-> {}]]
+    /\ clientIgnoring   = [c \in Clients |-> {}]
+    /\ clientConnected  = [c \in Clients |-> TRUE]
+    /\ clientSubscribed = [c \in Clients |-> {}]
+    /\ clientToServer   = [c \in Clients |-> <<>>]
+    /\ serverToClient   = [c \in Clients |-> <<>>]
+    /\ serverDB         = [d \in DocIds  |-> {}]
+    /\ serverChannels   = [d \in DocIds  |-> {}]
+    /\ serverIndex      = {}
+    /\ updateCounter    = 0
+    /\ updateOrigin     = <<>>
+    /\ receivedRemote   = [c \in Clients |-> [d \in DocIds |-> {}]]
+
+(* ===================== SHARED CLIENT ACTIONS ===================== *)
+
+(*
+ * LocalDiskEdit(c, d): User edits the file on disk.
+ * Same for both client types — changes disk only.
+ *)
+LocalDiskEdit(c, d) ==
+    /\ updateCounter < MaxUpdates
+    /\ LET uid == updateCounter + 1
+       IN
+       /\ clientDisk' = [clientDisk EXCEPT ![c][d] = @ \cup {uid}]
+       /\ updateCounter' = uid
+       /\ updateOrigin' = [i \in DOMAIN updateOrigin \cup {uid} |->
+            IF i = uid THEN c ELSE updateOrigin[i]]
+    /\ UNCHANGED <<clientDoc, clientIgnoring, clientConnected, clientSubscribed,
+                   clientToServer, serverToClient,
+                   serverDB, serverChannels, serverIndex, receivedRemote>>
+
+(*
+ * ClientSubscribe(c, d): Client subscribes to a document.
+ *)
+ClientSubscribe(c, d) ==
+    /\ clientConnected[c]
+    /\ d \notin clientSubscribed[c]
+    /\ clientToServer' = [clientToServer EXCEPT
+         ![c] = Append(@, [type  |-> MsgS1,
+                           docId |-> d,
+                           have  |-> clientDoc[c][d]])]
+    /\ UNCHANGED <<clientDoc, clientDisk, clientIgnoring,
+                   clientConnected, clientSubscribed,
+                   serverToClient, serverDB, serverChannels,
+                   serverIndex, updateCounter, updateOrigin, receivedRemote>>
+
+(*
+ * ClientGoOffline(c): Client disconnects.
+ *)
+ClientGoOffline(c) ==
+    /\ clientConnected[c]
+    /\ clientConnected'  = [clientConnected EXCEPT ![c] = FALSE]
+    /\ clientSubscribed' = [clientSubscribed EXCEPT ![c] = {}]
+    /\ serverChannels'   = [d \in DocIds |-> serverChannels[d] \ {c}]
+    /\ clientToServer'   = [clientToServer EXCEPT ![c] = <<>>]
+    /\ serverToClient'   = [serverToClient EXCEPT ![c] = <<>>]
+    /\ UNCHANGED <<clientDoc, clientDisk, clientIgnoring,
+                   serverDB, serverIndex, updateCounter,
+                   updateOrigin, receivedRemote>>
+
+(*
+ * ClientReconnect(c): Client comes back online.
+ *)
+ClientReconnect(c) ==
+    /\ ~clientConnected[c]
+    /\ clientConnected' = [clientConnected EXCEPT ![c] = TRUE]
+    /\ UNCHANGED <<clientDoc, clientDisk, clientIgnoring, clientSubscribed,
+                   clientToServer, serverToClient, serverDB, serverChannels,
+                   serverIndex, updateCounter, updateOrigin, receivedRemote>>
+
+(* ===================== OBSIDIAN CLIENT ACTIONS ===================== *)
+
+(*
+ * ObsidianWatcherFires(c, d): Obsidian's file watcher fires.
+ *
+ * Blocked if ignoreChanges is set. Includes the post-read guard:
+ * re-checks ignoreChanges and compares disk vs CRDT before diffing.
+ * This is the FIXED version matching the patched main.ts.
+ *)
+ObsidianWatcherFires(c, d) ==
+    /\ IsObsidian(c)
+    /\ clientConnected[c]
+    /\ d \notin clientIgnoring[c]
+    /\ clientDisk[c][d] /= clientDoc[c][d]
+    \* Content comparison guard: if disk == CRDT, skip (no-op)
+    \* (Already handled by the precondition above)
+    /\ LET adds == clientDisk[c][d] \ clientDoc[c][d]
+           dels == clientDoc[c][d] \ clientDisk[c][d]
+       IN
+       /\ clientDoc' = [clientDoc EXCEPT ![c][d] = clientDisk[c][d]]
+       /\ IF d \in clientSubscribed[c]
+          THEN clientToServer' = [clientToServer EXCEPT
+                 ![c] = Append(@, [type   |-> MsgU,
+                                   docId  |-> d,
+                                   adds   |-> adds,
+                                   dels   |-> dels,
+                                   origin |-> c])]
+          ELSE UNCHANGED clientToServer
+    /\ UNCHANGED <<clientDisk, clientIgnoring, clientConnected, clientSubscribed,
+                   serverToClient, serverDB, serverChannels, serverIndex,
+                   updateCounter, updateOrigin, receivedRemote>>
+
+(*
+ * ObsidianApplyRemote(c): Obsidian processes a server message.
+ *
+ * Step 1 (this action): Apply to CRDT only.
+ * Step 2 (ObsidianWriteToDisk): Write to disk + set ignoreChanges.
+ *
+ * The pre-suppress guard sets ignoreChanges BEFORE the disk write,
+ * matching the fixed main.ts behavior.
+ *)
+ObsidianApplyRemote(c) ==
+    /\ IsObsidian(c)
+    /\ clientConnected[c]
+    /\ serverToClient[c] /= <<>>
+    /\ LET msg == Head(serverToClient[c])
+       IN
+       CASE msg.type = MsgS2 ->
+            /\ clientDoc' = [clientDoc EXCEPT
+                 ![c][msg.docId] = @ \cup msg.adds]
+            \* Pre-suppress: set ignoreChanges BEFORE disk write
+            /\ clientIgnoring' = [clientIgnoring EXCEPT
+                 ![c] = @ \cup {msg.docId}]
+            /\ LET nonLocal == {u \in msg.adds : u \notin DOMAIN updateOrigin
+                                                  \/ updateOrigin[u] /= c}
+               IN receivedRemote' = [receivedRemote EXCEPT
+                    ![c][msg.docId] = @ \cup nonLocal]
+
+         [] msg.type = MsgU ->
+            /\ clientDoc' = [clientDoc EXCEPT
+                 ![c][msg.docId] = (@ \cup msg.adds) \ msg.dels]
+            /\ clientIgnoring' = [clientIgnoring EXCEPT
+                 ![c] = @ \cup {msg.docId}]
+            /\ LET nonLocal == {u \in msg.adds : u \notin DOMAIN updateOrigin
+                                                  \/ updateOrigin[u] /= c}
+               IN receivedRemote' = [receivedRemote EXCEPT
+                    ![c][msg.docId] = @ \cup nonLocal]
+
+         [] OTHER ->
+            /\ UNCHANGED <<clientDoc, clientIgnoring, receivedRemote>>
+
+    /\ serverToClient' = [serverToClient EXCEPT ![c] = Tail(@)]
+    /\ UNCHANGED <<clientDisk, clientConnected, clientSubscribed,
+                   clientToServer, serverDB, serverChannels, serverIndex,
+                   updateCounter, updateOrigin>>
+
+(*
+ * ObsidianWriteToDisk(c, d): Obsidian writes CRDT content to disk.
+ * This is a separate step from ApplyRemote — can be interleaved.
+ * ignoreChanges is already set by ApplyRemote (pre-suppress).
+ *)
+ObsidianWriteToDisk(c, d) ==
+    /\ IsObsidian(c)
+    /\ clientDoc[c][d] /= clientDisk[c][d]
+    /\ clientDisk' = [clientDisk EXCEPT ![c][d] = clientDoc[c][d]]
+    /\ UNCHANGED <<clientDoc, clientIgnoring, clientConnected, clientSubscribed,
+                   clientToServer, serverToClient,
+                   serverDB, serverChannels, serverIndex,
+                   updateCounter, updateOrigin, receivedRemote>>
+
+(*
+ * ObsidianIgnoreExpires(c, d): The ignoreChanges timer fires.
+ *
+ * PRECONDITION: disk must match CRDT for this doc.
+ * In the real code, the setTimeout for clearing ignoreChanges runs
+ * in the .finally() block AFTER `await vault.modify()` completes.
+ * So the ignore timeout cannot fire until the disk write has finished.
+ *)
+ObsidianIgnoreExpires(c, d) ==
+    /\ IsObsidian(c)
+    /\ d \in clientIgnoring[c]
+    /\ clientDisk[c][d] = clientDoc[c][d]   \* disk write must have completed
+    /\ clientIgnoring' = [clientIgnoring EXCEPT ![c] = @ \ {d}]
+    /\ UNCHANGED <<clientDoc, clientDisk, clientConnected, clientSubscribed,
+                   clientToServer, serverToClient,
+                   serverDB, serverChannels, serverIndex,
+                   updateCounter, updateOrigin, receivedRemote>>
+
+(* ===================== FOLDER CLIENT ACTIONS ===================== *)
+
+(*
+ * FolderWatcherFires(c, d): Folder client's file watcher fires.
+ *
+ * The folder client has NO ignoreChanges mechanism — the watcher
+ * always fires. But it compares disk content to the existing CRDT
+ * before diffing, so if disk == CRDT no action is taken.
+ * This is safe because disk is always written synchronously after
+ * applying remote updates (see FolderApplyRemote).
+ *)
+FolderWatcherFires(c, d) ==
+    /\ IsFolder(c)
+    /\ clientConnected[c]
+    /\ clientDisk[c][d] /= clientDoc[c][d]
+    /\ LET adds == clientDisk[c][d] \ clientDoc[c][d]
+           dels == clientDoc[c][d] \ clientDisk[c][d]
+       IN
+       /\ clientDoc' = [clientDoc EXCEPT ![c][d] = clientDisk[c][d]]
+       /\ IF d \in clientSubscribed[c]
+          THEN clientToServer' = [clientToServer EXCEPT
+                 ![c] = Append(@, [type   |-> MsgU,
+                                   docId  |-> d,
+                                   adds   |-> adds,
+                                   dels   |-> dels,
+                                   origin |-> c])]
+          ELSE UNCHANGED clientToServer
+    /\ UNCHANGED <<clientDisk, clientIgnoring, clientConnected, clientSubscribed,
+                   serverToClient, serverDB, serverChannels, serverIndex,
+                   updateCounter, updateOrigin, receivedRemote>>
+
+(*
+ * FolderApplyRemote(c): Folder client processes a server message.
+ *
+ * KEY DIFFERENCE from Obsidian:
+ *   1. Read disk first
+ *   2. If disk ≠ CRDT → apply local diff, broadcast it
+ *   3. Apply remote update
+ *   4. Write merged result to disk (ATOMIC with steps 1–3)
+ *
+ * Maps to: app.rs lines 257–284 (the pre-apply strategy)
+ *)
+FolderApplyRemote(c) ==
+    /\ IsFolder(c)
+    /\ clientConnected[c]
+    /\ serverToClient[c] /= <<>>
+    /\ LET msg == Head(serverToClient[c])
+           d   == msg.docId
+       IN
+       CASE msg.type = MsgS2 ->
+            \* Step 1-2: Pre-apply local diff if disk differs from CRDT
+            /\ LET localAdds == clientDisk[c][d] \ clientDoc[c][d]
+                   localDels == clientDoc[c][d] \ clientDisk[c][d]
+                   \* After pre-apply: CRDT matches disk
+                   afterPreApply == clientDisk[c][d]
+                   \* Step 3: Apply remote additions on top
+                   finalDoc == afterPreApply \cup msg.adds
+               IN
+               /\ clientDoc' = [clientDoc EXCEPT ![c][d] = finalDoc]
+               \* Step 4: Write merged result to disk (synchronous)
+               /\ clientDisk' = [clientDisk EXCEPT ![c][d] = finalDoc]
+               \* Broadcast local diff if there was one
+               /\ IF localAdds /= {} \/ localDels /= {}
+                  THEN clientToServer' = [clientToServer EXCEPT
+                         ![c] = Append(@, [type   |-> MsgU,
+                                           docId  |-> d,
+                                           adds   |-> localAdds,
+                                           dels   |-> localDels,
+                                           origin |-> c])]
+                  ELSE UNCHANGED clientToServer
+               /\ LET nonLocal == {u \in msg.adds : u \notin DOMAIN updateOrigin
+                                                     \/ updateOrigin[u] /= c}
+                  IN receivedRemote' = [receivedRemote EXCEPT
+                       ![c][d] = @ \cup nonLocal]
+
+         [] msg.type = MsgU ->
+            /\ LET localAdds == clientDisk[c][d] \ clientDoc[c][d]
+                   localDels == clientDoc[c][d] \ clientDisk[c][d]
+                   afterPreApply == clientDisk[c][d]
+                   finalDoc == (afterPreApply \cup msg.adds) \ msg.dels
+               IN
+               /\ clientDoc' = [clientDoc EXCEPT ![c][d] = finalDoc]
+               /\ clientDisk' = [clientDisk EXCEPT ![c][d] = finalDoc]
+               /\ IF localAdds /= {} \/ localDels /= {}
+                  THEN clientToServer' = [clientToServer EXCEPT
+                         ![c] = Append(@, [type   |-> MsgU,
+                                           docId  |-> d,
+                                           adds   |-> localAdds,
+                                           dels   |-> localDels,
+                                           origin |-> c])]
+                  ELSE UNCHANGED clientToServer
+               /\ LET nonLocal == {u \in msg.adds : u \notin DOMAIN updateOrigin
+                                                     \/ updateOrigin[u] /= c}
+                  IN receivedRemote' = [receivedRemote EXCEPT
+                       ![c][d] = @ \cup nonLocal]
+
+         [] OTHER ->
+            /\ UNCHANGED <<clientDoc, clientDisk, clientToServer, receivedRemote>>
+
+    /\ serverToClient' = [serverToClient EXCEPT ![c] = Tail(@)]
+    /\ UNCHANGED <<clientIgnoring, clientConnected, clientSubscribed,
+                   serverDB, serverChannels, serverIndex,
+                   updateCounter, updateOrigin>>
+
+(* ===================== SERVER ACTIONS ===================== *)
+
+ServerReceiveSyncStep1(c) ==
+    /\ clientToServer[c] /= <<>>
+    /\ Head(clientToServer[c]).type = MsgS1
+    /\ LET msg  == Head(clientToServer[c])
+           d    == msg.docId
+           diff == serverDB[d] \ msg.have
+       IN
+       /\ serverChannels' = [serverChannels EXCEPT ![d] = @ \cup {c}]
+       /\ clientSubscribed' = [clientSubscribed EXCEPT ![c] = @ \cup {d}]
+       /\ serverIndex' = serverIndex \cup {d}
+       /\ serverToClient' = [serverToClient EXCEPT
+            ![c] = Append(@, [type |-> MsgS2, docId |-> d, adds |-> diff])]
+       /\ clientToServer' = [clientToServer EXCEPT ![c] = Tail(@)]
+    /\ UNCHANGED <<clientDoc, clientDisk, clientIgnoring, clientConnected,
+                   serverDB, updateCounter, updateOrigin, receivedRemote>>
+
+ServerReceiveUpdate(c) ==
+    /\ clientToServer[c] /= <<>>
+    /\ Head(clientToServer[c]).type = MsgU
+    /\ LET msg == Head(clientToServer[c])
+           d   == msg.docId
+       IN
+       /\ serverDB' = [serverDB EXCEPT ![d] = (@ \cup msg.adds) \ msg.dels]
+       /\ serverIndex' = serverIndex \cup {d}
+       /\ LET recipients == serverChannels[d] \ {c}
+          IN serverToClient' = [s \in Clients |->
+               IF s \in recipients
+               THEN Append(serverToClient[s],
+                           [type   |-> MsgU, docId  |-> d,
+                            adds   |-> msg.adds, dels |-> msg.dels,
+                            origin |-> msg.origin])
+               ELSE serverToClient[s]]
+       /\ clientToServer' = [clientToServer EXCEPT ![c] = Tail(@)]
+    /\ UNCHANGED <<clientDoc, clientDisk, clientIgnoring, clientConnected,
+                   clientSubscribed, serverChannels,
+                   updateCounter, updateOrigin, receivedRemote>>
+
+(* ===================== NEXT-STATE RELATION ===================== *)
+
+Next ==
+    \* Shared actions
+    \/ \E c \in Clients, d \in DocIds : LocalDiskEdit(c, d)
+    \/ \E c \in Clients, d \in DocIds : ClientSubscribe(c, d)
+    \/ \E c \in Clients : ClientGoOffline(c)
+    \/ \E c \in Clients : ClientReconnect(c)
+    \* Obsidian-specific
+    \/ \E c \in Clients, d \in DocIds : ObsidianWatcherFires(c, d)
+    \/ \E c \in Clients : ObsidianApplyRemote(c)
+    \/ \E c \in Clients, d \in DocIds : ObsidianWriteToDisk(c, d)
+    \/ \E c \in Clients, d \in DocIds : ObsidianIgnoreExpires(c, d)
+    \* Folder-specific
+    \/ \E c \in Clients, d \in DocIds : FolderWatcherFires(c, d)
+    \/ \E c \in Clients : FolderApplyRemote(c)
+    \* Server
+    \/ \E c \in Clients : ServerReceiveSyncStep1(c)
+    \/ \E c \in Clients : ServerReceiveUpdate(c)
+
+Fairness ==
+    /\ \A c \in Clients : WF_vars(ServerReceiveSyncStep1(c))
+    /\ \A c \in Clients : WF_vars(ServerReceiveUpdate(c))
+    /\ \A c \in Clients : WF_vars(ObsidianApplyRemote(c))
+    /\ \A c \in Clients : WF_vars(FolderApplyRemote(c))
+    \* Obsidian eventually writes to disk and ignore expires
+    /\ \A c \in Clients, d \in DocIds : WF_vars(ObsidianWriteToDisk(c, d))
+    /\ \A c \in Clients, d \in DocIds : WF_vars(ObsidianIgnoreExpires(c, d))
+
+Spec == Init /\ [][Next]_vars /\ Fairness
+
+(* ===================== SAFETY PROPERTIES ===================== *)
+
+NoEcho ==
+    \A c \in Clients :
+        \A i \in 1..Len(serverToClient[c]) :
+            LET msg == serverToClient[c][i]
+            IN msg.type = MsgU => msg.origin /= c
+
+NoContentLoss ==
+    \A c \in Clients, d \in DocIds :
+        receivedRemote[c][d] \subseteq clientDoc[c][d]
+
+ChannelOnlyForConnected ==
+    \A d \in DocIds :
+        \A c \in serverChannels[d] :
+            clientConnected[c]
+
+(* ===================== LIVENESS PROPERTIES ===================== *)
+
+(*
+ * CrossClientConvergence: When all clients are connected, subscribed,
+ * and all queues are drained, all clients (regardless of type) have
+ * the same document content.
+ *)
+CrossClientConvergence ==
+    \A d \in DocIds :
+      <>( /\ \A c \in Clients : clientConnected[c]
+          /\ \A c \in Clients : d \in clientSubscribed[c]
+          /\ \A c \in Clients : clientToServer[c] = <<>>
+          /\ \A c \in Clients : serverToClient[c] = <<>>
+          /\ \A c \in Clients : clientDoc[c][d] = clientDisk[c][d]
+          => \A c1, c2 \in Clients :
+               clientDoc[c1][d] = clientDoc[c2][d])
+
+(*
+ * DiskCrdtEventualConsistency: Disk eventually matches CRDT for
+ * every connected, subscribed client (both types).
+ *)
+DiskCrdtEventualConsistency ==
+    \A c \in Clients, d \in DocIds :
+      [](clientConnected[c] /\ d \in clientSubscribed[c] =>
+          <>(clientDisk[c][d] = clientDoc[c][d]))
+
+=============================================================================

--- a/docs/tla/SynclineSyncDiffLayer.tla
+++ b/docs/tla/SynclineSyncDiffLayer.tla
@@ -1,0 +1,330 @@
+----------------------- MODULE SynclineSyncDiffLayer -----------------------
+(*
+ * Phase 2: Diff Layer specification.
+ *
+ * Extends the core protocol with the file-system diff layer that converts
+ * between disk files and CRDT operations. This models:
+ *   - clientDisk: what's written on the physical file
+ *   - clientIgnoring: Obsidian's ignoreChanges suppression
+ *   - The stale-read bug (Issue #6) where a diff on stale disk content
+ *     generates spurious DELETE operations
+ *
+ * KEY ABSTRACTION: Documents are modeled as SETS of update IDs.
+ * CRDT merge = set union. The diff operation can both ADD and DELETE
+ * items. Deletions propagate via messages carrying {adds, dels}.
+ *
+ * EXPECTED RESULT: The NoContentLoss invariant SHOULD BE VIOLATED,
+ * confirming Issue #6 exists in the model. TLC will produce a
+ * counterexample trace showing the exact bug scenario.
+ *)
+EXTENDS Naturals, Sequences, FiniteSets, TLC
+
+CONSTANTS
+    Clients,
+    DocIds,
+    MaxUpdates,
+    MaxQueueLen
+
+(* ===================== VARIABLES ===================== *)
+
+VARIABLES
+    clientDoc,          \* [Clients -> [DocIds -> SUBSET Nat]] — effective CRDT content
+    clientDisk,         \* [Clients -> [DocIds -> SUBSET Nat]] — file content on disk
+    clientIgnoring,     \* [Clients -> SUBSET DocIds] — watcher suppressed
+    clientConnected,    \* [Clients -> BOOLEAN]
+    clientSubscribed,   \* [Clients -> SUBSET DocIds]
+    clientToServer,     \* [Clients -> Seq(Message)]
+    serverToClient,     \* [Clients -> Seq(Message)]
+    serverDB,           \* [DocIds -> SUBSET Nat] — server's merged doc state
+    serverChannels,     \* [DocIds -> SUBSET Clients]
+    serverIndex,        \* SUBSET DocIds
+    updateCounter,      \* Nat
+    updateOrigin,       \* Function: update ID -> originating client
+    receivedRemote      \* [Clients -> [DocIds -> SUBSET Nat]] — ghost: non-local updates ever received
+
+vars == <<clientDoc, clientDisk, clientIgnoring,
+          clientConnected, clientSubscribed,
+          clientToServer, serverToClient,
+          serverDB, serverChannels, serverIndex,
+          updateCounter, updateOrigin, receivedRemote>>
+
+(* ===================== STATE CONSTRAINT ===================== *)
+
+StateConstraint ==
+    /\ \A c \in Clients : Len(clientToServer[c]) <= MaxQueueLen
+    /\ \A c \in Clients : Len(serverToClient[c]) <= MaxQueueLen
+    /\ updateCounter <= MaxUpdates
+
+(* ===================== MESSAGE TYPES ===================== *)
+
+MsgS1 == "S1"   \* SyncStep1: client -> server, carries state vector
+MsgS2 == "S2"   \* SyncStep2: server -> client, carries missing updates (adds only)
+MsgU  == "U"    \* Update: carries adds and dels
+
+(* ===================== INITIAL STATE ===================== *)
+
+Init ==
+    /\ clientDoc        = [c \in Clients |-> [d \in DocIds |-> {}]]
+    /\ clientDisk       = [c \in Clients |-> [d \in DocIds |-> {}]]
+    /\ clientIgnoring   = [c \in Clients |-> {}]
+    /\ clientConnected  = [c \in Clients |-> TRUE]
+    /\ clientSubscribed = [c \in Clients |-> {}]
+    /\ clientToServer   = [c \in Clients |-> <<>>]
+    /\ serverToClient   = [c \in Clients |-> <<>>]
+    /\ serverDB         = [d \in DocIds  |-> {}]
+    /\ serverChannels   = [d \in DocIds  |-> {}]
+    /\ serverIndex      = {}
+    /\ updateCounter    = 0
+    /\ updateOrigin     = <<>>
+    /\ receivedRemote   = [c \in Clients |-> [d \in DocIds |-> {}]]
+
+(* ===================== CLIENT ACTIONS ===================== *)
+
+(*
+ * LocalDiskEdit(c, d): User edits the file on disk (types in editor).
+ * Changes disk ONLY. The watcher will later pick up the change.
+ *)
+LocalDiskEdit(c, d) ==
+    /\ updateCounter < MaxUpdates
+    /\ LET uid == updateCounter + 1
+       IN
+       /\ clientDisk' = [clientDisk EXCEPT ![c][d] = @ \cup {uid}]
+       /\ updateCounter' = uid
+       /\ updateOrigin' = [i \in DOMAIN updateOrigin \cup {uid} |->
+            IF i = uid THEN c ELSE updateOrigin[i]]
+    /\ UNCHANGED <<clientDoc, clientIgnoring, clientConnected, clientSubscribed,
+                   clientToServer, serverToClient,
+                   serverDB, serverChannels, serverIndex, receivedRemote>>
+
+(*
+ * ClientWatcherFires(c, d): File watcher detects change, diffs disk vs CRDT.
+ *
+ * After this action: clientDoc[c][d] = clientDisk[c][d].
+ * Generates adds (local content) and dels (SPURIOUS if disk is stale!).
+ * Blocked if ignoreChanges is set.
+ *)
+ClientWatcherFires(c, d) ==
+    /\ clientConnected[c]
+    /\ d \notin clientIgnoring[c]
+    /\ clientDisk[c][d] /= clientDoc[c][d]
+    /\ LET adds == clientDisk[c][d] \ clientDoc[c][d]
+           dels == clientDoc[c][d] \ clientDisk[c][d]
+       IN
+       \* CRDT becomes disk content (the diff's effect)
+       /\ clientDoc' = [clientDoc EXCEPT ![c][d] = clientDisk[c][d]]
+       \* Send update to server if subscribed
+       /\ IF d \in clientSubscribed[c]
+          THEN clientToServer' = [clientToServer EXCEPT
+                 ![c] = Append(@, [type   |-> MsgU,
+                                   docId  |-> d,
+                                   adds   |-> adds,
+                                   dels   |-> dels,
+                                   origin |-> c])]
+          ELSE UNCHANGED clientToServer
+    /\ UNCHANGED <<clientDisk, clientIgnoring, clientConnected, clientSubscribed,
+                   serverToClient, serverDB, serverChannels, serverIndex,
+                   updateCounter, updateOrigin, receivedRemote>>
+
+(*
+ * ClientSubscribe(c, d): Client sends SyncStep1 for doc d.
+ *)
+ClientSubscribe(c, d) ==
+    /\ clientConnected[c]
+    /\ d \notin clientSubscribed[c]
+    /\ clientToServer' = [clientToServer EXCEPT
+         ![c] = Append(@, [type  |-> MsgS1,
+                           docId |-> d,
+                           have  |-> clientDoc[c][d]])]
+    /\ UNCHANGED <<clientDoc, clientDisk, clientIgnoring,
+                   clientConnected, clientSubscribed,
+                   serverToClient, serverDB, serverChannels,
+                   serverIndex, updateCounter, updateOrigin, receivedRemote>>
+
+(*
+ * ClientApplyRemote(c): Process next message from server.
+ * Applies to CRDT only — disk write is a SEPARATE action.
+ * This models the real system where apply_update and vault.modify
+ * are separate (potentially interleaved) steps.
+ *)
+ClientApplyRemote(c) ==
+    /\ clientConnected[c]
+    /\ serverToClient[c] /= <<>>
+    /\ LET msg == Head(serverToClient[c])
+       IN
+       CASE msg.type = MsgS2 ->
+            \* SyncStep2: merge additions into CRDT
+            /\ clientDoc' = [clientDoc EXCEPT
+                 ![c][msg.docId] = @ \cup msg.adds]
+            /\ LET nonLocal == {u \in msg.adds : u \notin DOMAIN updateOrigin
+                                                  \/ updateOrigin[u] /= c}
+               IN receivedRemote' = [receivedRemote EXCEPT
+                    ![c][msg.docId] = @ \cup nonLocal]
+
+         [] msg.type = MsgU ->
+            \* Update: apply adds and dels
+            /\ clientDoc' = [clientDoc EXCEPT
+                 ![c][msg.docId] = (@ \cup msg.adds) \ msg.dels]
+            /\ LET nonLocal == {u \in msg.adds : u \notin DOMAIN updateOrigin
+                                                  \/ updateOrigin[u] /= c}
+               IN receivedRemote' = [receivedRemote EXCEPT
+                    ![c][msg.docId] = @ \cup nonLocal]
+
+         [] OTHER ->
+            /\ UNCHANGED clientDoc
+            /\ UNCHANGED receivedRemote
+
+    /\ serverToClient' = [serverToClient EXCEPT ![c] = Tail(@)]
+    /\ UNCHANGED <<clientDisk, clientIgnoring, clientConnected, clientSubscribed,
+                   clientToServer, serverDB, serverChannels, serverIndex,
+                   updateCounter, updateOrigin>>
+
+(*
+ * ClientWriteToDisk(c, d): Write CRDT content to disk file.
+ * Sets ignoreChanges to suppress the file-watcher echo.
+ *)
+ClientWriteToDisk(c, d) ==
+    /\ clientDoc[c][d] /= clientDisk[c][d]
+    /\ clientDisk' = [clientDisk EXCEPT ![c][d] = clientDoc[c][d]]
+    /\ clientIgnoring' = [clientIgnoring EXCEPT ![c] = @ \cup {d}]
+    /\ UNCHANGED <<clientDoc, clientConnected, clientSubscribed,
+                   clientToServer, serverToClient,
+                   serverDB, serverChannels, serverIndex,
+                   updateCounter, updateOrigin, receivedRemote>>
+
+(*
+ * ClientIgnoreExpires(c, d): The ignoreChanges timeout fires.
+ * In Obsidian: setTimeout(() => ignoreChanges.delete(path), 500)
+ *)
+ClientIgnoreExpires(c, d) ==
+    /\ d \in clientIgnoring[c]
+    /\ clientIgnoring' = [clientIgnoring EXCEPT ![c] = @ \ {d}]
+    /\ UNCHANGED <<clientDoc, clientDisk, clientConnected, clientSubscribed,
+                   clientToServer, serverToClient,
+                   serverDB, serverChannels, serverIndex,
+                   updateCounter, updateOrigin, receivedRemote>>
+
+(*
+ * ClientGoOffline(c): Client disconnects.
+ *)
+ClientGoOffline(c) ==
+    /\ clientConnected[c]
+    /\ clientConnected'  = [clientConnected EXCEPT ![c] = FALSE]
+    /\ clientSubscribed' = [clientSubscribed EXCEPT ![c] = {}]
+    /\ serverChannels'   = [d \in DocIds |-> serverChannels[d] \ {c}]
+    /\ clientToServer'   = [clientToServer EXCEPT ![c] = <<>>]
+    /\ serverToClient'   = [serverToClient EXCEPT ![c] = <<>>]
+    /\ UNCHANGED <<clientDoc, clientDisk, clientIgnoring,
+                   serverDB, serverIndex, updateCounter,
+                   updateOrigin, receivedRemote>>
+
+(*
+ * ClientReconnect(c): Client comes back online.
+ *)
+ClientReconnect(c) ==
+    /\ ~clientConnected[c]
+    /\ clientConnected' = [clientConnected EXCEPT ![c] = TRUE]
+    /\ UNCHANGED <<clientDoc, clientDisk, clientIgnoring, clientSubscribed,
+                   clientToServer, serverToClient, serverDB, serverChannels,
+                   serverIndex, updateCounter, updateOrigin, receivedRemote>>
+
+(* ===================== SERVER ACTIONS ===================== *)
+
+(*
+ * ServerReceiveSyncStep1(c): Process MSG_SYNC_STEP_1.
+ *)
+ServerReceiveSyncStep1(c) ==
+    /\ clientToServer[c] /= <<>>
+    /\ Head(clientToServer[c]).type = MsgS1
+    /\ LET msg  == Head(clientToServer[c])
+           d    == msg.docId
+           diff == serverDB[d] \ msg.have   \* Updates the client is missing
+       IN
+       /\ serverChannels' = [serverChannels EXCEPT ![d] = @ \cup {c}]
+       /\ clientSubscribed' = [clientSubscribed EXCEPT ![c] = @ \cup {d}]
+       /\ serverIndex' = serverIndex \cup {d}
+       /\ serverToClient' = [serverToClient EXCEPT
+            ![c] = Append(@, [type |-> MsgS2, docId |-> d, adds |-> diff])]
+       /\ clientToServer' = [clientToServer EXCEPT ![c] = Tail(@)]
+    /\ UNCHANGED <<clientDoc, clientDisk, clientIgnoring, clientConnected,
+                   serverDB, updateCounter, updateOrigin, receivedRemote>>
+
+(*
+ * ServerReceiveUpdate(c): Process MSG_UPDATE.
+ * 1. Apply to server DB (persist)
+ * 2. Broadcast to all subscribers EXCEPT sender
+ *)
+ServerReceiveUpdate(c) ==
+    /\ clientToServer[c] /= <<>>
+    /\ Head(clientToServer[c]).type = MsgU
+    /\ LET msg == Head(clientToServer[c])
+           d   == msg.docId
+       IN
+       /\ serverDB' = [serverDB EXCEPT ![d] = (@ \cup msg.adds) \ msg.dels]
+       /\ serverIndex' = serverIndex \cup {d}
+       /\ LET recipients == serverChannels[d] \ {c}
+          IN serverToClient' = [s \in Clients |->
+               IF s \in recipients
+               THEN Append(serverToClient[s],
+                           [type   |-> MsgU,
+                            docId  |-> d,
+                            adds   |-> msg.adds,
+                            dels   |-> msg.dels,
+                            origin |-> msg.origin])
+               ELSE serverToClient[s]]
+       /\ clientToServer' = [clientToServer EXCEPT ![c] = Tail(@)]
+    /\ UNCHANGED <<clientDoc, clientDisk, clientIgnoring, clientConnected,
+                   clientSubscribed, serverChannels,
+                   updateCounter, updateOrigin, receivedRemote>>
+
+(* ===================== NEXT-STATE RELATION ===================== *)
+
+Next ==
+    \/ \E c \in Clients, d \in DocIds : LocalDiskEdit(c, d)
+    \/ \E c \in Clients, d \in DocIds : ClientWatcherFires(c, d)
+    \/ \E c \in Clients, d \in DocIds : ClientSubscribe(c, d)
+    \/ \E c \in Clients : ClientApplyRemote(c)
+    \/ \E c \in Clients, d \in DocIds : ClientWriteToDisk(c, d)
+    \/ \E c \in Clients, d \in DocIds : ClientIgnoreExpires(c, d)
+    \/ \E c \in Clients : ClientGoOffline(c)
+    \/ \E c \in Clients : ClientReconnect(c)
+    \/ \E c \in Clients : ServerReceiveSyncStep1(c)
+    \/ \E c \in Clients : ServerReceiveUpdate(c)
+
+Fairness ==
+    /\ \A c \in Clients : WF_vars(ServerReceiveSyncStep1(c))
+    /\ \A c \in Clients : WF_vars(ServerReceiveUpdate(c))
+    /\ \A c \in Clients : WF_vars(ClientApplyRemote(c))
+
+Spec == Init /\ [][Next]_vars /\ Fairness
+
+(* ===================== SAFETY PROPERTIES ===================== *)
+
+(*
+ * NoEcho: Server never sends update back to the originating client.
+ *)
+NoEcho ==
+    \A c \in Clients :
+        \A i \in 1..Len(serverToClient[c]) :
+            LET msg == serverToClient[c][i]
+            IN msg.type = MsgU => msg.origin /= c
+
+(*
+ * NoContentLoss: Once a non-local update is received and applied,
+ * it should NEVER be removed from the CRDT.
+ *
+ * EXPECTED: VIOLATED — this is Issue #6. TLC will produce a
+ * counterexample showing the stale-diff scenario.
+ *)
+NoContentLoss ==
+    \A c \in Clients, d \in DocIds :
+        receivedRemote[c][d] \subseteq clientDoc[c][d]
+
+(*
+ * ChannelOnlyForConnected: Only connected clients in broadcast channels.
+ *)
+ChannelOnlyForConnected ==
+    \A d \in DocIds :
+        \A c \in serverChannels[d] :
+            clientConnected[c]
+
+=============================================================================

--- a/docs/tla/SynclineSyncDiffLayerBug.cfg
+++ b/docs/tla/SynclineSyncDiffLayerBug.cfg
@@ -1,0 +1,18 @@
+\* Config to demonstrate Issue #6 (stale-diff bug).
+\* NoContentLoss is EXPECTED TO FAIL with a counterexample trace.
+
+SPECIFICATION Spec
+
+CONSTANTS
+    Clients = {"A", "B"}
+    DocIds = {"d1"}
+    MaxUpdates = 3
+    MaxQueueLen = 3
+
+CONSTRAINT
+    StateConstraint
+
+INVARIANTS
+    NoEcho
+    ChannelOnlyForConnected
+    NoContentLoss

--- a/docs/tla/SynclineSyncDiffLayerFixed.cfg
+++ b/docs/tla/SynclineSyncDiffLayerFixed.cfg
@@ -1,0 +1,17 @@
+\* Config for the FIXED diff layer — NoContentLoss should PASS.
+
+SPECIFICATION Spec
+
+CONSTANTS
+    Clients = {"A", "B"}
+    DocIds = {"d1"}
+    MaxUpdates = 3
+    MaxQueueLen = 3
+
+CONSTRAINT
+    StateConstraint
+
+INVARIANTS
+    NoEcho
+    ChannelOnlyForConnected
+    NoContentLoss

--- a/docs/tla/SynclineSyncDiffLayerFixed.tla
+++ b/docs/tla/SynclineSyncDiffLayerFixed.tla
@@ -1,0 +1,250 @@
+--------------------- MODULE SynclineSyncDiffLayerFixed ---------------------
+(*
+ * Phase 2 FIXED: Diff Layer with atomic write-after-apply.
+ *
+ * This is identical to SynclineSyncDiffLayer except ClientApplyRemote
+ * ATOMICALLY writes to disk after applying the remote update.
+ * This models the folder client's behavior (pre-apply + immediate write)
+ * where disk is always kept in sync with the CRDT.
+ *
+ * EXPECTED RESULT: NoContentLoss should PASS — the fix prevents
+ * stale diffs from generating spurious deletes.
+ *)
+EXTENDS Naturals, Sequences, FiniteSets, TLC
+
+CONSTANTS Clients, DocIds, MaxUpdates, MaxQueueLen
+
+VARIABLES
+    clientDoc, clientDisk, clientIgnoring,
+    clientConnected, clientSubscribed,
+    clientToServer, serverToClient,
+    serverDB, serverChannels, serverIndex,
+    updateCounter, updateOrigin, receivedRemote
+
+vars == <<clientDoc, clientDisk, clientIgnoring,
+          clientConnected, clientSubscribed,
+          clientToServer, serverToClient,
+          serverDB, serverChannels, serverIndex,
+          updateCounter, updateOrigin, receivedRemote>>
+
+StateConstraint ==
+    /\ \A c \in Clients : Len(clientToServer[c]) <= MaxQueueLen
+    /\ \A c \in Clients : Len(serverToClient[c]) <= MaxQueueLen
+    /\ updateCounter <= MaxUpdates
+
+MsgS1 == "S1"
+MsgS2 == "S2"
+MsgU  == "U"
+
+Init ==
+    /\ clientDoc        = [c \in Clients |-> [d \in DocIds |-> {}]]
+    /\ clientDisk       = [c \in Clients |-> [d \in DocIds |-> {}]]
+    /\ clientIgnoring   = [c \in Clients |-> {}]
+    /\ clientConnected  = [c \in Clients |-> TRUE]
+    /\ clientSubscribed = [c \in Clients |-> {}]
+    /\ clientToServer   = [c \in Clients |-> <<>>]
+    /\ serverToClient   = [c \in Clients |-> <<>>]
+    /\ serverDB         = [d \in DocIds  |-> {}]
+    /\ serverChannels   = [d \in DocIds  |-> {}]
+    /\ serverIndex      = {}
+    /\ updateCounter    = 0
+    /\ updateOrigin     = <<>>
+    /\ receivedRemote   = [c \in Clients |-> [d \in DocIds |-> {}]]
+
+(* ===================== CLIENT ACTIONS ===================== *)
+
+LocalDiskEdit(c, d) ==
+    /\ updateCounter < MaxUpdates
+    /\ LET uid == updateCounter + 1
+       IN
+       /\ clientDisk' = [clientDisk EXCEPT ![c][d] = @ \cup {uid}]
+       /\ updateCounter' = uid
+       /\ updateOrigin' = [i \in DOMAIN updateOrigin \cup {uid} |->
+            IF i = uid THEN c ELSE updateOrigin[i]]
+    /\ UNCHANGED <<clientDoc, clientIgnoring, clientConnected, clientSubscribed,
+                   clientToServer, serverToClient,
+                   serverDB, serverChannels, serverIndex, receivedRemote>>
+
+ClientWatcherFires(c, d) ==
+    /\ clientConnected[c]
+    /\ d \notin clientIgnoring[c]
+    /\ clientDisk[c][d] /= clientDoc[c][d]
+    /\ LET adds == clientDisk[c][d] \ clientDoc[c][d]
+           dels == clientDoc[c][d] \ clientDisk[c][d]
+       IN
+       /\ clientDoc' = [clientDoc EXCEPT ![c][d] = clientDisk[c][d]]
+       /\ IF d \in clientSubscribed[c]
+          THEN clientToServer' = [clientToServer EXCEPT
+                 ![c] = Append(@, [type   |-> MsgU,
+                                   docId  |-> d,
+                                   adds   |-> adds,
+                                   dels   |-> dels,
+                                   origin |-> c])]
+          ELSE UNCHANGED clientToServer
+    /\ UNCHANGED <<clientDisk, clientIgnoring, clientConnected, clientSubscribed,
+                   serverToClient, serverDB, serverChannels, serverIndex,
+                   updateCounter, updateOrigin, receivedRemote>>
+
+ClientSubscribe(c, d) ==
+    /\ clientConnected[c]
+    /\ d \notin clientSubscribed[c]
+    /\ clientToServer' = [clientToServer EXCEPT
+         ![c] = Append(@, [type  |-> MsgS1,
+                           docId |-> d,
+                           have  |-> clientDoc[c][d]])]
+    /\ UNCHANGED <<clientDoc, clientDisk, clientIgnoring,
+                   clientConnected, clientSubscribed,
+                   serverToClient, serverDB, serverChannels,
+                   serverIndex, updateCounter, updateOrigin, receivedRemote>>
+
+(*
+ * ClientApplyRemote(c): THE FIX — atomically applies remote update
+ * AND writes to disk in the same step. This prevents any interleaving
+ * where the watcher fires between CRDT update and disk write.
+ *
+ * This matches the folder client's behavior where the event loop
+ * processes the remote update and writes to disk synchronously.
+ *)
+ClientApplyRemote(c) ==
+    /\ clientConnected[c]
+    /\ serverToClient[c] /= <<>>
+    /\ LET msg == Head(serverToClient[c])
+       IN
+       CASE msg.type = MsgS2 ->
+            /\ clientDoc' = [clientDoc EXCEPT
+                 ![c][msg.docId] = @ \cup msg.adds]
+            \* FIX: atomically write to disk
+            /\ clientDisk' = [clientDisk EXCEPT
+                 ![c][msg.docId] = clientDoc'[c][msg.docId]]
+            /\ clientIgnoring' = [clientIgnoring EXCEPT
+                 ![c] = @ \cup {msg.docId}]
+            /\ LET nonLocal == {u \in msg.adds : u \notin DOMAIN updateOrigin
+                                                  \/ updateOrigin[u] /= c}
+               IN receivedRemote' = [receivedRemote EXCEPT
+                    ![c][msg.docId] = @ \cup nonLocal]
+
+         [] msg.type = MsgU ->
+            /\ clientDoc' = [clientDoc EXCEPT
+                 ![c][msg.docId] = (@ \cup msg.adds) \ msg.dels]
+            \* FIX: atomically write to disk
+            /\ clientDisk' = [clientDisk EXCEPT
+                 ![c][msg.docId] = clientDoc'[c][msg.docId]]
+            /\ clientIgnoring' = [clientIgnoring EXCEPT
+                 ![c] = @ \cup {msg.docId}]
+            /\ LET nonLocal == {u \in msg.adds : u \notin DOMAIN updateOrigin
+                                                  \/ updateOrigin[u] /= c}
+               IN receivedRemote' = [receivedRemote EXCEPT
+                    ![c][msg.docId] = @ \cup nonLocal]
+
+         [] OTHER ->
+            /\ UNCHANGED <<clientDoc, clientDisk, clientIgnoring>>
+            /\ UNCHANGED receivedRemote
+
+    /\ serverToClient' = [serverToClient EXCEPT ![c] = Tail(@)]
+    /\ UNCHANGED <<clientConnected, clientSubscribed,
+                   clientToServer, serverDB, serverChannels, serverIndex,
+                   updateCounter, updateOrigin>>
+
+ClientIgnoreExpires(c, d) ==
+    /\ d \in clientIgnoring[c]
+    /\ clientIgnoring' = [clientIgnoring EXCEPT ![c] = @ \ {d}]
+    /\ UNCHANGED <<clientDoc, clientDisk, clientConnected, clientSubscribed,
+                   clientToServer, serverToClient,
+                   serverDB, serverChannels, serverIndex,
+                   updateCounter, updateOrigin, receivedRemote>>
+
+ClientGoOffline(c) ==
+    /\ clientConnected[c]
+    /\ clientConnected'  = [clientConnected EXCEPT ![c] = FALSE]
+    /\ clientSubscribed' = [clientSubscribed EXCEPT ![c] = {}]
+    /\ serverChannels'   = [d \in DocIds |-> serverChannels[d] \ {c}]
+    /\ clientToServer'   = [clientToServer EXCEPT ![c] = <<>>]
+    /\ serverToClient'   = [serverToClient EXCEPT ![c] = <<>>]
+    /\ UNCHANGED <<clientDoc, clientDisk, clientIgnoring,
+                   serverDB, serverIndex, updateCounter,
+                   updateOrigin, receivedRemote>>
+
+ClientReconnect(c) ==
+    /\ ~clientConnected[c]
+    /\ clientConnected' = [clientConnected EXCEPT ![c] = TRUE]
+    /\ UNCHANGED <<clientDoc, clientDisk, clientIgnoring, clientSubscribed,
+                   clientToServer, serverToClient, serverDB, serverChannels,
+                   serverIndex, updateCounter, updateOrigin, receivedRemote>>
+
+(* ===================== SERVER ACTIONS ===================== *)
+
+ServerReceiveSyncStep1(c) ==
+    /\ clientToServer[c] /= <<>>
+    /\ Head(clientToServer[c]).type = MsgS1
+    /\ LET msg  == Head(clientToServer[c])
+           d    == msg.docId
+           diff == serverDB[d] \ msg.have
+       IN
+       /\ serverChannels' = [serverChannels EXCEPT ![d] = @ \cup {c}]
+       /\ clientSubscribed' = [clientSubscribed EXCEPT ![c] = @ \cup {d}]
+       /\ serverIndex' = serverIndex \cup {d}
+       /\ serverToClient' = [serverToClient EXCEPT
+            ![c] = Append(@, [type |-> MsgS2, docId |-> d, adds |-> diff])]
+       /\ clientToServer' = [clientToServer EXCEPT ![c] = Tail(@)]
+    /\ UNCHANGED <<clientDoc, clientDisk, clientIgnoring, clientConnected,
+                   serverDB, updateCounter, updateOrigin, receivedRemote>>
+
+ServerReceiveUpdate(c) ==
+    /\ clientToServer[c] /= <<>>
+    /\ Head(clientToServer[c]).type = MsgU
+    /\ LET msg == Head(clientToServer[c])
+           d   == msg.docId
+       IN
+       /\ serverDB' = [serverDB EXCEPT ![d] = (@ \cup msg.adds) \ msg.dels]
+       /\ serverIndex' = serverIndex \cup {d}
+       /\ LET recipients == serverChannels[d] \ {c}
+          IN serverToClient' = [s \in Clients |->
+               IF s \in recipients
+               THEN Append(serverToClient[s],
+                           [type   |-> MsgU, docId |-> d,
+                            adds   |-> msg.adds, dels |-> msg.dels,
+                            origin |-> msg.origin])
+               ELSE serverToClient[s]]
+       /\ clientToServer' = [clientToServer EXCEPT ![c] = Tail(@)]
+    /\ UNCHANGED <<clientDoc, clientDisk, clientIgnoring, clientConnected,
+                   clientSubscribed, serverChannels,
+                   updateCounter, updateOrigin, receivedRemote>>
+
+(* ===================== SPECIFICATION ===================== *)
+
+Next ==
+    \/ \E c \in Clients, d \in DocIds : LocalDiskEdit(c, d)
+    \/ \E c \in Clients, d \in DocIds : ClientWatcherFires(c, d)
+    \/ \E c \in Clients, d \in DocIds : ClientSubscribe(c, d)
+    \/ \E c \in Clients : ClientApplyRemote(c)
+    \/ \E c \in Clients, d \in DocIds : ClientIgnoreExpires(c, d)
+    \/ \E c \in Clients : ClientGoOffline(c)
+    \/ \E c \in Clients : ClientReconnect(c)
+    \/ \E c \in Clients : ServerReceiveSyncStep1(c)
+    \/ \E c \in Clients : ServerReceiveUpdate(c)
+
+Fairness ==
+    /\ \A c \in Clients : WF_vars(ServerReceiveSyncStep1(c))
+    /\ \A c \in Clients : WF_vars(ServerReceiveUpdate(c))
+    /\ \A c \in Clients : WF_vars(ClientApplyRemote(c))
+
+Spec == Init /\ [][Next]_vars /\ Fairness
+
+(* ===================== PROPERTIES ===================== *)
+
+NoEcho ==
+    \A c \in Clients :
+        \A i \in 1..Len(serverToClient[c]) :
+            LET msg == serverToClient[c][i]
+            IN msg.type = MsgU => msg.origin /= c
+
+NoContentLoss ==
+    \A c \in Clients, d \in DocIds :
+        receivedRemote[c][d] \subseteq clientDoc[c][d]
+
+ChannelOnlyForConnected ==
+    \A d \in DocIds :
+        \A c \in serverChannels[d] :
+            clientConnected[c]
+
+=============================================================================

--- a/docs/tla/SynclineSyncSmall.cfg
+++ b/docs/tla/SynclineSyncSmall.cfg
@@ -1,0 +1,21 @@
+\* Minimal TLC config: invariants only, small bounds.
+\* Should complete in seconds.
+
+SPECIFICATION Spec
+
+CONSTANTS
+    Clients = {"A", "B"}
+    DocIds = {"d1"}
+    MaxUpdates = 2
+    MaxQueueLen = 3
+
+CONSTRAINT
+    StateConstraint
+
+INVARIANTS
+    TypeOK
+    NoEcho
+    PersistBeforeBroadcast
+    ChannelOnlyForConnected
+    IndexConsistency
+    SubscriptionConsistency

--- a/obsidian-plugin/main.ts
+++ b/obsidian-plugin/main.ts
@@ -71,6 +71,17 @@ async function initWasm(): Promise<WasmModule> {
   return wasm;
 }
 
+/**
+ * Duration to suppress the file-watcher after writing a remote update to disk.
+ * Must be strictly greater than the onFileModify debounce window (300 ms) to
+ * guarantee that any debounced handler triggered by our own vault.modify()
+ * call is still suppressed when it finally fires.
+ *
+ * See docs/tla/SynclineSyncDiffLayer.tla — the TLA+ model proved that
+ * without this guard, a stale disk read generates spurious DELETE operations.
+ */
+const IGNORE_CHANGES_TIMEOUT_MS = 1000;
+
 export default class SynclinePlugin extends Plugin {
   settings: SynclineSettings;
   statusBarItem: HTMLElement;
@@ -416,7 +427,7 @@ export default class SynclinePlugin extends Plugin {
               this.app.vault
                 .modify(file, remoteContent)
                 .finally(() => {
-                  setTimeout(() => this.ignoreChanges.delete(file.path), 500);
+                  setTimeout(() => this.ignoreChanges.delete(file.path), IGNORE_CHANGES_TIMEOUT_MS);
                 })
                 .catch((error) => {
                   console.error(`[Syncline] Error updating ${file.path} after initial merge:`, error);
@@ -432,7 +443,7 @@ export default class SynclinePlugin extends Plugin {
               this.app.vault
                 .modify(file, merged)
                 .finally(() => {
-                  setTimeout(() => this.ignoreChanges.delete(file.path), 500);
+                  setTimeout(() => this.ignoreChanges.delete(file.path), IGNORE_CHANGES_TIMEOUT_MS);
                 })
                 .catch((error) => {
                   console.error(`[Syncline] Error updating ${file.path} after merge:`, error);
@@ -448,6 +459,12 @@ export default class SynclinePlugin extends Plugin {
           });
       } else {
         if (!isMerging) {
+          // FIX(Issue #6): Suppress the file-watcher IMMEDIATELY when CRDT
+          // is updated, BEFORE the async disk write in onRemoteUpdate().
+          // The TLA+ model proved that without this, there is a window
+          // where the watcher reads stale disk content and generates a
+          // spurious diff that deletes valid remote content.
+          this.ignoreChanges.add(file.path);
           void this.onRemoteUpdate(uuid);
         }
       }
@@ -506,7 +523,7 @@ export default class SynclinePlugin extends Plugin {
       this.app.fileManager.trashFile(file).catch((error) => {
         console.error(`[Syncline] Error deleting file ${filePath}:`, error);
       }).finally(() => {
-        setTimeout(() => this.ignoreChanges.delete(filePath), 500);
+        setTimeout(() => this.ignoreChanges.delete(filePath), IGNORE_CHANGES_TIMEOUT_MS);
       });
     }
     this.client?.remove_doc(uuid);
@@ -546,7 +563,7 @@ export default class SynclinePlugin extends Plugin {
           setTimeout(() => {
             this.ignoreChanges.delete(currentPath);
             this.ignoreChanges.delete(metaPath);
-          }, 500);
+          }, IGNORE_CHANGES_TIMEOUT_MS);
         }
       }
     }
@@ -557,14 +574,22 @@ export default class SynclinePlugin extends Plugin {
       try {
         const currentContent = await this.app.vault.read(file);
         if (currentContent === content) {
+          // Disk already matches CRDT — clear ignore early, nothing to write.
+          this.ignoreChanges.delete(targetPath);
           return;
         }
+        // ignoreChanges is already set by the caller (addDocOnly callback)
+        // but ensure it's set in case onRemoteUpdate is called from elsewhere.
         this.ignoreChanges.add(targetPath);
         await this.app.vault.modify(file, content);
       } catch (error) {
         console.error(`[Syncline] Error updating file ${targetPath}:`, error);
       } finally {
-        setTimeout(() => this.ignoreChanges.delete(targetPath), 500);
+        // Clear the suppression after IGNORE_CHANGES_TIMEOUT_MS.
+        // This MUST be longer than the 300 ms debounce on onFileModify so
+        // that any watcher event caused by our vault.modify() call above
+        // is still suppressed when the debounced handler fires.
+        setTimeout(() => this.ignoreChanges.delete(targetPath), IGNORE_CHANGES_TIMEOUT_MS);
       }
     } else if (!file && targetPath) {
       try {
@@ -579,7 +604,7 @@ export default class SynclinePlugin extends Plugin {
       } catch (error) {
         console.error(`[Syncline] Failed to create file ${targetPath} on remote update:`, error);
       } finally {
-        setTimeout(() => this.ignoreChanges.delete(targetPath), 500);
+        setTimeout(() => this.ignoreChanges.delete(targetPath), IGNORE_CHANGES_TIMEOUT_MS);
       }
     }
   }
@@ -599,6 +624,19 @@ export default class SynclinePlugin extends Plugin {
 
     try {
       const content = await this.app.vault.read(file);
+
+      // FIX(Issue #6): After the async read, re-check ignoreChanges.
+      // A remote update may have been applied between the debounce
+      // trigger and the actual disk read, making our content stale.
+      if (this.ignoreChanges.has(file.path)) return;
+
+      // FIX(Issue #6): Compare disk content against the current CRDT state.
+      // If they already match, skip the update — this prevents the diff
+      // from generating no-op (or worse, spurious rollback) operations
+      // when the disk content reflects a recently-applied remote update.
+      const crdtContent = this.client.get_text(uuid);
+      if (crdtContent === content) return;
+
       this.client.update(uuid, content);
     } catch (error) {
       console.error("[Syncline] Error syncing:", error);


### PR DESCRIPTION
## Summary

Closes the stale file-watcher race condition (Issue #6) in the Obsidian plugin and adds TLA+ formal verification for the Syncline synchronization protocol.

## Bug

When a remote CRDT update was applied, the Obsidian plugin updated the CRDT state and then asynchronously wrote the new content to disk. During this gap, the file-watcher could read the stale disk content, diff it against the updated CRDT, and generate a **spurious DELETE** operation — rolling back the remote update and propagating the deletion to all other clients.

## Fix (3 layers of defense)

1. **Pre-suppress** (`ignoreChanges.add()` before calling `onRemoteUpdate()`): closes the window between CRDT update and disk write.
2. **Post-read guard**: re-check `ignoreChanges` after the async `vault.read()` in `onFileModify`, catching cases where a remote update arrived during the 300ms debounce window.
3. **Content comparison**: compare disk content against current CRDT state before calling `update()`, preventing no-op or spurious rollback diffs.

Also raises the ignore timeout from 500ms to 1000ms (named constant `IGNORE_CHANGES_TIMEOUT_MS`) to guarantee coverage over the 300ms debounce window.

## TLA+ Formal Verification

This PR includes a complete TLA+ formal model of the Syncline sync protocol:

### Phase 1 — Core protocol
- `SynclineSync.tla`: 2 clients, server relay, offline/reconnect
- **All 7 properties pass** across 860K distinct states (34s)

### Phase 2 — Diff layer (Issue #6)
- `SynclineSyncDiffLayer.tla`: **Reproduces the bug** — TLC finds a 10-state counterexample in 1 second
- `SynclineSyncDiffLayerFixed.tla`: **Verifies the fix** — passes across 1.7M distinct states (14s)

### Running the verification
```bash
cd docs/tla
curl -L -o tla2tools.jar https://github.com/tlaplus/tlaplus/releases/download/v1.8.0/tla2tools.jar
java -XX:+UseParallelGC -jar tla2tools.jar -config SynclineSyncDiffLayerBug.cfg -workers 4 -nowarning SynclineSyncDiffLayer.tla
```
