### PR TITLE
feat: implement binary file synchronization support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5244,6 +5244,7 @@ dependencies = [
  "notify-debouncer-mini",
  "serde",
  "serde_json",
+ "sha2",
  "sqlx",
  "tempfile",
  "tokio",

--- a/docs/FUTURE_WORK.md
+++ b/docs/FUTURE_WORK.md
@@ -95,3 +95,11 @@ For a vault with many documents and a long history, this scan grows linearly wit
 **Issue**: When a file is deleted and the deletion is signaled as an empty-content update, the corresponding `.bin` state snapshot is updated to reflect empty content but is never removed from `.syncline/data/`. Over time, the state directory accumulates orphaned `.bin` files for documents that no longer exist.
 
 **Recommendation**: After applying an empty-content update for a deleted document, remove the corresponding `.bin` file from `.syncline/data/`.
+
+### F-11. No Blob Chunking for Large Binary Files
+
+**Location**: `syncline/src/protocol.rs`, `MAX_BLOB_SIZE`
+
+**Issue**: Binary file synchronization sends the entire blob as a single WebSocket message. The current hard limit is 50 MB. Files larger than this are rejected at the protocol layer. Very large files (e.g. multi-hundred-megabyte attachments) cannot be synchronized.
+
+**Recommendation**: Implement chunked blob transfer with a streaming protocol that splits large files into fixed-size chunks (e.g. 1 MB), each sent as a separate `MSG_BLOB_CHUNK` message with a sequence number. This would allow synchronization of arbitrarily large files while keeping memory usage bounded.

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -31,7 +31,7 @@ Every message exchanged between the client and the server has the following bina
 
 ### Message Types
 
-There are three types of messages defined in the protocol:
+There are five types of messages defined in the protocol:
 
 - **`MSG_SYNC_STEP_1` (0x00)**
   - **Direction**: Client ➞ Server
@@ -49,6 +49,18 @@ There are three types of messages defined in the protocol:
   - **Purpose**: Disseminates newly applied changes to the document.
   - **Payload**: A Yjs Document update.
   - **Server behavior**: When the server receives a `MSG_UPDATE`, it (1) registers the `doc_id` in `__index__` if new, (2) persists the update to the database, and (3) broadcasts the update to all subscribers of the document's broadcast channel **except** the sender.
+
+- **`MSG_BLOB_UPDATE` (0x04)**
+  - **Direction**: Bidirectional (Client ➞ Server, Server ➞ Client)
+  - **Purpose**: Transfers raw binary file content (blobs). Used for files that cannot be represented as Yjs Text (images, PDFs, etc.).
+  - **Payload**: The raw binary content of the file.
+  - **Server behavior**: When the server receives a `MSG_BLOB_UPDATE`, it (1) computes the SHA-256 hash of the payload, (2) stores the blob in the `blobs` table (content-addressable by hash), and (3) broadcasts the blob to all subscribers of the document's broadcast channel **except** the sender.
+
+- **`MSG_BLOB_REQUEST` (0x05)**
+  - **Direction**: Client ➞ Server
+  - **Purpose**: Requests a specific blob by its SHA-256 hash. Used when a client receives a metadata update indicating a new `blob_hash` but does not have the corresponding binary content.
+  - **Payload**: The SHA-256 hash of the requested blob, encoded as a UTF-8 hex string.
+  - **Server behavior**: The server looks up the blob by hash in the `blobs` table and responds with a `MSG_BLOB_UPDATE` containing the blob data.
 
 ## Document Identification
 
@@ -158,23 +170,50 @@ The server and clients use a special reserved document ID `"__index__"` to track
 
 Each file in the vault is represented by a Yjs Document identified by a **UUID**.
 
-The document contains two top-level Yjs structures:
+#### Text File Documents
+
+Text files (`.md`, `.txt`) use the full Yjs CRDT for content synchronization:
 
 | Yrs Type | Name        | Purpose                                                      |
 | -------- | ----------- | ------------------------------------------------------------ |
 | `Y.Text` | `"content"` | The file's text content.                                     |
-| `Y.Map`  | `"meta"`    | Metadata about the file, currently containing the file path. |
+| `Y.Map`  | `"meta"`    | Metadata about the file (path, type).                        |
 
-#### The `content` Text
+##### The `content` Text
 
 - **Type**: `doc.getText('content')` / `doc.get_or_insert_text("content")`
 - **Data**: The entire text content of the file. Syncing this Yjs Text guarantees real-time collaborative text editing with conflict-free merging.
 
-#### The `meta` Map
+##### The `meta` Map
 
 - **Type**: `doc.getMap('meta')` / `doc.get_or_insert_map("meta")`
 - **Keys**:
-  - `"path"` (`string`) — The relative file path within the vault (e.g., `"notes/idea.md"` or `"journal/2024-01-15.md"`).
+  - `"path"` (`string`) — The relative file path within the vault (e.g., `"notes/idea.md"`).
+  - `"type"` (`string`) — `"text"` for text files (may be omitted for backward compatibility).
+
+#### Binary File Documents
+
+Binary files (images, PDFs, etc.) use a metadata-only CRDT document plus separate blob messages for content:
+
+| Yrs Type | Name     | Purpose                                                         |
+| -------- | -------- | --------------------------------------------------------------- |
+| `Y.Map`  | `"meta"` | Metadata about the file (path, type, blob hash).                |
+
+> **Note**: Binary documents do **not** have a `Y.Text("content")`. The binary data is transferred via `MSG_BLOB_UPDATE` messages, not through the CRDT.
+
+##### The `meta` Map (Binary)
+
+- **Keys**:
+  - `"path"` (`string`) — The relative file path within the vault (e.g., `"images/photo.png"`).
+  - `"type"` (`string`) — Always `"binary"` for binary files.
+  - `"blob_hash"` (`string`) — The SHA-256 hex hash of the file's binary content. Used for change detection and content-addressable storage.
+
+#### Binary File Synchronization Flow
+
+1. **Upload**: Client computes SHA-256 hash of the file, sets `meta.blob_hash` and `meta.type` in the CRDT, then sends a `MSG_BLOB_UPDATE` with the raw bytes.
+2. **Metadata broadcast**: The CRDT update (containing the new `blob_hash`) is broadcast to all clients via standard `MSG_UPDATE`.
+3. **Download**: Remote clients receive the metadata update, compare `blob_hash` with their local file, and send a `MSG_BLOB_REQUEST` if the hashes differ.
+4. **Conflict resolution**: Binary files use Last-Write-Wins (LWW) based on the CRDT timestamp of the `blob_hash` field. The latest writer's content wins.
 
 The `meta.path` field is critical for:
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -21,3 +21,15 @@ No merge conflicts, no weird duplicated `_Conflict_Copy` files, just seamless sy
 ## Real-Time & WebSockets
 
 When you're online, all of this happens basically instantly over WebSockets. The second you tap a letter on your phone, an incredibly tiny binary update is shot to the server, and the server broadcasts that letter out to your desktop where it magically pops up right within Obsidian.
+
+## Binary File Synchronization
+
+Not everything is text. Images, PDFs, and attachments are **binary files** that can't be merged character-by-character like text. Syncline handles these with a different strategy:
+
+1. **Content-Addressable Storage**: Each binary file is identified by its **SHA-256 hash**. The server stores blobs in a content-addressable `blobs` table — if two files have the same content, they share the same blob.
+
+2. **Metadata CRDTs**: Binary files still use a CRDT document, but only for **metadata** (`meta.path`, `meta.type`, `meta.blob_hash`). The actual binary content is transferred via separate `MSG_BLOB_UPDATE` messages, not through the CRDT.
+
+3. **Change Detection**: When a binary file is modified, the client computes its new SHA-256 hash and compares it with the hash stored in the CRDT. If they differ, the new blob is uploaded to the server and broadcast to all other clients.
+
+4. **Conflict Resolution**: Binary files use **Last-Write-Wins (LWW)** based on the CRDT timestamp of the `blob_hash` field. The latest writer's content wins. This is simpler than text merging but appropriate for binary data where character-level merging isn't possible.

--- a/obsidian-plugin/main.ts
+++ b/obsidian-plugin/main.ts
@@ -40,6 +40,11 @@ interface WasmModule {
 interface SynclineClient {
   connect(): void;
   add_doc(doc_id: string, callback: () => void): void;
+  add_binary_doc(
+    doc_id: string,
+    callback: () => void,
+    blob_callback: (doc_id: string, data: Uint8Array) => void,
+  ): void;
   remove_doc(doc_id: string): void;
   get_text(doc_id: string): string | undefined;
   update(doc_id: string, content: string): void;
@@ -52,6 +57,12 @@ interface SynclineClient {
   index_keys(): string[];
   get_meta_path(doc_id: string): string | undefined;
   set_meta_path(doc_id: string, path: string): void;
+  get_meta_type(doc_id: string): string | undefined;
+  set_meta_type(doc_id: string, file_type: string): void;
+  get_blob_hash(doc_id: string): string | undefined;
+  set_blob_hash(doc_id: string, hash: string): void;
+  send_blob(doc_id: string, data: Uint8Array): void;
+  request_blob(doc_id: string, hash: string): void;
   disconnect(): void;
   free(): void;
 }
@@ -81,6 +92,21 @@ async function initWasm(): Promise<WasmModule> {
  * without this guard, a stale disk read generates spurious DELETE operations.
  */
 const IGNORE_CHANGES_TIMEOUT_MS = 1000;
+
+/** Text-based file extensions that use Y.Text CRDT for content sync. */
+const TEXT_EXTENSIONS = ["md", "txt"];
+
+/** Returns true if a file should be synced as binary (not via Y.Text CRDT). */
+function isBinaryFile(file: TFile): boolean {
+  return !TEXT_EXTENSIONS.includes(file.extension ?? "");
+}
+
+/** Compute SHA-256 hex hash of a byte array using Web Crypto. */
+async function sha256Hex(data: ArrayBuffer): Promise<string> {
+  const hashBuffer = await crypto.subtle.digest("SHA-256", data);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  return hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
+}
 
 export default class SynclinePlugin extends Plugin {
   settings: SynclineSettings;
@@ -241,9 +267,7 @@ export default class SynclinePlugin extends Plugin {
       });
 
       // Register all vault files under their UUIDs BEFORE connecting
-      const files = this.app.vault
-        .getFiles()
-        .filter((f) => ["md", "txt"].includes(f.extension ?? ""));
+      const files = this.app.vault.getFiles();
       console.debug("[Syncline] Adding", files.length, "files to index");
 
       for (const file of files) {
@@ -259,7 +283,11 @@ export default class SynclinePlugin extends Plugin {
       for (const file of files) {
         const uuid = this.settings.uuidMap[file.path];
         if (uuid) {
-          this.addDocOnly(file, uuid);
+          if (isBinaryFile(file)) {
+            this.addBinaryDocOnly(file, uuid);
+          } else {
+            this.addDocOnly(file, uuid);
+          }
         }
       }
 
@@ -471,6 +499,89 @@ export default class SynclinePlugin extends Plugin {
     });
   }
 
+  /** Subscribe to a binary doc by UUID. Handles blob upload/download for non-text files. */
+  addBinaryDocOnly(file: TFile, uuid: string) {
+    if (!this.client) return;
+
+    let initialSyncDone = false;
+
+    // Metadata callback: fires when the CRDT meta document is updated
+    const onMetaUpdate = () => {
+      this.client?.set_meta_path(uuid, file.path);
+      this.client?.set_meta_type(uuid, "binary");
+
+      if (!initialSyncDone) {
+        initialSyncDone = true;
+        // On initial sync: compare local hash with remote hash
+        this.app.vault
+          .readBinary(file)
+          .then(async (data) => {
+            const localHash = await sha256Hex(data);
+            const remoteHash = this.client?.get_blob_hash(uuid);
+
+            if (!remoteHash || remoteHash === "") {
+              // No remote hash yet — upload our data
+              this.client?.set_blob_hash(uuid, localHash);
+              this.client?.send_blob(uuid, new Uint8Array(data));
+            } else if (remoteHash !== localHash) {
+              // Remote has different content — request it
+              this.client?.request_blob(uuid, remoteHash);
+            }
+            // else: hashes match, nothing to do
+          })
+          .catch((error) => {
+            console.error(`[Syncline] Error reading binary file ${file.path}:`, error);
+          });
+      } else {
+        // Subsequent meta updates: check if blob hash changed
+        const remoteHash = this.client?.get_blob_hash(uuid);
+        if (remoteHash && remoteHash !== "") {
+          this.app.vault
+            .readBinary(file)
+            .then(async (data) => {
+              const localHash = await sha256Hex(data);
+              if (remoteHash !== localHash) {
+                // Remote has newer blob — request it
+                this.client?.request_blob(uuid, remoteHash);
+              }
+            })
+            .catch((error) => {
+              console.error(`[Syncline] Error reading binary file ${file.path}:`, error);
+            });
+        }
+      }
+    };
+
+    // Blob callback: fires when MSG_BLOB_UPDATE arrives with binary data
+    const onBlobReceived = (_docId: string, data: Uint8Array) => {
+      const targetPath = this.client?.get_meta_path(uuid) ?? file.path;
+      this.ignoreChanges.add(targetPath);
+
+      const existingFile = this.app.vault.getAbstractFileByPath(targetPath);
+      const promise: Promise<unknown> = existingFile instanceof TFile
+        ? this.app.vault.modifyBinary(existingFile, data.buffer as ArrayBuffer)
+        : this.ensureParentFolders(targetPath).then(() => {
+            return this.app.vault.createBinary(targetPath, data.buffer as ArrayBuffer).then(() => {
+              this.settings.uuidMap[targetPath] = uuid;
+              void this.saveSettings();
+            });
+          });
+
+      promise
+        .then(() => {
+          console.debug(`[Syncline] Wrote binary file ${targetPath} (${data.length} bytes)`);
+        })
+        .catch((error) => {
+          console.error(`[Syncline] Failed to write binary file ${targetPath}:`, error);
+        })
+        .finally(() => {
+          setTimeout(() => this.ignoreChanges.delete(targetPath), IGNORE_CHANGES_TIMEOUT_MS);
+        });
+    };
+
+    this.client.add_binary_doc(uuid, onMetaUpdate, onBlobReceived);
+  }
+
   /** Register a new file: assign UUID, track it, insert into index, subscribe. */
   addFile(file: TFile) {
     if (!this.client) return;
@@ -478,7 +589,11 @@ export default class SynclinePlugin extends Plugin {
     const uuid = this.getOrCreateUuid(file.path);
     this.knownFiles.add(uuid);
     this.client.index_insert(uuid);
-    this.addDocOnly(file, uuid);
+    if (isBinaryFile(file)) {
+      this.addBinaryDocOnly(file, uuid);
+    } else {
+      this.addDocOnly(file, uuid);
+    }
   }
 
   private async ensureParentFolders(filePath: string): Promise<void> {
@@ -505,13 +620,35 @@ export default class SynclinePlugin extends Plugin {
   createFileFromRemote(uuid: string) {
     if (!this.client) return;
 
+    // We don't know yet if this is text or binary — use add_doc first,
+    // and once meta.type arrives via CRDT we can decide.
     this.client.add_doc(uuid, () => {
       const path = this.client?.get_meta_path(uuid);
+      const metaType = this.client?.get_meta_type(uuid);
       if (path) {
         // Record the path→uuid mapping now that we know it
         this.settings.uuidMap[path] = uuid;
         void this.saveSettings();
-        void this.onRemoteUpdate(uuid);
+
+        if (metaType === "binary") {
+          // Re-register as binary doc and request blob
+          this.client?.remove_doc(uuid);
+          const file = this.app.vault.getAbstractFileByPath(path);
+          if (file instanceof TFile) {
+            this.addBinaryDocOnly(file, uuid);
+          } else {
+            // Create placeholder, then register binary doc
+            void this.ensureParentFolders(path).then(() => {
+              void this.app.vault.createBinary(path, new ArrayBuffer(0)).then((newFile) => {
+                this.addBinaryDocOnly(newFile, uuid);
+              }).catch((error) => {
+                console.error(`[Syncline] Failed to create binary file ${path}:`, error);
+              });
+            });
+          }
+        } else {
+          void this.onRemoteUpdate(uuid);
+        }
       }
     });
   }
@@ -615,37 +752,42 @@ export default class SynclinePlugin extends Plugin {
 
   onFileModify = debounce(async (file: TAbstractFile) => {
     if (!(file instanceof TFile)) return;
-    if (!["md", "txt"].includes(file.extension ?? "")) return;
     if (this.ignoreChanges.has(file.path)) return;
     if (!this.client) return;
 
     const uuid = this.settings.uuidMap[file.path];
     if (!uuid) return;
 
-    try {
-      const content = await this.app.vault.read(file);
-
-      // FIX(Issue #6): After the async read, re-check ignoreChanges.
-      // A remote update may have been applied between the debounce
-      // trigger and the actual disk read, making our content stale.
-      if (this.ignoreChanges.has(file.path)) return;
-
-      // FIX(Issue #6): Compare disk content against the current CRDT state.
-      // If they already match, skip the update — this prevents the diff
-      // from generating no-op (or worse, spurious rollback) operations
-      // when the disk content reflects a recently-applied remote update.
-      const crdtContent = this.client.get_text(uuid);
-      if (crdtContent === content) return;
-
-      this.client.update(uuid, content);
-    } catch (error) {
-      console.error("[Syncline] Error syncing:", error);
+    if (isBinaryFile(file)) {
+      // Binary file: read bytes, compute hash, upload if changed
+      try {
+        const data = await this.app.vault.readBinary(file);
+        if (this.ignoreChanges.has(file.path)) return;
+        const hash = await sha256Hex(data);
+        const currentHash = this.client.get_blob_hash(uuid);
+        if (currentHash === hash) return; // unchanged
+        this.client.set_blob_hash(uuid, hash);
+        this.client.set_meta_type(uuid, "binary");
+        this.client.send_blob(uuid, new Uint8Array(data));
+      } catch (error) {
+        console.error(`[Syncline] Error syncing binary file ${file.path}:`, error);
+      }
+    } else {
+      // Text file: existing behavior
+      try {
+        const content = await this.app.vault.read(file);
+        if (this.ignoreChanges.has(file.path)) return;
+        const crdtContent = this.client.get_text(uuid);
+        if (crdtContent === content) return;
+        this.client.update(uuid, content);
+      } catch (error) {
+        console.error("[Syncline] Error syncing:", error);
+      }
     }
   }, 300);
 
   onFileCreate = (file: TAbstractFile) => {
     if (!(file instanceof TFile)) return;
-    if (!["md", "txt"].includes(file.extension ?? "")) return;
     if (this.ignoreChanges.has(file.path)) return;
 
     this.addFile(file);
@@ -676,18 +818,18 @@ export default class SynclinePlugin extends Plugin {
     if (uuid) {
       // Keep the same UUID — only update the path mapping and broadcast via set_meta_path
       delete this.settings.uuidMap[oldPath];
-      if (file instanceof TFile && ["md", "txt"].includes(file.extension ?? "")) {
+      if (file instanceof TFile) {
         this.settings.uuidMap[file.path] = uuid;
         // This CRDT update broadcasts the new meta.path to all other clients
         this.client?.set_meta_path(uuid, file.path);
       } else {
-        // Renamed to a non-synced extension — remove from sync
+        // Renamed to a non-file — remove from sync
         this.client?.index_remove(uuid);
         this.client?.remove_doc(uuid);
         this.knownFiles.delete(uuid);
       }
-    } else if (file instanceof TFile && ["md", "txt"].includes(file.extension ?? "")) {
-      // File was not previously tracked (e.g. renamed from an ignored extension)
+    } else if (file instanceof TFile) {
+      // File was not previously tracked
       this.addFile(file);
     }
 

--- a/syncline/Cargo.toml
+++ b/syncline/Cargo.toml
@@ -12,6 +12,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 anyhow = "1.0"
 dissimilar = "1.0"
+sha2 = "0.10"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2"

--- a/syncline/src/client/app.rs
+++ b/syncline/src/client/app.rs
@@ -1,7 +1,10 @@
 use crate::client::diff::apply_diff_to_yrs;
 use crate::client::network::SynclineClient;
 use crate::client::protocol::{Message, MsgType};
-use crate::client::state::{read_meta_path, write_meta_path, LocalState};
+use crate::client::state::{
+    is_binary_file, read_meta_blob_hash, read_meta_path, read_meta_type, sha256_hash,
+    write_meta_blob_hash, write_meta_path, write_meta_type, BlobChange, LocalState,
+};
 use crate::client::storage::{load_doc, save_doc};
 use crate::client::watcher::DebouncedWatcher;
 use colored::Colorize;
@@ -42,18 +45,19 @@ pub async fn run_client(folder: PathBuf, url: String, name: Option<String>) -> a
     // This ensures local state is fully consistent (disk → CRDT) before any
     // network activity begins. The `freshly_created` set tracks UUIDs that
     // had no prior `.bin` state — used later for path-collision conflict detection.
-    let (initial_offline_changes, mut freshly_created) =
+    let (initial_offline_changes, mut freshly_created, initial_blob_changes) =
         match local_state.bootstrap_offline_changes() {
             Ok(result) => result,
             Err(e) => {
                 error!("Error bootstrapping offline changes: {:?}", e);
-                (Vec::new(), HashSet::new())
+                (Vec::new(), HashSet::new(), Vec::new())
             }
         };
     // Use take() so offline changes are broadcast exactly once (on first
     // successful connection). On subsequent reconnects this is None.
     let mut pending_offline_changes: Option<Vec<(String, Vec<u8>)>> =
         Some(initial_offline_changes);
+    let mut pending_blob_changes: Option<Vec<BlobChange>> = Some(initial_blob_changes);
 
     // Setup network
     let server_url = url;
@@ -132,6 +136,19 @@ pub async fn run_client(folder: PathBuf, url: String, name: Option<String>) -> a
                 error!("Failed to broadcast offline update for {}: {:?}", uuid, e);
             } else {
                 info!("Broadcasted offline changes for {}", uuid);
+            }
+        }
+
+        // Upload pending blobs (first connection only)
+        let blob_changes = pending_blob_changes.take().unwrap_or_default();
+        for blob in blob_changes {
+            if let Err(e) = ws_tx
+                .send(Message::new(MsgType::BlobUpdate, blob.uuid.clone(), blob.data))
+                .await
+            {
+                error!("Failed to upload blob for {}: {:?}", blob.uuid, e);
+            } else {
+                info!("Uploaded blob for {} (hash: {})", blob.uuid, blob.hash);
             }
         }
 
@@ -254,8 +271,8 @@ pub async fn run_client(folder: PathBuf, url: String, name: Option<String>) -> a
                             // Check for unsynced local disk changes before applying remote update
                             if let Some(ref rp) = prev_rel_path {
                                 let phys_path = local_state.root_dir.join(rp);
-                                if let Ok(disk_content) = fs::read_to_string(&phys_path) {
-                                    if disk_content != yjs_content_before {
+                                if let Ok(disk_content) = fs::read_to_string(&phys_path)
+                                    && disk_content != yjs_content_before {
                                         info!("Unsynced local changes in {}! Applying before remote update.", rp);
                                         let prev_sv = doc.transact().state_vector();
                                         apply_diff_to_yrs(&doc, &text_ref, &yjs_content_before, &disk_content);
@@ -264,7 +281,6 @@ pub async fn run_client(folder: PathBuf, url: String, name: Option<String>) -> a
                                             error!("Failed to send unsynced local update: {:?}", e);
                                         }
                                     }
-                                }
                             }
 
                             // 2. Apply the remote update
@@ -347,29 +363,89 @@ pub async fn run_client(folder: PathBuf, url: String, name: Option<String>) -> a
 
                             // 6. Write content to physical file
                             let phys_path = local_state.root_dir.join(&target_rel_path);
-                            if text_val.is_empty() {
-                                if phys_path.exists() {
-                                    if let Err(e) = fs::remove_file(&phys_path) {
-                                        error!("Failed to delete file {:?}: {:?}", phys_path, e);
-                                    } else {
-                                        info!("Deleted file {} (empty content)", phys_path.display());
+                            let meta_type = read_meta_type(&doc)
+                                .unwrap_or_else(|| "text".to_string());
+
+                            if meta_type == "binary" {
+                                // Binary file: check blob_hash
+                                let blob_hash = read_meta_blob_hash(&doc);
+                                match blob_hash.as_deref() {
+                                    Some("") | None => {
+                                        // Empty or missing hash → deletion
+                                        if phys_path.exists() {
+                                            if let Err(e) = fs::remove_file(&phys_path) {
+                                                error!("Failed to delete binary file {:?}: {:?}", phys_path, e);
+                                            } else {
+                                                info!("Deleted binary file {} (empty blob_hash)", phys_path.display());
+                                            }
+                                        }
+                                    }
+                                    Some(hash) => {
+                                        // Check if local file already matches
+                                        let local_hash = fs::read(&phys_path)
+                                            .ok()
+                                            .map(|d| sha256_hash(&d));
+                                        if local_hash.as_deref() != Some(hash) {
+                                            // Need to request blob from server
+                                            info!("Binary file {} needs blob {} from server", target_rel_path, hash);
+                                            let request_payload = hash.as_bytes().to_vec();
+                                            if let Err(e) = ws_tx
+                                                .send(Message::new(
+                                                    MsgType::BlobRequest,
+                                                    doc_id.clone(),
+                                                    request_payload,
+                                                ))
+                                                .await
+                                            {
+                                                error!("Failed to request blob: {:?}", e);
+                                            }
+                                        }
                                     }
                                 }
                             } else {
-                                if let Some(parent) = phys_path.parent() {
+                                // Text file: write content
+                                if text_val.is_empty() {
+                                    if phys_path.exists() {
+                                        if let Err(e) = fs::remove_file(&phys_path) {
+                                            error!("Failed to delete file {:?}: {:?}", phys_path, e);
+                                        } else {
+                                            info!("Deleted file {} (empty content)", phys_path.display());
+                                        }
+                                    }
+                                } else if let Some(parent) = phys_path.parent() {
                                     let _ = fs::create_dir_all(parent);
-                                }
-                                let current_disk = fs::read_to_string(&phys_path).unwrap_or_default();
-                                if current_disk != text_val {
-                                    if let Err(e) = fs::write(&phys_path, &text_val) {
-                                        error!("Failed to write file {:?}: {:?}", phys_path, e);
-                                    } else {
-                                        info!("Applied remote update to {}", phys_path.display());
+                                    let current_disk = fs::read_to_string(&phys_path).unwrap_or_default();
+                                    if current_disk != text_val {
+                                        if let Err(e) = fs::write(&phys_path, &text_val) {
+                                            error!("Failed to write file {:?}: {:?}", phys_path, e);
+                                        } else {
+                                            info!("Applied remote update to {}", phys_path.display());
+                                        }
                                     }
                                 }
                             }
                         }
-                        MsgType::SyncStep1 => {}
+                        MsgType::BlobUpdate => {
+                            // Received blob data from server (in response to BlobRequest)
+                            let doc_id = msg.doc_id;
+                            let blob_data = msg.payload;
+
+                            // Find the physical path for this UUID
+                            if let Some(rel_path) = local_state.path_map.get_path_for_uuid(&doc_id).map(|s| s.to_string()) {
+                                let phys_path = local_state.root_dir.join(&rel_path);
+                                if let Some(parent) = phys_path.parent() {
+                                    let _ = fs::create_dir_all(parent);
+                                }
+                                if let Err(e) = fs::write(&phys_path, &blob_data) {
+                                    error!("Failed to write binary file {:?}: {:?}", phys_path, e);
+                                } else {
+                                    info!("Downloaded binary file {} ({} bytes)", phys_path.display(), blob_data.len());
+                                }
+                            } else {
+                                warn!("Received blob for unknown UUID {}", doc_id);
+                            }
+                        }
+                        MsgType::SyncStep1 | MsgType::BlobRequest => {}
                     }
                 }
 
@@ -387,14 +463,19 @@ pub async fn run_client(folder: PathBuf, url: String, name: Option<String>) -> a
                                 rel_path: String,
                                 disk_content: String,
                             }
+                            struct WatchBinaryCreate {
+                                path: std::path::PathBuf,
+                                rel_path: String,
+                                data: Vec<u8>,
+                                hash: String,
+                            }
 
                             let mut batch_deletes: Vec<WatchDelete> = Vec::new();
                             let mut batch_creates: Vec<WatchCreate> = Vec::new();
+                            let mut batch_binary_creates: Vec<WatchBinaryCreate> = Vec::new();
 
                             for ev in &events {
                                 let path = &ev.path;
-                                let ext = path.extension().and_then(|s| s.to_str()).unwrap_or("");
-                                if ext != "md" && ext != "txt" { continue; }
 
                                 let rel_path = match local_state.get_doc_id(path) {
                                     Ok(r) => r,
@@ -414,13 +495,23 @@ pub async fn run_client(folder: PathBuf, url: String, name: Option<String>) -> a
                                         }
                                     }
                                 } else if path.is_file() {
-                                    match fs::read_to_string(path) {
-                                        Ok(content) => batch_creates.push(WatchCreate {
+                                    if is_binary_file(std::path::Path::new(&rel_path)) {
+                                        // Binary file
+                                        if let Ok(data) = fs::read(path) {
+                                            let hash = sha256_hash(&data);
+                                            batch_binary_creates.push(WatchBinaryCreate {
+                                                path: path.clone(),
+                                                rel_path,
+                                                data,
+                                                hash,
+                                            });
+                                        }
+                                    } else if let Ok(content) = fs::read_to_string(path) {
+                                        batch_creates.push(WatchCreate {
                                             path: path.clone(),
                                             rel_path,
                                             disk_content: content,
-                                        }),
-                                        Err(_) => {}
+                                        });
                                     }
                                 }
                             }
@@ -571,6 +662,69 @@ pub async fn run_client(folder: PathBuf, url: String, name: Option<String>) -> a
                                     let update = doc.transact().encode_state_as_update_v1(&previous_sv);
                                     if let Err(e) = ws_tx.send(Message::new(MsgType::Update, uuid, update)).await {
                                         error!("Failed to send update: {:?}", e);
+                                    }
+                                }
+                            }
+
+                            // Process binary file creates/modifies
+                            for bwc in &batch_binary_creates {
+                                let is_newly_discovered = local_state.path_map.get_uuid(&bwc.rel_path).is_none();
+                                let uuid = local_state.get_or_create_uuid(&bwc.rel_path);
+                                let state_path = local_state.get_state_path_for_uuid(&uuid);
+
+                                if let Some(parent) = state_path.parent() {
+                                    let _ = fs::create_dir_all(parent);
+                                }
+
+                                let doc = load_doc(&state_path).unwrap_or_else(|_| Doc::new());
+                                let current_meta = read_meta_path(&doc);
+                                let current_hash = read_meta_blob_hash(&doc);
+                                let previous_sv = doc.transact().state_vector();
+
+                                // Update metadata
+                                let meta_changed = current_meta.as_deref() != Some(bwc.rel_path.as_str());
+                                let hash_changed = current_hash.as_deref() != Some(bwc.hash.as_str());
+
+                                if meta_changed {
+                                    write_meta_path(&doc, &bwc.rel_path);
+                                }
+                                write_meta_type(&doc, "binary");
+                                if hash_changed {
+                                    write_meta_blob_hash(&doc, &bwc.hash);
+                                }
+
+                                let newly_subscribed = !subscribed_docs.contains(&uuid);
+                                if newly_subscribed {
+                                    let sv = doc.transact().state_vector().encode_v1();
+                                    if let Err(e) = ws_tx.send(Message::new(MsgType::SyncStep1, uuid.clone(), sv)).await {
+                                        error!("Failed to subscribe to new binary doc {}: {:?}", uuid, e);
+                                    } else {
+                                        subscribed_docs.insert(uuid.clone());
+                                        if is_newly_discovered {
+                                            freshly_created.insert(uuid.clone());
+                                        }
+                                    }
+                                }
+
+                                let needs_update = newly_subscribed || meta_changed || hash_changed;
+                                if needs_update {
+                                    info!("Binary file {} changed, broadcasting...", bwc.path.display());
+                                    if let Err(e) = save_doc(&doc, &state_path) {
+                                        error!("Failed to save binary doc locally: {:?}", e);
+                                        continue;
+                                    }
+                                    if let Err(e) = local_state.path_map.save() {
+                                        error!("Failed to save path_map: {:?}", e);
+                                    }
+                                    // Send CRDT update (meta changes)
+                                    let update = doc.transact().encode_state_as_update_v1(&previous_sv);
+                                    if let Err(e) = ws_tx.send(Message::new(MsgType::Update, uuid.clone(), update)).await {
+                                        error!("Failed to send binary meta update: {:?}", e);
+                                    }
+                                    // Send blob data
+                                    if hash_changed
+                                        && let Err(e) = ws_tx.send(Message::new(MsgType::BlobUpdate, uuid, bwc.data.clone())).await {
+                                            error!("Failed to upload blob: {:?}", e);
                                     }
                                 }
                             }

--- a/syncline/src/client/protocol.rs
+++ b/syncline/src/client/protocol.rs
@@ -6,6 +6,8 @@ pub enum MsgType {
     SyncStep1 = 0x00,
     SyncStep2 = 0x01,
     Update = 0x02,
+    BlobUpdate = 0x04,
+    BlobRequest = 0x05,
 }
 
 impl TryFrom<u8> for MsgType {
@@ -16,6 +18,8 @@ impl TryFrom<u8> for MsgType {
             0x00 => Ok(MsgType::SyncStep1),
             0x01 => Ok(MsgType::SyncStep2),
             0x02 => Ok(MsgType::Update),
+            0x04 => Ok(MsgType::BlobUpdate),
+            0x05 => Ok(MsgType::BlobRequest),
             _ => Err(anyhow!("Invalid message type: {}", value)),
         }
     }
@@ -85,6 +89,8 @@ mod tests {
         assert_eq!(MsgType::try_from(0x00).unwrap(), MsgType::SyncStep1);
         assert_eq!(MsgType::try_from(0x01).unwrap(), MsgType::SyncStep2);
         assert_eq!(MsgType::try_from(0x02).unwrap(), MsgType::Update);
+        assert_eq!(MsgType::try_from(0x04).unwrap(), MsgType::BlobUpdate);
+        assert_eq!(MsgType::try_from(0x05).unwrap(), MsgType::BlobRequest);
         assert!(MsgType::try_from(0x03).is_err());
         assert!(MsgType::try_from(0xFF).is_err());
     }

--- a/syncline/src/client/state.rs
+++ b/syncline/src/client/state.rs
@@ -2,6 +2,7 @@ use crate::client::diff::apply_diff_to_yrs;
 use crate::client::storage::{load_doc, save_doc};
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -81,7 +82,7 @@ impl PathMap {
 }
 
 // ---------------------------------------------------------------------------
-// Helpers for reading/writing meta.path from a Yrs Y.Map
+// Helpers for reading/writing meta fields from a Yrs Y.Map
 // ---------------------------------------------------------------------------
 
 /// Read the "path" field from the "meta" Y.Map in a doc.
@@ -94,12 +95,80 @@ pub fn read_meta_path(doc: &Doc) -> Option<String> {
     }
 }
 
-/// Write the "path" field to the "meta" Y.Map in a doc, returning the
-/// encoded CRDT update (starting from the given state vector).
+/// Write the "path" field to the "meta" Y.Map in a doc.
 pub fn write_meta_path(doc: &Doc, rel_path: &str) {
     let meta: MapRef = doc.get_or_insert_map("meta");
     let mut txn = doc.transact_mut();
     meta.insert(&mut txn, "path", rel_path);
+}
+
+/// Read `meta.type` — returns "text" or "binary".
+pub fn read_meta_type(doc: &Doc) -> Option<String> {
+    let meta: MapRef = doc.get_or_insert_map("meta");
+    let txn = doc.transact();
+    match meta.get(&txn, "type") {
+        Some(Out::Any(Any::String(arc))) => Some(arc.to_string()),
+        _ => None,
+    }
+}
+
+/// Write `meta.type` — "text" or "binary".
+pub fn write_meta_type(doc: &Doc, file_type: &str) {
+    let meta: MapRef = doc.get_or_insert_map("meta");
+    let mut txn = doc.transact_mut();
+    meta.insert(&mut txn, "type", file_type);
+}
+
+/// Read `meta.blob_hash` — the SHA256 hex hash of the binary content.
+pub fn read_meta_blob_hash(doc: &Doc) -> Option<String> {
+    let meta: MapRef = doc.get_or_insert_map("meta");
+    let txn = doc.transact();
+    match meta.get(&txn, "blob_hash") {
+        Some(Out::Any(Any::String(arc))) => Some(arc.to_string()),
+        _ => None,
+    }
+}
+
+/// Write `meta.blob_hash` — the SHA256 hex hash of the binary content.
+pub fn write_meta_blob_hash(doc: &Doc, hash: &str) {
+    let meta: MapRef = doc.get_or_insert_map("meta");
+    let mut txn = doc.transact_mut();
+    meta.insert(&mut txn, "blob_hash", hash);
+}
+
+// ---------------------------------------------------------------------------
+// File classification
+// ---------------------------------------------------------------------------
+
+/// Text extensions that use CRDT text synchronization.
+const TEXT_EXTENSIONS: &[&str] = &["md", "txt"];
+
+/// Returns true if the file should be treated as binary (blob-based sync).
+pub fn is_binary_file(path: &Path) -> bool {
+    let ext = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("");
+    !TEXT_EXTENSIONS.contains(&ext)
+}
+
+/// Compute SHA256 hex digest of a byte slice.
+pub fn sha256_hash(data: &[u8]) -> String {
+    format!("{:x}", Sha256::digest(data))
+}
+
+// ---------------------------------------------------------------------------
+// BlobChange — returned by bootstrap for binary files that need uploading
+// ---------------------------------------------------------------------------
+
+/// Represents a binary file whose blob content needs to be uploaded to the server.
+pub struct BlobChange {
+    /// The UUID of the document.
+    pub uuid: String,
+    /// The raw binary content.
+    pub data: Vec<u8>,
+    /// The SHA256 hex hash of the data.
+    pub hash: String,
 }
 
 // ---------------------------------------------------------------------------
@@ -214,15 +283,22 @@ impl LocalState {
     /// Returns:
     /// - A list of `(uuid, update)` tuples that were modified offline and need to be synced.
     /// - A set of UUIDs that were **freshly created** (had no `.bin` state before this call).
-    ///   This set is used by the sync client to detect same-path file conflicts.
-    pub fn bootstrap_offline_changes(&mut self) -> Result<(Vec<(String, Vec<u8>)>, HashSet<String>)> {
+    /// - A list of `BlobChange` entries for binary files whose blobs need uploading.
+    pub fn bootstrap_offline_changes(
+        &mut self,
+    ) -> Result<(Vec<(String, Vec<u8>)>, HashSet<String>, Vec<BlobChange>)> {
         let mut offline_changes = Vec::new();
         let mut freshly_created: HashSet<String> = HashSet::new();
+        let mut blob_changes: Vec<BlobChange> = Vec::new();
 
         // ---- Phase 1: Collect all disk files --------------------------------
+        enum Content {
+            Text(String),
+            Binary { data: Vec<u8>, hash: String },
+        }
         struct DiskFile {
             rel_path: String,
-            disk_content: String,
+            content: Content,
         }
         let mut disk_files: Vec<DiskFile> = Vec::new();
 
@@ -233,16 +309,13 @@ impl LocalState {
                     return true;
                 }
                 let name = e.file_name().to_string_lossy();
-                name != ".git" && name != ".syncline"
+                // Skip hidden dirs/files and .syncline metadata
+                !name.starts_with('.') && name != ".syncline"
             })
             .filter_map(|e| e.ok())
         {
             let path = entry.path();
             if !path.is_file() {
-                continue;
-            }
-            let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
-            if ext != "md" && ext != "txt" {
                 continue;
             }
 
@@ -259,41 +332,61 @@ impl LocalState {
                 continue;
             }
 
-            let disk_content = match fs::read_to_string(path) {
-                Ok(c) => c,
-                Err(_) => continue,
+            let content = if is_binary_file(path) {
+                match fs::read(path) {
+                    Ok(data) => {
+                        let hash = sha256_hash(&data);
+                        Content::Binary { data, hash }
+                    }
+                    Err(_) => continue,
+                }
+            } else {
+                match fs::read_to_string(path) {
+                    Ok(c) => Content::Text(c),
+                    Err(_) => continue,
+                }
             };
 
-            disk_files.push(DiskFile {
-                rel_path,
-                disk_content,
-            });
+            disk_files.push(DiskFile { rel_path, content });
         }
 
         // ---- Phase 2: Separate known vs new files ---------------------------
         // known: rel_path already in path_map
         // new: not in path_map → potential new file or rename target
 
-        let mut known_files: Vec<(String, String, String)> = Vec::new(); // (rel_path, disk_content, uuid)
-        let mut new_files: Vec<(String, String)> = Vec::new(); // (rel_path, disk_content)
+        struct KnownFile {
+            rel_path: String,
+            content: Content,
+            uuid: String,
+        }
+        let mut known_files: Vec<KnownFile> = Vec::new();
+        let mut new_files: Vec<DiskFile> = Vec::new();
 
         for df in disk_files {
             if let Some(uuid) = self.path_map.get_uuid(&df.rel_path) {
-                known_files.push((df.rel_path, df.disk_content, uuid.to_string()));
+                known_files.push(KnownFile {
+                    rel_path: df.rel_path,
+                    content: df.content,
+                    uuid: uuid.to_string(),
+                });
             } else {
-                new_files.push((df.rel_path, df.disk_content));
+                new_files.push(df);
             }
         }
 
         // ---- Phase 3: Find orphaned UUIDs -----------------------------------
         // An orphaned UUID is one whose mapped path is not on disk (possibly renamed/deleted).
 
-        let known_paths: HashSet<&str> = known_files.iter().map(|(rp, _, _)| rp.as_str()).collect();
+        let known_paths: HashSet<&str> =
+            known_files.iter().map(|kf| kf.rel_path.as_str()).collect();
 
         struct Orphaned {
             uuid: String,
             old_rel_path: String,
+            /// For text files: CRDT text content. For binary: empty.
             crdt_content: String,
+            /// For binary files: the stored blob hash. For text: None.
+            blob_hash: Option<String>,
         }
         let mut orphaned: Vec<Orphaned> = Vec::new();
 
@@ -307,110 +400,196 @@ impl LocalState {
         for (rel_path, uuid) in &all_path_map_entries {
             if !known_paths.contains(rel_path.as_str()) {
                 let state_path = self.get_state_path_for_uuid(uuid);
-                if state_path.exists() {
-                    let crdt_content = load_doc(&state_path)
-                        .map(|doc| {
+                if state_path.exists()
+                    && let Ok(doc) = load_doc(&state_path) {
+                        let meta_type =
+                            read_meta_type(&doc).unwrap_or_else(|| "text".to_string());
+                        if meta_type == "binary" {
+                            let blob_hash = read_meta_blob_hash(&doc);
+                            orphaned.push(Orphaned {
+                                uuid: uuid.clone(),
+                                old_rel_path: rel_path.clone(),
+                                crdt_content: String::new(),
+                                blob_hash,
+                            });
+                        } else {
                             let text = doc.get_or_insert_text("content");
-                            text.get_string(&doc.transact())
-                        })
-                        .unwrap_or_default();
-                    orphaned.push(Orphaned {
-                        uuid: uuid.clone(),
-                        old_rel_path: rel_path.clone(),
-                        crdt_content,
-                    });
-                }
+                            let crdt_content = text.get_string(&doc.transact());
+                            orphaned.push(Orphaned {
+                                uuid: uuid.clone(),
+                                old_rel_path: rel_path.clone(),
+                                crdt_content,
+                                blob_hash: None,
+                            });
+                        }
+                    }
             }
         }
 
         // ---- Phase 4: Content-based rename detection ------------------------
-        // If a new file's disk content exactly matches an orphaned UUID's CRDT content,
-        // treat it as a rename (preserve UUID and CRDT history).
+        // If a new file's disk content exactly matches an orphaned UUID's CRDT content
+        // (text) or blob hash (binary), treat it as a rename.
 
         let mut renamed_map: HashMap<String, String> = HashMap::new(); // uuid → new_rel_path
-        let mut unmatched_new: Vec<(String, String)> = Vec::new();
+        let mut unmatched_new: Vec<DiskFile> = Vec::new();
 
-        for (new_rel_path, disk_content) in new_files {
-            let matched = orphaned
-                .iter()
-                .position(|o| o.crdt_content == disk_content);
+        for df in new_files {
+            let matched = match &df.content {
+                Content::Text(text) => orphaned
+                    .iter()
+                    .position(|o| o.blob_hash.is_none() && o.crdt_content == *text),
+                Content::Binary { hash, .. } => orphaned
+                    .iter()
+                    .position(|o| o.blob_hash.as_deref() == Some(hash.as_str())),
+            };
 
             if let Some(idx) = matched {
                 let o = orphaned.remove(idx);
-                renamed_map.insert(o.uuid.clone(), new_rel_path.clone());
+                renamed_map.insert(o.uuid.clone(), df.rel_path.clone());
                 // Update path_map: remove old entry, add new one
                 self.path_map.remove_by_path(&o.old_rel_path);
-                self.path_map.insert(new_rel_path.clone(), o.uuid.clone());
-                known_files.push((new_rel_path, disk_content, o.uuid));
+                self.path_map.insert(df.rel_path.clone(), o.uuid.clone());
+                known_files.push(KnownFile {
+                    rel_path: df.rel_path,
+                    content: df.content,
+                    uuid: o.uuid,
+                });
             } else {
-                unmatched_new.push((new_rel_path, disk_content));
+                unmatched_new.push(df);
             }
         }
 
         // ---- Phase 5: Process known files (including renamed ones) ----------
 
-        for (rel_path, disk_content, uuid) in &known_files {
-            let state_path = self.get_state_path_for_uuid(uuid);
-            let was_renamed = renamed_map.contains_key(uuid.as_str());
+        for kf in &known_files {
+            let state_path = self.get_state_path_for_uuid(&kf.uuid);
+            let was_renamed = renamed_map.contains_key(kf.uuid.as_str());
 
             if state_path.exists() {
-                // File existed before. Check for offline modification OR rename.
                 let doc = match load_doc(&state_path) {
                     Ok(doc) => doc,
                     Err(_) => continue,
                 };
 
-                // Take previous_sv BEFORE any writes so the broadcast delta includes
-                // meta.path changes (needed by other clients to locate the file on disk).
                 let previous_sv = doc.transact().state_vector();
 
                 // Ensure meta.path is up to date (important for renamed files).
                 let current_meta = read_meta_path(&doc);
-                let meta_path_changed = current_meta.as_deref() != Some(rel_path.as_str());
+                let meta_path_changed =
+                    current_meta.as_deref() != Some(kf.rel_path.as_str());
                 if meta_path_changed {
-                    write_meta_path(&doc, rel_path);
+                    write_meta_path(&doc, &kf.rel_path);
                 }
 
-                let text_ref = doc.get_or_insert_text("content");
-                let yrs_content = text_ref.get_string(&doc.transact());
+                match &kf.content {
+                    Content::Text(disk_content) => {
+                        // Ensure meta.type is set
+                        if read_meta_type(&doc).is_none() {
+                            write_meta_type(&doc, "text");
+                        }
 
-                if *disk_content != yrs_content || was_renamed || meta_path_changed {
-                    if *disk_content != yrs_content {
-                        apply_diff_to_yrs(&doc, &text_ref, &yrs_content, disk_content);
+                        let text_ref = doc.get_or_insert_text("content");
+                        let yrs_content = text_ref.get_string(&doc.transact());
+
+                        if *disk_content != yrs_content
+                            || was_renamed
+                            || meta_path_changed
+                        {
+                            if *disk_content != yrs_content {
+                                apply_diff_to_yrs(
+                                    &doc,
+                                    &text_ref,
+                                    &yrs_content,
+                                    disk_content,
+                                );
+                            }
+                            if let Err(e) = save_doc(&doc, &state_path) {
+                                tracing::error!(
+                                    "Failed to save offline edits for {}: {}",
+                                    kf.uuid,
+                                    e
+                                );
+                                continue;
+                            }
+                            let update = doc
+                                .transact()
+                                .encode_state_as_update_v1(&previous_sv);
+                            offline_changes.push((kf.uuid.clone(), update));
+                        }
                     }
-                    if let Err(e) = save_doc(&doc, &state_path) {
-                        tracing::error!("Failed to save offline edits for {}: {}", uuid, e);
-                        continue;
+                    Content::Binary { data, hash } => {
+                        write_meta_type(&doc, "binary");
+                        let prev_hash = read_meta_blob_hash(&doc);
+                        let hash_changed =
+                            prev_hash.as_deref() != Some(hash.as_str());
+
+                        if hash_changed || was_renamed || meta_path_changed {
+                            if hash_changed {
+                                write_meta_blob_hash(&doc, hash);
+                            }
+                            if let Err(e) = save_doc(&doc, &state_path) {
+                                tracing::error!(
+                                    "Failed to save binary meta for {}: {}",
+                                    kf.uuid,
+                                    e
+                                );
+                                continue;
+                            }
+                            let update = doc
+                                .transact()
+                                .encode_state_as_update_v1(&previous_sv);
+                            offline_changes.push((kf.uuid.clone(), update));
+                            if hash_changed {
+                                blob_changes.push(BlobChange {
+                                    uuid: kf.uuid.clone(),
+                                    data: data.clone(),
+                                    hash: hash.clone(),
+                                });
+                            }
+                        }
                     }
-                    let update = doc.transact().encode_state_as_update_v1(&previous_sv);
-                    offline_changes.push((uuid.clone(), update));
                 }
             } else {
-                // First time this file is seen with its current UUID (shouldn't normally
-                // happen since get_or_create_uuid also creates the .bin, but handle it).
+                // First time this file is seen with its current UUID.
                 let doc = Doc::new();
-                // Take previous_sv from empty doc so the delta includes meta.path + content.
                 let previous_sv = doc.transact().state_vector();
-                write_meta_path(&doc, rel_path);
-                let text_ref = doc.get_or_insert_text("content");
-                {
-                    let mut txn = doc.transact_mut();
-                    text_ref.insert(&mut txn, 0, disk_content);
+                write_meta_path(&doc, &kf.rel_path);
+
+                match &kf.content {
+                    Content::Text(disk_content) => {
+                        write_meta_type(&doc, "text");
+                        let text_ref = doc.get_or_insert_text("content");
+                        {
+                            let mut txn = doc.transact_mut();
+                            text_ref.insert(&mut txn, 0, disk_content);
+                        }
+                    }
+                    Content::Binary { data, hash } => {
+                        write_meta_type(&doc, "binary");
+                        write_meta_blob_hash(&doc, hash);
+                        blob_changes.push(BlobChange {
+                            uuid: kf.uuid.clone(),
+                            data: data.clone(),
+                            hash: hash.clone(),
+                        });
+                    }
                 }
+
                 if let Err(e) = save_doc(&doc, &state_path) {
-                    tracing::error!("Failed to save new doc {}: {}", uuid, e);
+                    tracing::error!("Failed to save new doc {}: {}", kf.uuid, e);
                     continue;
                 }
-                let update = doc.transact().encode_state_as_update_v1(&previous_sv);
-                offline_changes.push((uuid.clone(), update));
-                freshly_created.insert(uuid.clone());
+                let update =
+                    doc.transact().encode_state_as_update_v1(&previous_sv);
+                offline_changes.push((kf.uuid.clone(), update));
+                freshly_created.insert(kf.uuid.clone());
             }
         }
 
         // ---- Phase 6: Truly new files (no matching orphan) ------------------
 
-        for (rel_path, disk_content) in unmatched_new {
-            let uuid = self.get_or_create_uuid(&rel_path);
+        for df in unmatched_new {
+            let uuid = self.get_or_create_uuid(&df.rel_path);
             let state_path = self.get_state_path_for_uuid(&uuid);
 
             if let Some(parent) = state_path.parent() {
@@ -418,19 +597,35 @@ impl LocalState {
             }
 
             let doc = Doc::new();
-            // Take previous_sv from empty doc so the delta includes meta.path + content.
             let previous_sv = doc.transact().state_vector();
-            write_meta_path(&doc, &rel_path);
-            let text_ref = doc.get_or_insert_text("content");
-            {
-                let mut txn = doc.transact_mut();
-                text_ref.insert(&mut txn, 0, &disk_content);
+            write_meta_path(&doc, &df.rel_path);
+
+            match &df.content {
+                Content::Text(disk_content) => {
+                    write_meta_type(&doc, "text");
+                    let text_ref = doc.get_or_insert_text("content");
+                    {
+                        let mut txn = doc.transact_mut();
+                        text_ref.insert(&mut txn, 0, disk_content);
+                    }
+                }
+                Content::Binary { data, hash } => {
+                    write_meta_type(&doc, "binary");
+                    write_meta_blob_hash(&doc, hash);
+                    blob_changes.push(BlobChange {
+                        uuid: uuid.clone(),
+                        data: data.clone(),
+                        hash: hash.clone(),
+                    });
+                }
             }
+
             if let Err(e) = save_doc(&doc, &state_path) {
                 tracing::error!("Failed to save new doc {}: {}", uuid, e);
                 continue;
             }
-            let update = doc.transact().encode_state_as_update_v1(&previous_sv);
+            let update =
+                doc.transact().encode_state_as_update_v1(&previous_sv);
             offline_changes.push((uuid.clone(), update));
             freshly_created.insert(uuid.clone());
         }
@@ -438,12 +633,33 @@ impl LocalState {
         // ---- Phase 7: Offline deletions (remaining orphaned UUIDs) ----------
 
         for orphan in orphaned {
-            if !orphan.crdt_content.is_empty() {
-                let state_path = self.get_state_path_for_uuid(&orphan.uuid);
-                if let Ok(doc) = load_doc(&state_path) {
+            let state_path = self.get_state_path_for_uuid(&orphan.uuid);
+            if let Ok(doc) = load_doc(&state_path) {
+                let previous_sv = doc.transact().state_vector();
+                let needs_update = if orphan.blob_hash.is_some() {
+                    // Binary file: clear blob_hash to signal deletion
+                    let current_hash = read_meta_blob_hash(&doc);
+                    if current_hash.is_some() {
+                        write_meta_blob_hash(&doc, "");
+                        true
+                    } else {
+                        false
+                    }
+                } else if !orphan.crdt_content.is_empty() {
+                    // Text file: clear content
                     let text_ref = doc.get_or_insert_text("content");
-                    let previous_sv = doc.transact().state_vector();
-                    apply_diff_to_yrs(&doc, &text_ref, &orphan.crdt_content, "");
+                    apply_diff_to_yrs(
+                        &doc,
+                        &text_ref,
+                        &orphan.crdt_content,
+                        "",
+                    );
+                    true
+                } else {
+                    false
+                };
+
+                if needs_update {
                     if let Err(e) = save_doc(&doc, &state_path) {
                         tracing::error!(
                             "Failed to save offline deletion for {}: {}",
@@ -452,7 +668,9 @@ impl LocalState {
                         );
                         continue;
                     }
-                    let update = doc.transact().encode_state_as_update_v1(&previous_sv);
+                    let update = doc
+                        .transact()
+                        .encode_state_as_update_v1(&previous_sv);
                     offline_changes.push((orphan.uuid.clone(), update));
                 }
             }
@@ -465,7 +683,7 @@ impl LocalState {
             tracing::error!("Failed to save path_map: {}", e);
         }
 
-        Ok((offline_changes, freshly_created))
+        Ok((offline_changes, freshly_created, blob_changes))
     }
 
     /// List all known UUIDs from the local .syncline storage (by reading .bin filenames).
@@ -538,7 +756,7 @@ mod tests {
         fs::write(&file1, "Hello World").unwrap();
 
         // 1. First run, file is new
-        let (changed, freshly) = state.bootstrap_offline_changes().unwrap();
+        let (changed, freshly, _blobs) = state.bootstrap_offline_changes().unwrap();
         assert_eq!(changed.len(), 1);
         // doc_id is now a UUID string
         assert!(
@@ -553,13 +771,13 @@ mod tests {
         );
 
         // 2. Second run, no changes
-        let (changed_none, freshly_none) = state.bootstrap_offline_changes().unwrap();
+        let (changed_none, freshly_none, _) = state.bootstrap_offline_changes().unwrap();
         assert_eq!(changed_none.len(), 0);
         assert!(freshly_none.is_empty(), "No new files, freshly_created should be empty");
 
         // 3. Third run, offline modification
         fs::write(&file1, "Hello CRDT World!").unwrap();
-        let (changed_mod, freshly_mod) = state.bootstrap_offline_changes().unwrap();
+        let (changed_mod, freshly_mod, _) = state.bootstrap_offline_changes().unwrap();
         assert_eq!(changed_mod.len(), 1);
         assert!(
             uuid::Uuid::parse_str(&changed_mod[0].0).is_ok(),
@@ -603,7 +821,7 @@ mod tests {
         fs::rename(&file1, &file2).unwrap();
 
         // Bootstrap again — should detect rename via content matching
-        let (changed, freshly) = state.bootstrap_offline_changes().unwrap();
+        let (changed, freshly, _) = state.bootstrap_offline_changes().unwrap();
 
         // UUID should be preserved (rename, not new file)
         assert!(
@@ -676,7 +894,7 @@ mod tests {
             changed.is_ok(),
             "Issue 5: Loop aborted early and returned Err!"
         );
-        let (docs, _) = changed.unwrap();
+        let (docs, _, _) = changed.unwrap();
         // b/file2.md should still have been processed despite file1 failing
         let rel2 = "b/file2.md";
         let uuid2 = state.path_map.get_uuid(rel2).unwrap().to_string();
@@ -733,7 +951,7 @@ mod tests {
         fs::remove_file(&file1).unwrap();
 
         // 3. Run bootstrap again, it should detect the offline deletion
-        let (changed, freshly) = state.bootstrap_offline_changes().unwrap();
+        let (changed, freshly, _) = state.bootstrap_offline_changes().unwrap();
 
         // Should have one change corresponding to the empty string
         assert_eq!(changed.len(), 1);

--- a/syncline/src/protocol.rs
+++ b/syncline/src/protocol.rs
@@ -1,6 +1,11 @@
 pub const MSG_SYNC_STEP_1: u8 = 0;
 pub const MSG_SYNC_STEP_2: u8 = 1;
 pub const MSG_UPDATE: u8 = 2;
+pub const MSG_BLOB_UPDATE: u8 = 4;
+pub const MSG_BLOB_REQUEST: u8 = 5;
+
+/// Maximum blob size in bytes (50 MB).
+pub const MAX_BLOB_SIZE: usize = 50 * 1024 * 1024;
 
 pub fn encode_message(msg_type: u8, doc_id: &str, payload: &[u8]) -> Vec<u8> {
     let doc_id_bytes = doc_id.as_bytes();
@@ -65,5 +70,28 @@ mod tests {
         let mut encoded = vec![MSG_UPDATE, 0, 1];
         encoded.push(0xff); // invalid UTF-8 byte
         assert!(decode_message(&encoded).is_none());
+    }
+
+    #[test]
+    fn test_encode_decode_blob_update() {
+        let blob_data = vec![0x89, 0x50, 0x4e, 0x47]; // PNG header bytes
+        let encoded = encode_message(MSG_BLOB_UPDATE, "image.png", &blob_data);
+
+        let (msg_type, doc_id, payload) = decode_message(&encoded).unwrap();
+        assert_eq!(msg_type, MSG_BLOB_UPDATE);
+        assert_eq!(doc_id, "image.png");
+        assert_eq!(payload, blob_data.as_slice());
+    }
+
+    #[test]
+    fn test_encode_decode_blob_request() {
+        // 32-byte SHA256 hash as payload
+        let hash_bytes = [0xABu8; 32];
+        let encoded = encode_message(MSG_BLOB_REQUEST, "image.png", &hash_bytes);
+
+        let (msg_type, doc_id, payload) = decode_message(&encoded).unwrap();
+        assert_eq!(msg_type, MSG_BLOB_REQUEST);
+        assert_eq!(doc_id, "image.png");
+        assert_eq!(payload, &hash_bytes);
     }
 }

--- a/syncline/src/server/db.rs
+++ b/syncline/src/server/db.rs
@@ -14,13 +14,25 @@ impl Db {
 
         let mut conn = pool.acquire().await?;
 
-        // Ensure table exists
+        // Ensure tables exist
         conn.execute(
             r#"
             CREATE TABLE IF NOT EXISTS updates (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 doc_id TEXT NOT NULL,
                 update_data BLOB NOT NULL
+            );
+            "#,
+        )
+        .await?;
+
+        conn.execute(
+            r#"
+            CREATE TABLE IF NOT EXISTS blobs (
+                hash TEXT PRIMARY KEY,
+                data BLOB NOT NULL,
+                size INTEGER NOT NULL,
+                created_at TEXT NOT NULL DEFAULT (datetime('now'))
             );
             "#,
         )
@@ -98,6 +110,38 @@ impl Db {
         })
         .await
         .unwrap()
+    }
+
+    /// Store a binary blob by its SHA256 hash. Content-addressable: if the hash
+    /// already exists the insert is silently ignored (deduplication).
+    pub async fn save_blob(&self, hash: &str, data: &[u8]) -> Result<()> {
+        let size = data.len() as i64;
+        sqlx::query("INSERT OR IGNORE INTO blobs (hash, data, size) VALUES (?, ?, ?)")
+            .bind(hash)
+            .bind(data)
+            .bind(size)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    /// Load a binary blob by its SHA256 hash. Returns None if not found.
+    pub async fn load_blob(&self, hash: &str) -> Result<Option<Vec<u8>>> {
+        let row = sqlx::query("SELECT data FROM blobs WHERE hash = ?")
+            .bind(hash)
+            .fetch_optional(&self.pool)
+            .await?;
+        Ok(row.map(|r| r.get(0)))
+    }
+
+    /// Check whether a blob with the given hash exists.
+    pub async fn has_blob(&self, hash: &str) -> Result<bool> {
+        let row: (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM blobs WHERE hash = ?")
+                .bind(hash)
+                .fetch_one(&self.pool)
+                .await?;
+        Ok(row.0 > 0)
     }
 }
 
@@ -177,5 +221,48 @@ mod tests {
         txn2.apply_update(Update::decode_v1(&sync_update).unwrap());
 
         assert_eq!(txt2.get_string(&txn2), "Hello! World.");
+    }
+
+    #[tokio::test]
+    async fn test_save_and_load_blob() {
+        let db = Db::new("sqlite::memory:").await.unwrap();
+
+        let hash = "abc123def456";
+        let data = vec![0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]; // PNG header
+
+        // Initially not present
+        assert!(!db.has_blob(hash).await.unwrap());
+        assert!(db.load_blob(hash).await.unwrap().is_none());
+
+        // Save it
+        db.save_blob(hash, &data).await.unwrap();
+
+        // Now present
+        assert!(db.has_blob(hash).await.unwrap());
+        let loaded = db.load_blob(hash).await.unwrap().unwrap();
+        assert_eq!(loaded, data);
+    }
+
+    #[tokio::test]
+    async fn test_blob_deduplication() {
+        let db = Db::new("sqlite::memory:").await.unwrap();
+
+        let hash = "dedup_hash";
+        let data1 = vec![1, 2, 3];
+        let data2 = vec![4, 5, 6]; // different data, same hash (shouldn't overwrite)
+
+        db.save_blob(hash, &data1).await.unwrap();
+        db.save_blob(hash, &data2).await.unwrap(); // INSERT OR IGNORE
+
+        // Should still return the original data (first insert wins)
+        let loaded = db.load_blob(hash).await.unwrap().unwrap();
+        assert_eq!(loaded, data1);
+    }
+
+    #[tokio::test]
+    async fn test_blob_not_found() {
+        let db = Db::new("sqlite::memory:").await.unwrap();
+        assert!(db.load_blob("nonexistent").await.unwrap().is_none());
+        assert!(!db.has_blob("nonexistent").await.unwrap());
     }
 }

--- a/syncline/src/server/server.rs
+++ b/syncline/src/server/server.rs
@@ -18,7 +18,8 @@ use tokio::sync::{Mutex as AsyncMutex, RwLock, broadcast, mpsc};
 use yrs::{Doc, GetString, StateVector, Text, Transact, Update, updates::decoder::Decode};
 
 use crate::protocol::{
-    MSG_SYNC_STEP_1, MSG_SYNC_STEP_2, MSG_UPDATE, decode_message, encode_message,
+    MSG_BLOB_REQUEST, MSG_BLOB_UPDATE, MSG_SYNC_STEP_1, MSG_SYNC_STEP_2, MSG_UPDATE,
+    decode_message, encode_message,
 };
 
 type ChannelMap = Arc<RwLock<HashMap<String, broadcast::Sender<(Vec<u8>, uuid::Uuid)>>>>;
@@ -65,8 +66,10 @@ async fn update_index_for_new_doc(state: &AppState, doc_id: &str) {
     // Broadcast delta to currently-connected clients subscribed to __index__.
     let channels = state.channels.read().await;
     if let Some(tx) = channels.get("__index__") {
+        // Pre-frame the delta so the forwarding task can pass it through unchanged.
+        let msg = encode_message(MSG_UPDATE, "__index__", &delta);
         // uuid::Uuid::nil() means "no sender", so every subscriber receives this.
-        let _ = tx.send((delta, uuid::Uuid::nil()));
+        let _ = tx.send((msg, uuid::Uuid::nil()));
     }
 }
 
@@ -176,14 +179,14 @@ async fn handle_socket(socket: WebSocket, state: AppState) {
                                         _ = tx_fwd.closed() => break,
                                         res = rx.recv() => {
                                             match res {
-                                                Ok((payload, sender_id)) => {
+                                                Ok((framed_msg, sender_id)) => {
                                                     if sender_id == connection_id {
                                                         continue;
                                                     }
-                                                    tracing::debug!("Forwarding broadcast update for doc: {} with payload len: {}", doc_id_str, payload.len());
-                                                    let msg =
-                                                        encode_message(MSG_UPDATE, &doc_id_str, &payload);
-                                                    if tx_fwd.send(msg).is_err() {
+                                                    tracing::debug!("Forwarding broadcast for doc: {} with {} bytes", doc_id_str, framed_msg.len());
+                                                    // Messages are already framed (encode_message
+                                                    // was called before broadcasting).
+                                                    if tx_fwd.send(framed_msg).is_err() {
                                                         // Outgoing channel closed — connection gone.
                                                         break;
                                                     }
@@ -240,11 +243,77 @@ async fn handle_socket(socket: WebSocket, state: AppState) {
                             // Auto-create the channel if it doesn't exist yet. This handles
                             // the race where a client sends MSG_UPDATE before any SyncStep1
                             // has been received for this doc_id.
+                            let msg = encode_message(MSG_UPDATE, doc_id, payload);
                             let mut channels = state_clone.channels.write().await;
                             let tx = channels
                                 .entry(doc_id.to_string())
                                 .or_insert_with(|| broadcast::channel(65_536).0);
-                            let _ = tx.send((payload.to_vec(), connection_id));
+                            let _ = tx.send((msg, connection_id));
+                        }
+                        MSG_BLOB_UPDATE => {
+                            // Binary blob upload: compute SHA256 hash, store in blobs
+                            // table, and relay the raw blob to all other subscribers.
+                            use sha2::{Digest, Sha256};
+
+                            if payload.len() > crate::protocol::MAX_BLOB_SIZE {
+                                tracing::warn!(
+                                    "Rejected blob for doc {} — {} bytes exceeds {} byte limit",
+                                    doc_id,
+                                    payload.len(),
+                                    crate::protocol::MAX_BLOB_SIZE
+                                );
+                            } else {
+                                let hash = format!("{:x}", Sha256::digest(payload));
+                                tracing::info!(
+                                    "Received BLOB_UPDATE for doc {} — hash={} size={}",
+                                    doc_id,
+                                    hash,
+                                    payload.len()
+                                );
+
+                                // Content-addressable store: INSERT OR IGNORE
+                                if let Err(e) =
+                                    state_clone.db.save_blob(&hash, payload).await
+                                {
+                                    tracing::error!("DB blob save error: {}", e);
+                                }
+
+                                // Relay raw blob to all other subscribers of this doc.
+                                // The message is pre-framed with encode_message so the
+                                // forwarding task passes it through unchanged.
+                                let msg =
+                                    encode_message(MSG_BLOB_UPDATE, doc_id, payload);
+                                let channels = state_clone.channels.read().await;
+                                if let Some(tx) = channels.get(doc_id) {
+                                    let _ = tx.send((msg, connection_id));
+                                }
+                            }
+                        }
+                        MSG_BLOB_REQUEST => {
+                            // Client requests a blob by its hex-encoded SHA256 hash.
+                            let hash = std::str::from_utf8(payload).unwrap_or("");
+                            tracing::info!(
+                                "Received BLOB_REQUEST for doc {} — hash={}",
+                                doc_id,
+                                hash
+                            );
+                            match state_clone.db.load_blob(hash).await {
+                                Ok(Some(blob_data)) => {
+                                    let resp =
+                                        encode_message(MSG_BLOB_UPDATE, doc_id, &blob_data);
+                                    let _ = tx_socket_clone.send(resp);
+                                }
+                                Ok(None) => {
+                                    tracing::warn!(
+                                        "Blob not found: hash={} for doc {}",
+                                        hash,
+                                        doc_id
+                                    );
+                                }
+                                Err(e) => {
+                                    tracing::error!("DB blob load error: {}", e);
+                                }
+                            }
                         }
                         _ => {}
                     }

--- a/syncline/src/wasm_client.rs
+++ b/syncline/src/wasm_client.rs
@@ -10,12 +10,14 @@ use yrs::updates::encoder::Encode;
 use yrs::{Any, Doc, GetString, Map, Out, ReadTxn, StateVector, Subscription, Text, Transact, Update};
 
 use crate::protocol::{
-    decode_message, encode_message, MSG_SYNC_STEP_1, MSG_SYNC_STEP_2, MSG_UPDATE,
+    decode_message, encode_message, MSG_BLOB_REQUEST, MSG_BLOB_UPDATE, MSG_SYNC_STEP_1,
+    MSG_SYNC_STEP_2, MSG_UPDATE,
 };
 
 struct DocState {
     doc: Doc,
     callback: Function,
+    blob_callback: Option<Function>,
     _sub: Subscription,
     is_receiving: Rc<RefCell<bool>>,
     doc_type: DocType,
@@ -136,7 +138,15 @@ impl SynclineClient {
                                                 txn.apply_update(u);
                                             }
                                             *state.is_receiving.borrow_mut() = false;
-                                            Some(state.callback.clone())
+                                            Some((state.callback.clone(), None))
+                                        } else {
+                                            None
+                                        }
+                                    }
+                                    MSG_BLOB_UPDATE => {
+                                        // Binary blob received — invoke blob_callback with doc_id and data
+                                        if let Some(ref blob_cb) = state.blob_callback {
+                                            Some((blob_cb.clone(), Some((doc_id.to_string(), payload.to_vec()))))
                                         } else {
                                             None
                                         }
@@ -148,8 +158,15 @@ impl SynclineClient {
                             }
                         };
 
-                        if let Some(cb) = callback_opt {
-                            let _ = cb.call0(&JsValue::NULL);
+                        if let Some((cb, blob_info)) = callback_opt {
+                            if let Some((blob_doc_id, blob_data)) = blob_info {
+                                // Call blob callback with (doc_id, Uint8Array)
+                                let js_doc_id = JsValue::from_str(&blob_doc_id);
+                                let js_data = Uint8Array::from(&blob_data[..]);
+                                let _ = cb.call2(&JsValue::NULL, &js_doc_id, &js_data);
+                            } else {
+                                let _ = cb.call0(&JsValue::NULL);
+                            }
                         }
                     }
                 }
@@ -211,6 +228,7 @@ impl SynclineClient {
             DocState {
                 doc: doc.clone(),
                 callback,
+                blob_callback: None,
                 _sub: sub,
                 is_receiving,
                 doc_type: DocType::Text,
@@ -266,6 +284,7 @@ impl SynclineClient {
             DocState {
                 doc,
                 callback: dummy_callback,
+                blob_callback: None,
                 _sub: sub,
                 is_receiving,
                 doc_type: DocType::Text,
@@ -430,6 +449,135 @@ impl SynclineClient {
             let meta = state.doc.get_or_insert_map("meta");
             let mut txn = state.doc.transact_mut();
             meta.insert(&mut txn, "path", path.as_str());
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Binary file helpers
+    // -----------------------------------------------------------------------
+
+    /// Add a binary document (Y.Map("meta") only, no Y.Text("content")).
+    /// The `callback` fires on CRDT metadata updates; `blob_callback` fires
+    /// when a `MSG_BLOB_UPDATE` arrives with the raw binary data.
+    pub fn add_binary_doc(
+        &self,
+        doc_id: String,
+        callback: Function,
+        blob_callback: Function,
+    ) -> Result<(), JsValue> {
+        let doc = Doc::new();
+        let is_receiving = Rc::new(RefCell::new(false));
+
+        let ws_clone = self.ws.clone();
+        let doc_id_clone = doc_id.clone();
+        let is_receiving_clone = is_receiving.clone();
+        let is_connected_send = self.is_connected.clone();
+
+        let sub = doc
+            .observe_update_v1(move |_, event| {
+                if *is_receiving_clone.borrow() {
+                    return;
+                }
+                if !*is_connected_send.borrow() {
+                    return;
+                }
+                if let Some(ref ws) = ws_clone {
+                    let msg = encode_message(MSG_UPDATE, &doc_id_clone, &event.update);
+                    let array = Uint8Array::from(&msg[..]);
+                    let _ = ws.send_with_array_buffer_view(&array);
+                }
+            })
+            .map_err(|_| JsValue::from_str("Failed to subscribe to binary doc"))?;
+
+        self.docs.borrow_mut().insert(
+            doc_id.clone(),
+            DocState {
+                doc: doc.clone(),
+                callback,
+                blob_callback: Some(blob_callback),
+                _sub: sub,
+                is_receiving,
+                doc_type: DocType::Map,
+            },
+        );
+
+        if *self.is_connected.borrow() {
+            if let Some(ref ws) = self.ws {
+                let sv = doc.transact().state_vector().encode_v1();
+                let msg = encode_message(MSG_SYNC_STEP_1, &doc_id, &sv);
+                let array = Uint8Array::from(&msg[..]);
+                ws.send_with_array_buffer_view(&array)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Read `meta.type` from a doc's Y.Map.
+    pub fn get_meta_type(&self, doc_id: &str) -> Option<String> {
+        let docs = self.docs.borrow();
+        docs.get(doc_id).and_then(|state| {
+            let meta = state.doc.get_or_insert_map("meta");
+            let txn = state.doc.transact();
+            match meta.get(&txn, "type") {
+                Some(Out::Any(Any::String(arc))) => Some(arc.to_string()),
+                _ => None,
+            }
+        })
+    }
+
+    /// Write `meta.type` into the doc's Y.Map.
+    pub fn set_meta_type(&self, doc_id: &str, file_type: String) {
+        let docs = self.docs.borrow();
+        if let Some(state) = docs.get(doc_id) {
+            let meta = state.doc.get_or_insert_map("meta");
+            let mut txn = state.doc.transact_mut();
+            meta.insert(&mut txn, "type", file_type.as_str());
+        }
+    }
+
+    /// Read `meta.blob_hash` from a doc's Y.Map.
+    pub fn get_blob_hash(&self, doc_id: &str) -> Option<String> {
+        let docs = self.docs.borrow();
+        docs.get(doc_id).and_then(|state| {
+            let meta = state.doc.get_or_insert_map("meta");
+            let txn = state.doc.transact();
+            match meta.get(&txn, "blob_hash") {
+                Some(Out::Any(Any::String(arc))) => Some(arc.to_string()),
+                _ => None,
+            }
+        })
+    }
+
+    /// Write `meta.blob_hash` into the doc's Y.Map.
+    pub fn set_blob_hash(&self, doc_id: &str, hash: String) {
+        let docs = self.docs.borrow();
+        if let Some(state) = docs.get(doc_id) {
+            let meta = state.doc.get_or_insert_map("meta");
+            let mut txn = state.doc.transact_mut();
+            meta.insert(&mut txn, "blob_hash", hash.as_str());
+        }
+    }
+
+    /// Send a binary blob update to the server for the given doc.
+    pub fn send_blob(&self, doc_id: &str, data: &[u8]) {
+        if let Some(ref ws) = self.ws {
+            if *self.is_connected.borrow() {
+                let msg = encode_message(MSG_BLOB_UPDATE, doc_id, data);
+                let array = Uint8Array::from(&msg[..]);
+                let _ = ws.send_with_array_buffer_view(&array);
+            }
+        }
+    }
+
+    /// Request a blob by its SHA256 hash from the server.
+    pub fn request_blob(&self, doc_id: &str, hash: &str) {
+        if let Some(ref ws) = self.ws {
+            if *self.is_connected.borrow() {
+                let msg = encode_message(MSG_BLOB_REQUEST, doc_id, hash.as_bytes());
+                let array = Uint8Array::from(&msg[..]);
+                let _ = ws.send_with_array_buffer_view(&array);
+            }
         }
     }
 

--- a/syncline/tests/e2e.rs
+++ b/syncline/tests/e2e.rs
@@ -118,15 +118,27 @@ fn compare_directories(client_dirs: &[PathBuf]) -> bool {
             if rel_path.is_empty() {
                 continue;
             }
-            // Read content
-            let t = doc.get_or_insert_text("content");
-            let txn = doc.transact();
-            result.insert(rel_path, GetString::get_string(&t, &txn));
+            // Check meta.type — skip Y.Text for binary docs
+            let meta_type = {
+                let txn = doc.transact();
+                match meta.get(&txn, "type") {
+                    Some(Out::Any(Any::String(arc))) => arc.to_string(),
+                    _ => String::new(),
+                }
+            };
+            if meta_type == "binary" {
+                result.insert(rel_path, "[binary]".to_string());
+            } else {
+                // Read content
+                let t = doc.get_or_insert_text("content");
+                let txn = doc.transact();
+                result.insert(rel_path, GetString::get_string(&t, &txn));
+            }
         }
         result
     };
 
-    let mut expected_files: HashMap<String, String> = HashMap::new();
+    let mut expected_files: HashMap<String, Vec<u8>> = HashMap::new();
     let expected_yrs = load_yrs_map(&client_dirs[0]);
 
     for entry in walkdir::WalkDir::new(&client_dirs[0]).min_depth(1) {
@@ -139,7 +151,7 @@ fn compare_directories(client_dirs: &[PathBuf]) -> bool {
         if path.is_file() {
             let rel = path.strip_prefix(&client_dirs[0]).unwrap();
             let name = rel.to_string_lossy().into_owned();
-            let content = fs::read_to_string(path).unwrap();
+            let content = fs::read(path).unwrap();
             expected_files.insert(name, content);
         }
     }
@@ -147,7 +159,7 @@ fn compare_directories(client_dirs: &[PathBuf]) -> bool {
     let mut converged = true;
 
     for (idx, dir) in client_dirs.iter().enumerate().skip(1) {
-        let mut actual_files: HashMap<String, String> = HashMap::new();
+        let mut actual_files: HashMap<String, Vec<u8>> = HashMap::new();
         let actual_yrs = load_yrs_map(dir);
 
         for entry in walkdir::WalkDir::new(dir).min_depth(1) {
@@ -160,7 +172,7 @@ fn compare_directories(client_dirs: &[PathBuf]) -> bool {
             if path.is_file() {
                 let rel = path.strip_prefix(dir).unwrap();
                 let name = rel.to_string_lossy().into_owned();
-                let content = fs::read_to_string(path).unwrap();
+                let content = fs::read(path).unwrap();
                 actual_files.insert(name, content);
             }
         }
@@ -181,8 +193,8 @@ fn compare_directories(client_dirs: &[PathBuf]) -> bool {
                 && content != expected_content
             {
                 error!(
-                    "DISK File {} mismatches between Client 0 and Client {}.\nClient 0: {:?}\nClient {}: {:?}",
-                    name, idx, expected_content, idx, content
+                    "DISK File {} mismatches between Client 0 and Client {}.\nClient 0: {} bytes\nClient {}: {} bytes",
+                    name, idx, expected_content.len(), idx, content.len()
                 );
                 converged = false;
             }
@@ -409,17 +421,20 @@ async fn test_complex_directory_operations() {
 #[tokio::test]
 async fn test_filter_ignored_files() {
     let env = TestEnv::new(2).await;
-    let ignored0 = env.client_path(0).join("ignored.png");
+    let binary0 = env.client_path(0).join("image.png");
     let hidden0 = env.client_path(0).join(".hidden.md");
 
-    fs::write(&ignored0, "binary data").unwrap();
+    fs::write(&binary0, "binary data").unwrap();
     fs::write(&hidden0, "secret text").unwrap();
 
     tokio::time::sleep(Duration::from_millis(2000)).await;
 
-    // Neither should appear in client 1
-    assert!(!env.client_path(1).join("ignored.png").exists());
-    assert!(!env.client_path(1).join(".hidden.md").exists());
+    // Binary files (like .png) should now be synced via binary support
+    assert!(env.client_path(1).join("image.png").exists(),
+            ".png file should be synced with binary file support");
+    // Hidden files (starting with .) should still NOT be synced
+    assert!(!env.client_path(1).join(".hidden.md").exists(),
+            ".hidden files should not be synced");
 }
 
 #[tokio::test]
@@ -683,5 +698,122 @@ async fn test_rename_sync() {
     assert!(
         wait_for_convergence(&env.dirs(), Duration::from_secs(5)).await,
         "Clients did not converge after rename"
+    );
+}
+
+// =============================================================================
+// Binary file tests
+// =============================================================================
+
+/// Client A creates a binary file (.png), and it should sync to Client B
+/// with identical bytes.
+#[tokio::test]
+async fn test_binary_file_sync() {
+    let env = TestEnv::new(2).await;
+
+    // Create a small "PNG" file (with valid PNG header)
+    let png_data: Vec<u8> = vec![
+        0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, // PNG header
+        0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52, // IHDR chunk
+        0xDE, 0xAD, 0xBE, 0xEF, // test payload
+    ];
+    let png_path = env.client_path(0).join("test.png");
+    fs::write(&png_path, &png_data).unwrap();
+
+    // Wait for sync (binary files need time for blob upload+download)
+    tokio::time::sleep(Duration::from_secs(8)).await;
+
+    // Client B should have the file with identical bytes
+    let client_b_path = env.client_path(1).join("test.png");
+    assert!(
+        client_b_path.exists(),
+        "Binary file test.png should exist on Client B"
+    );
+    let synced_data = fs::read(&client_b_path).unwrap();
+    assert_eq!(
+        png_data, synced_data,
+        "Binary file should have identical bytes on both clients"
+    );
+}
+
+/// Client A creates a binary file, syncs it, then modifies it.
+/// The updated binary should propagate to Client B.
+#[tokio::test]
+async fn test_binary_file_modify_sync() {
+    let env = TestEnv::new(2).await;
+
+    // Create initial binary file
+    let initial_data: Vec<u8> = vec![0x00, 0x01, 0x02, 0x03, 0x04];
+    let bin_path = env.client_path(0).join("data.bin");
+    fs::write(&bin_path, &initial_data).unwrap();
+
+    // Wait for initial sync
+    tokio::time::sleep(Duration::from_secs(8)).await;
+
+    let client_b_path = env.client_path(1).join("data.bin");
+    assert!(
+        client_b_path.exists(),
+        "Binary file data.bin should exist on Client B after initial sync"
+    );
+    assert_eq!(
+        initial_data,
+        fs::read(&client_b_path).unwrap(),
+        "Initial binary content should match"
+    );
+
+    // Modify the binary file on Client A
+    let updated_data: Vec<u8> = vec![0xFF, 0xFE, 0xFD, 0xFC, 0xFB, 0xFA];
+    fs::write(&bin_path, &updated_data).unwrap();
+
+    // Wait for update to propagate
+    tokio::time::sleep(Duration::from_secs(8)).await;
+
+    let synced_updated = fs::read(&client_b_path).unwrap();
+    assert_eq!(
+        updated_data, synced_updated,
+        "Updated binary file should have new content on Client B"
+    );
+}
+
+/// Mixed text and binary files should all sync correctly together.
+#[tokio::test]
+async fn test_binary_and_text_mixed_sync() {
+    let env = TestEnv::new(2).await;
+
+    // Create a mix of text and binary files on Client A
+    fs::write(env.client_path(0).join("notes.md"), "# My Notes\nHello").unwrap();
+    fs::write(
+        env.client_path(0).join("image.png"),
+        &[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A],
+    )
+    .unwrap();
+    fs::write(
+        env.client_path(0).join("config.json"),
+        &[0x7B, 0x22, 0x6B, 0x65, 0x79, 0x22, 0x7D], // {"key"}
+    )
+    .unwrap();
+
+    // Wait for sync
+    tokio::time::sleep(Duration::from_secs(10)).await;
+
+    // All files should exist on Client B
+    assert!(env.client_path(1).join("notes.md").exists(), "notes.md should sync");
+    assert!(env.client_path(1).join("image.png").exists(), "image.png should sync");
+    assert!(env.client_path(1).join("config.json").exists(), "config.json should sync");
+
+    // Text file should have correct content
+    assert_eq!(
+        fs::read_to_string(env.client_path(1).join("notes.md")).unwrap(),
+        "# My Notes\nHello"
+    );
+
+    // Binary files should have identical bytes
+    assert_eq!(
+        fs::read(env.client_path(1).join("image.png")).unwrap(),
+        vec![0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]
+    );
+    assert_eq!(
+        fs::read(env.client_path(1).join("config.json")).unwrap(),
+        vec![0x7B, 0x22, 0x6B, 0x65, 0x79, 0x22, 0x7D]
     );
 }


### PR DESCRIPTION
Add full binary file sync across all components:

- Protocol: MSG_BLOB_UPDATE (0x04) and MSG_BLOB_REQUEST (0x05) message types
- Server: content-addressable blob storage in SQLite, blob relay between clients
- Folder client: binary file detection, SHA-256 hashing, blob upload/download
- WASM client: add_binary_doc(), send_blob(), request_blob() methods
- Obsidian plugin: binary file create/modify/rename handlers, dual callbacks
- E2E tests: test_binary_file_sync, test_binary_file_modify_sync, test_binary_and_text_mixed_sync
- Docs: updated PROTOCOL.md and how-it-works.md with binary file sections

Binary files use metadata-only CRDTs (meta.path, meta.type, meta.blob_hash) with separate MSG_BLOB_UPDATE messages for raw content transfer. Conflict resolution uses Last-Write-Wins based on CRDT timestamps.