### PR TITLE
fix: use atomic writes with fsync for CRDT state persistence

### DIFF
--- a/syncline/src/client/state.rs
+++ b/syncline/src/client/state.rs
@@ -39,7 +39,16 @@ impl PathMap {
         if let Some(parent) = self.file_path.parent() {
             fs::create_dir_all(parent)?;
         }
-        fs::write(&self.file_path, json)?;
+
+        // Write to temp file, fsync, then atomic rename — same pattern as
+        // storage::save_doc to avoid half-written JSON on crash.
+        let tmp_path = self.file_path.with_extension("json.tmp");
+        {
+            let mut file = fs::File::create(&tmp_path)?;
+            std::io::Write::write_all(&mut file, json.as_bytes())?;
+            file.sync_all()?;
+        }
+        fs::rename(&tmp_path, &self.file_path)?;
         Ok(())
     }
 

--- a/syncline/src/client/storage.rs
+++ b/syncline/src/client/storage.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result};
 use std::fs;
+use std::io::Write;
 use std::path::Path;
 use yrs::ReadTxn;
 use yrs::Update;
@@ -7,6 +8,10 @@ use yrs::updates::decoder::Decode;
 use yrs::{Doc, StateVector, Transact};
 
 /// Serialize the entire document state to binary format.
+///
+/// Uses write-to-temp-then-rename for atomicity: if the process crashes
+/// mid-write, the original `.bin` file remains intact. Also calls `fsync`
+/// to ensure data reaches durable storage before renaming.
 pub fn save_doc(doc: &Doc, path: &Path) -> Result<()> {
     let txn = doc.transact();
     let update = txn.encode_state_as_update_v1(&StateVector::default());
@@ -16,7 +21,20 @@ pub fn save_doc(doc: &Doc, path: &Path) -> Result<()> {
         fs::create_dir_all(parent).context("Failed to create parent directories")?;
     }
 
-    fs::write(path, update).context("Failed to write document update to disk")?;
+    // Write to a temp file in the same directory, fsync, then rename.
+    // rename() is atomic on POSIX; on the same filesystem it's a single
+    // metadata operation that either succeeds fully or not at all.
+    let tmp_path = path.with_extension("bin.tmp");
+    {
+        let mut file =
+            fs::File::create(&tmp_path).context("Failed to create temp file for doc save")?;
+        file.write_all(&update)
+            .context("Failed to write doc state to temp file")?;
+        file.sync_all()
+            .context("Failed to fsync doc state")?;
+    }
+    fs::rename(&tmp_path, path).context("Failed to atomically rename temp file")?;
+
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- `save_doc()` in `storage.rs` now writes to a `.bin.tmp` file, calls `fsync`, then atomically renames — preventing half-written CRDT state on crash
- `PathMap::save()` in `state.rs` uses the same write-to-temp-then-rename pattern for `path_map.json`
- If the process crashes mid-write, the original file remains intact

## Context
P1 bug from the sync reliability audit. Previously both files used plain `fs::write`, which is not atomic — a crash mid-write could corrupt the file and lose all CRDT history or path mappings.

## Test plan
- [x] All 47 existing tests pass (`cargo test -p syncline --lib`)
- [ ] Manual: kill the syncline process during a save and verify `.bin` / `path_map.json` remain intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)