### PR TITLE
feat: add convergence checksums for divergence detection

### DIFF
--- a/syncline/src/client/app.rs
+++ b/syncline/src/client/app.rs
@@ -179,6 +179,9 @@ pub async fn run_client(folder: PathBuf, url: String, name: Option<String>) -> a
         let mut resync_interval = tokio::time::interval(std::time::Duration::from_secs(60));
         resync_interval.tick().await; // consume the immediate first tick
 
+        let mut checksum_interval = tokio::time::interval(tokio::time::Duration::from_secs(120));
+        checksum_interval.reset(); // skip immediate first tick
+
         loop {
             tokio::select! {
                 _ = resync_interval.tick() => {
@@ -509,7 +512,7 @@ pub async fn run_client(folder: PathBuf, url: String, name: Option<String>) -> a
                                 warn!("Received blob for unknown UUID {}", doc_id);
                             }
                         }
-                        MsgType::SyncStep1 | MsgType::BlobRequest | MsgType::Resync => {}
+                        MsgType::SyncStep1 | MsgType::BlobRequest | MsgType::Resync | MsgType::Checksum => {}
                     }
                 }
 
@@ -794,6 +797,31 @@ pub async fn run_client(folder: PathBuf, url: String, name: Option<String>) -> a
                             }
                         }
                         Err(e) => error!("Watcher error: {:?}", e),
+                    }
+                }
+
+                _ = checksum_interval.tick() => {
+                    // Periodically send content checksums for all subscribed text docs
+                    // so the server can detect divergence and push corrections.
+                    for uuid in &subscribed_docs {
+                        if uuid == "__index__" { continue; }
+                        let state_path = local_state.get_state_path_for_uuid(uuid);
+                        if let Ok(doc) = load_doc(&state_path) {
+                            let meta_type = read_meta_type(&doc)
+                                .unwrap_or_else(|| "text".to_string());
+                            if meta_type != "text" { continue; }
+                            let text_ref = doc.get_or_insert_text("content");
+                            let content = text_ref.get_string(&doc.transact());
+                            let hash = sha256_hash(content.as_bytes());
+                            if let Err(e) = ws_tx.send(Message::new(
+                                MsgType::Checksum,
+                                uuid.clone(),
+                                hash.into_bytes(),
+                            )).await {
+                                error!("Failed to send checksum for {}: {:?}", uuid, e);
+                                break;
+                            }
+                        }
                     }
                 }
             }

--- a/syncline/src/client/protocol.rs
+++ b/syncline/src/client/protocol.rs
@@ -9,6 +9,7 @@ pub enum MsgType {
     BlobUpdate = 0x04,
     BlobRequest = 0x05,
     Resync = 0x06,
+    Checksum = 0x07,
 }
 
 impl TryFrom<u8> for MsgType {
@@ -22,6 +23,7 @@ impl TryFrom<u8> for MsgType {
             0x04 => Ok(MsgType::BlobUpdate),
             0x05 => Ok(MsgType::BlobRequest),
             0x06 => Ok(MsgType::Resync),
+            0x07 => Ok(MsgType::Checksum),
             _ => Err(anyhow!("Invalid message type: {}", value)),
         }
     }
@@ -93,6 +95,7 @@ mod tests {
         assert_eq!(MsgType::try_from(0x02).unwrap(), MsgType::Update);
         assert_eq!(MsgType::try_from(0x04).unwrap(), MsgType::BlobUpdate);
         assert_eq!(MsgType::try_from(0x05).unwrap(), MsgType::BlobRequest);
+        assert_eq!(MsgType::try_from(0x07).unwrap(), MsgType::Checksum);
         assert!(MsgType::try_from(0x03).is_err());
         assert!(MsgType::try_from(0xFF).is_err());
     }

--- a/syncline/src/protocol.rs
+++ b/syncline/src/protocol.rs
@@ -8,6 +8,9 @@ pub const MSG_BLOB_REQUEST: u8 = 5;
 /// this does NOT subscribe the client to the broadcast channel (it's already
 /// subscribed from the initial SyncStep1).
 pub const MSG_RESYNC: u8 = 6;
+/// Convergence checksum: client sends SHA256 of text content for a doc.
+/// If the server's content disagrees, it responds with a full SyncStep2.
+pub const MSG_CHECKSUM: u8 = 7;
 
 /// Maximum blob size in bytes (50 MB).
 pub const MAX_BLOB_SIZE: usize = 50 * 1024 * 1024;

--- a/syncline/src/server/server.rs
+++ b/syncline/src/server/server.rs
@@ -18,8 +18,8 @@ use tokio::sync::{Mutex as AsyncMutex, RwLock, broadcast, mpsc};
 use yrs::{Doc, GetString, StateVector, Text, Transact, Update, updates::decoder::Decode};
 
 use crate::protocol::{
-    MSG_BLOB_REQUEST, MSG_BLOB_UPDATE, MSG_RESYNC, MSG_SYNC_STEP_1, MSG_SYNC_STEP_2, MSG_UPDATE,
-    decode_message, encode_message,
+    MSG_BLOB_REQUEST, MSG_BLOB_UPDATE, MSG_CHECKSUM, MSG_RESYNC, MSG_SYNC_STEP_1, MSG_SYNC_STEP_2,
+    MSG_UPDATE, decode_message, encode_message,
 };
 
 type ChannelMap = Arc<RwLock<HashMap<String, broadcast::Sender<(Vec<u8>, uuid::Uuid)>>>>;
@@ -380,6 +380,67 @@ async fn handle_socket(socket: WebSocket, state: AppState) {
                                     }
                                     Ok(_) => {} // fully in sync, nothing to send
                                     Err(e) => tracing::error!("DB Error during resync: {}", e),
+                                }
+                            }
+                        }
+                        MSG_CHECKSUM => {
+                            // Client sends SHA256 hex digest of its text content.
+                            // Reconstruct the doc from DB and compare. On mismatch,
+                            // respond with a full SyncStep2 so the client converges.
+                            let client_hash = std::str::from_utf8(payload).unwrap_or("");
+                            if client_hash.is_empty() {
+                                tracing::debug!("Empty checksum for doc {}, ignoring", doc_id);
+                            } else {
+                                match state_clone
+                                    .db
+                                    .get_all_updates_since(doc_id, &StateVector::default())
+                                    .await
+                                {
+                                    Ok(full_update) if !full_update.is_empty() => {
+                                        // Rebuild the doc in memory and extract text content.
+                                        let tmp_doc = Doc::new();
+                                        if let Ok(update) = Update::decode_v1(&full_update) {
+                                            let mut txn = tmp_doc.transact_mut();
+                                            txn.apply_update(update);
+                                            drop(txn);
+
+                                            let text_ref = tmp_doc.get_or_insert_text("content");
+                                            let server_text =
+                                                text_ref.get_string(&tmp_doc.transact());
+                                            use sha2::{Digest, Sha256};
+                                            let server_hash =
+                                                format!("{:x}", Sha256::digest(server_text.as_bytes()));
+
+                                            if server_hash != client_hash {
+                                                tracing::warn!(
+                                                    "Checksum mismatch for doc {}: client={} server={}. Sending full state.",
+                                                    doc_id, client_hash, server_hash
+                                                );
+                                                let resp = encode_message(
+                                                    MSG_SYNC_STEP_2,
+                                                    doc_id,
+                                                    &full_update,
+                                                );
+                                                let _ = tx_socket_clone.send(resp);
+                                            } else {
+                                                tracing::debug!(
+                                                    "Checksum OK for doc {}: {}",
+                                                    doc_id,
+                                                    client_hash
+                                                );
+                                            }
+                                        }
+                                    }
+                                    Ok(_) => {
+                                        // No data on server — nothing to compare.
+                                    }
+                                    Err(e) => {
+                                        tracing::error!(
+                                            "DB error during checksum for doc {}: {}",
+                                            doc_id,
+                                            e
+                                        );
+                                    }
                                 }
                             }
                         }
@@ -1210,6 +1271,99 @@ mod tests {
         assert_eq!(
             final_a, final_b,
             "Both clients must converge to the same merged content"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_checksum_mismatch_triggers_sync() {
+        let (port, _state) = setup_test_server().await;
+
+        let (mut ws, _) =
+            connect_async(format!("ws://127.0.0.1:{}/sync", port))
+                .await
+                .unwrap();
+
+        let doc_id = "checksum_test_doc";
+
+        // Subscribe and upload initial content
+        let doc = Doc::new();
+        let text = doc.get_or_insert_text("content");
+        {
+            let mut txn = doc.transact_mut();
+            text.insert(&mut txn, 0, "Hello checksum");
+        }
+
+        let sv = doc.transact().state_vector().encode_v1();
+        let sync1_msg =
+            crate::protocol::encode_message(crate::protocol::MSG_SYNC_STEP_1, doc_id, &sv);
+        ws.send(TungsteniteMessage::Binary(sync1_msg.into()))
+            .await
+            .unwrap();
+
+        let update = doc
+            .transact()
+            .encode_state_as_update_v1(&StateVector::default());
+        let update_msg =
+            crate::protocol::encode_message(crate::protocol::MSG_UPDATE, doc_id, &update);
+        ws.send(TungsteniteMessage::Binary(update_msg.into()))
+            .await
+            .unwrap();
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // Drain any pending messages (SyncStep2 from initial subscribe, index updates)
+        loop {
+            match tokio::time::timeout(Duration::from_millis(200), ws.next()).await {
+                Ok(Some(Ok(_))) => continue,
+                _ => break,
+            }
+        }
+
+        // Send a WRONG checksum — should trigger a SyncStep2 response
+        let wrong_hash = "0000000000000000000000000000000000000000000000000000000000000000";
+        let checksum_msg = crate::protocol::encode_message(
+            crate::protocol::MSG_CHECKSUM,
+            doc_id,
+            wrong_hash.as_bytes(),
+        );
+        ws.send(TungsteniteMessage::Binary(checksum_msg.into()))
+            .await
+            .unwrap();
+
+        // We should receive a SyncStep2 with the full state
+        let response = tokio::time::timeout(Duration::from_secs(2), ws.next())
+            .await
+            .expect("Should receive response within 2s")
+            .expect("Stream should not end")
+            .expect("Should be a valid message");
+
+        if let TungsteniteMessage::Binary(data) = response {
+            let (msg_type, resp_doc_id, _payload) =
+                crate::protocol::decode_message(&data).expect("Should decode");
+            assert_eq!(msg_type, crate::protocol::MSG_SYNC_STEP_2);
+            assert_eq!(resp_doc_id, doc_id);
+        } else {
+            panic!("Expected binary message, got: {:?}", response);
+        }
+
+        // Now send the CORRECT checksum — should get no response
+        use sha2::{Digest, Sha256};
+        let correct_hash = format!("{:x}", Sha256::digest(b"Hello checksum"));
+        let checksum_msg = crate::protocol::encode_message(
+            crate::protocol::MSG_CHECKSUM,
+            doc_id,
+            correct_hash.as_bytes(),
+        );
+        ws.send(TungsteniteMessage::Binary(checksum_msg.into()))
+            .await
+            .unwrap();
+
+        // No response expected — timeout should fire
+        let no_response =
+            tokio::time::timeout(Duration::from_millis(500), ws.next()).await;
+        assert!(
+            no_response.is_err(),
+            "Should NOT receive a response when checksum matches"
         );
     }
 }

--- a/syncline/tests/e2e.rs
+++ b/syncline/tests/e2e.rs
@@ -427,11 +427,16 @@ async fn test_filter_ignored_files() {
     fs::write(&binary0, "binary data").unwrap();
     fs::write(&hidden0, "secret text").unwrap();
 
+    // Wait for binary file to sync (may take longer on slow CI)
     let deadline = std::time::Instant::now() + Duration::from_secs(15);
     loop {
-        if env.client_path(1).join("image.png").exists() { break; }
-        assert!(std::time::Instant::now() < deadline,
-            ".png file should be synced with binary file support");
+        if env.client_path(1).join("image.png").exists() {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            ".png file should be synced with binary file support"
+        );
         tokio::time::sleep(Duration::from_millis(200)).await;
     }
 


### PR DESCRIPTION
## Summary
- New protocol message `MSG_CHECKSUM` (0x07): client sends SHA256 of document text content
- Server handler reconstructs doc from DB, compares hashes, and sends full SyncStep2 on mismatch
- Client sends checksums for all subscribed text docs every 120 seconds
- Acts as an end-to-end safety net: even if CRDT state vectors agree, detects content-level divergence (e.g. from corrupted state files or missed updates)

## How it works
1. Every 120s, client iterates subscribed docs, computes `sha256(plaintext_content)`, sends as `MSG_CHECKSUM`
2. Server receives checksum, loads all updates from DB, rebuilds doc, hashes the text
3. If hashes differ → server responds with `MSG_SYNC_STEP_2` (full state), client auto-merges
4. If hashes match → no response (zero overhead)

## Test plan
- [x] All 48 tests pass (`cargo test -p syncline --lib`) — 47 existing + 1 new
- [x] New test `test_checksum_mismatch_triggers_sync` verifies:
  - Wrong checksum → server sends SyncStep2
  - Correct checksum → no response

🤖 Generated with [Claude Code](https://claude.com/claude-code)