### PR TITLE
v1: Design document for manifest CRDT architecture

### DIFF
--- a/docs/DESIGN_DOC_V1.md
+++ b/docs/DESIGN_DOC_V1.md
@@ -1,0 +1,575 @@
+# Syncline v1 — Design Document
+
+**Status:** Proposal — release/v1 branch
+**Scope:** Protocol-incompatible rewrite replacing the `path_map.json` + server-side `__index__` Y.Text with a single, replicated **manifest Y.Doc** that is the source of truth for the vault namespace.
+**Non-goal:** v1 does not introduce an explicit journal / op-log (see Part II of the clean-room reference). Those arrive in v1.1.
+
+Reference architecture: `/co-ceo/research/crdt-filesystem-design.md` (internal, clean-room rewrite). v1 implements Part I of that document.
+
+---
+
+## 1. Goals & Non-Goals
+
+### 1.1 Goals
+
+- **One source of truth for the namespace.** The set of live paths, their parents, and their rename history live in a single CRDT (the *manifest*) that every client replicates and every peer updates via Yrs updates. No JSON side-files. No server-maintained index.
+- **Deterministic convergence for all fs operations.** Create, delete, rename, move, and modify must converge for every ordering of concurrent and offline operations currently exercised by the 49 tests in PR #38.
+- **Fix v0's root-cause bugs by construction, not by patches.**
+  - Ghost delete (empty content projected as file on peer): eliminated — deletion is a `deleted=true` LWW register on a node, not an empty text doc.
+  - Stale `__index__`: eliminated — the index *is* the manifest; it cannot diverge from the per-document state.
+  - Rename detection fragility: eliminated — rename is a rewrite of the `name` / `parent` fields on the existing `NodeId`; no content-hash heuristic is required.
+  - Directory ops unsupported: emergent support — directories are implicit children of the `parent` field; a directory "rename" is a batch of `parent` updates in one Yrs transaction.
+- **Content-addressed storage** for blobs, reused across renames, deduplicated across clients.
+- **Bounded metadata growth** via knowledge-vector tombstone GC (30-day floor).
+- **Local one-way migration** from v0 on-disk state to v1 manifest. Clients upgrade at their own pace; there is no server-side migration.
+
+### 1.2 Non-Goals
+
+- **No wire compatibility with v0.** v0 and v1 clients cannot talk to each other — they use different protocol version numbers and will refuse the handshake. Users migrate the full mesh (all clients + the server) together.
+- **No explicit directory documents.** A directory is simply "a path prefix that at least one live node uses as its parent chain". The empty-directory-sync case (`test_create_empty_directory_syncs`) remains a known gap, documented as v1.1 work.
+- **No journal / op-log in v1.** The manifest's LWW rules cover every fs operation in the test suite. A journal (Part II §18 of the reference) would make intent recoverable across GC and enable richer audit, but is not required for convergence; deferred to v1.1.
+- **No multi-vault, no partial replication.** The manifest is small (one node per live path + tombstones), always fully replicated.
+- **No E2EE in v1.** E2EE is orthogonal; it ships or does not ship per `docs/E2EE_IMPLEMENTATION.md`.
+
+---
+
+## 2. Architecture Overview
+
+### 2.1 The three layers
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Manifest Y.Doc   (one per vault, fully replicated)         │
+│  ─────────────                                              │
+│  nodes : Y.Map<NodeId, NodeEntry>                           │
+│    NodeEntry { name, parent, deleted, content_ref,          │
+│                kind, blob_hash, lamport, actor }            │
+│  tombstones_gc : Y.Map<NodeId, GcMeta>                      │
+│  knowledge   : Y.Map<ActorId, Lamport>                      │
+└─────────────────────────────────────────────────────────────┘
+           │  projects to
+           ▼
+┌─────────────────────────────────────────────────────────────┐
+│  Content subdocs  (one Y.Doc per text NodeId, lazy-loaded)  │
+│  ────────────────                                           │
+│  "content" : Y.Text   (the file body, as CRDT)              │
+│  "meta"    : Y.Map    (mtime hints, eol, bom, etc.)         │
+└─────────────────────────────────────────────────────────────┘
+           │  content-addresses
+           ▼
+┌─────────────────────────────────────────────────────────────┐
+│  CAS blob store   (SHA-256-keyed, dedup'd, lazy-fetched)    │
+│  ────────────────                                           │
+│  .syncline/blobs/<hash[0:2]>/<hash>                         │
+└─────────────────────────────────────────────────────────────┘
+```
+
+The **manifest** owns identity and structure. Every file in the vault is a `NodeId` (UUIDv7) in `nodes`. Renames and moves mutate the `name` / `parent` fields of the existing `NodeId`; deletions set `deleted=true`. Because the `NodeId` is stable, a rename-plus-modify is trivially the two Yrs updates being merged on the same entry — the fragile content-hash detection in v0's `bootstrap_offline_changes` (see `client/state.rs`) is deleted outright.
+
+The **content subdocs** carry the body of text files. They are addressed by `NodeId`, lazily loaded via SyncStep1 only when the local filesystem needs the file. Binary files do not allocate a content subdoc — they use `content_ref = Blob(hash)`.
+
+The **CAS blob store** is content-addressed (SHA-256). Blobs are pushed via `MSG_BLOB_UPDATE` and fetched on demand via `MSG_BLOB_REQUEST`. Binary renames cost zero bytes of blob traffic — the manifest updates, the hash does not.
+
+### 2.2 Node lifecycle
+
+```
+                create                rename/move                delete
+  (absent) ──────────────▶  live  ──────────────────▶  live  ──────────▶  tombstoned
+                             │          (same NodeId)                        │
+                             │                                               │
+                             │    modify (new Yrs update on content subdoc)  │
+                             │◀──────────────────────────────────────────────┘
+                                        (resurrection — see §6.3)
+```
+
+A deletion never removes an entry from `nodes`; it sets `deleted=true` with a Lamport timestamp. Concurrent modification of a tombstoned node **resurrects it** (modify-wins-over-delete — rationale in §6.3), provided the modification's Lamport is newer. Post-GC, resurrection is no longer possible (§8).
+
+### 2.3 Why a single manifest instead of per-file docs + a server index
+
+v0 kept each file's content in its own Y.Doc and reconstructed the vault namespace two ways: a client-side `path_map.json` (plain JSON, not a CRDT — it de-syncs under concurrency) and a server-side `__index__` Y.Text (a CRDT, but fed by ad-hoc client code that forgets to prune on delete). Every bug listed in `docs/KNOWN_BUGS.md` #9–#15 traces to one of these two diverging.
+
+A single manifest Y.Doc collapses both into one replicated structure. Yrs' own update-and-sync machinery guarantees eventual consistency; no side code can de-sync it because there is no side code. The server becomes a **dumb pipe + persistence layer** for the manifest and content subdocs — it no longer maintains an independent view of the namespace.
+
+---
+
+## 3. Data Format
+
+### 3.1 On-disk layout (per client)
+
+```
+<vault>/
+├── .syncline/
+│   ├── version                       # ASCII "1\n"; tripwire for old clients
+│   ├── manifest.bin                  # latest compacted Yrs snapshot of the manifest doc
+│   ├── manifest.updates              # append-only log of Yrs updates since last snapshot
+│   ├── content/
+│   │   ├── <nodeid[0:2]>/
+│   │   │   └── <nodeid>.bin          # compacted snapshot of one content subdoc
+│   ├── blobs/
+│   │   ├── <hash[0:2]>/
+│   │   │   └── <hash>                # raw bytes of a binary file content
+│   ├── actor_id                      # stable random UUIDv4 for this replica
+│   └── lamport                       # monotonic per-actor counter, persisted
+└── <user-visible files and directories>
+```
+
+The `.syncline/` folder is the only on-disk state the client writes. The `version` file is read before anything else; a mismatch (`!= "1"`) triggers migration (§7) or a hard refusal.
+
+The `actor_id` is generated once, persisted, never changes. Lamport counters increment on every operation this client performs and are persisted to `lamport` after each transaction.
+
+### 3.2 Manifest schema
+
+```rust
+type NodeId   = Uuid;       // UUIDv7, so IDs sort temporally
+type ActorId  = Uuid;       // UUIDv4, one per installation
+type Lamport  = u64;        // per-actor monotonic counter
+
+struct NodeEntry {
+    name:         String,           // LWW register — last segment of path
+    parent:       Option<NodeId>,   // LWW register — None = vault root
+    deleted:      bool,             // LWW register — tombstone flag
+    kind:         NodeKind,         // Text | Binary (immutable after create)
+    blob_hash:    Option<[u8; 32]>, // LWW register, only meaningful if kind == Binary
+    size:         u64,              // LWW register, hint for UI / GC
+    lamport:      Lamport,          // of the most recent field update on this entry
+    actor:        ActorId,          // of the most recent field update on this entry
+    created_at:   Lamport,          // of the create event (for GC age floor)
+}
+
+struct GcMeta {
+    tombstoned_at: Lamport,   // when deleted=true was set
+    last_knowledge_merge: Lamport,  // see §8
+}
+```
+
+Yrs expresses each field as a value in the `NodeEntry` Y.Map; LWW resolution happens at read time by comparing `(lamport, actor)` tuples. `(lamport, actor)` with max lamport wins; ties broken by `actor` lexicographic order (stable and symmetric across peers).
+
+### 3.3 Content subdoc schema
+
+```
+content : Y.Text           # the file body
+meta    : Y.Map {
+    eol:  "lf" | "crlf",   # preserved across platforms
+    bom:  bool,
+    lang: Option<String>,  # hint only, not load-bearing
+}
+```
+
+One subdoc per text `NodeId`. Loaded on demand (see §4.3). Binary nodes never allocate a content subdoc.
+
+### 3.4 Wire format (protocol framing)
+
+The v0 framing `[msg_type: u8][doc_id_len: u16 BE][doc_id: utf8][payload]` is retained. v1 adds a protocol version handshake at the head of the WebSocket session:
+
+```
+client → server:  [MSG_VERSION=0xF0][u8 major=1][u8 minor=0]
+server → client:  [MSG_VERSION=0xF0][u8 major=1][u8 minor=0]
+                  OR close(code=1002, "protocol version mismatch")
+```
+
+The handshake happens before any doc subscription. Mismatched major versions fatally close the connection; matching majors proceed. The server will accept `(major=1, minor=*)` for the v1 lifetime.
+
+---
+
+## 4. Sync Protocol Changes
+
+### 4.1 New message types
+
+| Code   | Name                   | Direction | Payload                                                                      |
+|--------|------------------------|-----------|------------------------------------------------------------------------------|
+| `0xF0` | `MSG_VERSION`          | both      | `[u8 major][u8 minor]`                                                       |
+| `0x20` | `MSG_MANIFEST_SYNC`    | both      | `[Yrs SyncMessage bytes]` — applies to the manifest doc only                 |
+| `0x21` | `MSG_MANIFEST_VERIFY`  | both      | `[root_merkle_hash: 32 bytes][mode: u8][detail...]` — convergence heartbeat  |
+
+Retained from v0 (unchanged semantics, except "`doc_id` = manifest" is no longer a special case):
+
+| Code   | Name                | Notes                                                       |
+|--------|---------------------|-------------------------------------------------------------|
+| `0x00` | `SYNC_STEP_1`       | Sent per content subdoc (one per NodeId that is resident)   |
+| `0x01` | `SYNC_STEP_2`       | Response to SYNC_STEP_1                                     |
+| `0x02` | `UPDATE`            | Ordinary Yrs update on a content subdoc                     |
+| `0x04` | `BLOB_UPDATE`       | CAS blob push (server persists to `blobs` table)            |
+| `0x05` | `BLOB_REQUEST`      | CAS blob fetch by hash                                      |
+
+Removed:
+
+- `MSG_RESYNC` (0x06) and `MSG_CHECKSUM` (0x07) — replaced by `MSG_MANIFEST_VERIFY` which verifies the *namespace*, not per-doc text. Per-doc divergence is detected and healed by the ordinary SyncStep1/2 exchange on demand.
+
+### 4.2 Session bring-up
+
+```
+1. WebSocket TCP + upgrade
+2. ─▶ MSG_VERSION(1,0)           (client)
+3. ◀─ MSG_VERSION(1,0)           (server)       [or disconnect]
+4. ─▶ MSG_MANIFEST_SYNC(SyncStep1, state_vector = client's)
+5. ◀─ MSG_MANIFEST_SYNC(SyncStep2, missing updates)
+6. ◀─ MSG_MANIFEST_SYNC(SyncStep1, state_vector = server's)   [reverse direction]
+7. ─▶ MSG_MANIFEST_SYNC(SyncStep2, missing updates)
+── manifest now converged ──
+8. (lazy) per-file: ─▶ SYNC_STEP_1 on content subdoc when needed locally
+```
+
+Manifest sync happens **first and always**, before any content subdoc is loaded. This guarantees the client sees the authoritative namespace before it makes local filesystem decisions (e.g. "does this path exist on disk? do I need to write it?").
+
+### 4.3 Lazy content subdoc loading
+
+v0 subscribed to every doc on connect. v1 subscribes only to content subdocs corresponding to live (non-deleted) NodeIds whose content is (a) on disk and out of sync, or (b) newly requested by the local file watcher.
+
+Server side: the broadcast channel map `doc_id → Sender` is already per-doc; no change beyond accepting subscribes that arrive post-connect.
+
+### 4.4 Convergence verification (`MSG_MANIFEST_VERIFY`)
+
+Every 30 seconds a client sends a verification message:
+
+```
+MSG_MANIFEST_VERIFY, mode=0 (ROOT)
+  root_hash = SHA256 of the canonical serialization of the projected namespace
+              (see §4.4.1) — computed over live nodes only
+```
+
+Server responds with its own `root_hash` over the same projection. On mismatch:
+
+```
+MSG_MANIFEST_VERIFY, mode=1 (FULL_SYNC_REQUEST)
+```
+
+…which triggers an unconditional SyncStep1 of the manifest in both directions. This is the heartbeat that catches silent data loss / divergence bugs; it is cheap (one SHA256 over ~a few hundred bytes per node) and runs whenever the connection is alive.
+
+#### 4.4.1 Canonical projection hash
+
+```
+For each live NodeId (deleted=false), in UUIDv7 ascending order:
+    SHA256.update(nodeid_bytes || name_utf8 || parent_bytes_or_zero || kind_byte || blob_hash_or_zero)
+Finalize.
+```
+
+Tombstones are excluded — they diverge legitimately during GC windows. A separate mode (FULL_SYNC_REQUEST, already in the table) covers the case where tombstone state is suspected of diverging.
+
+---
+
+## 5. Operation Semantics
+
+All operations below are expressed as Yrs transactions on the manifest (and, for modify, also on a content subdoc). Each transaction stamps every changed register with `(lamport, actor)` where `lamport` is this client's counter, incremented once per transaction.
+
+### 5.1 Create
+
+**Trigger:** `notify` watcher reports a new path on disk.
+
+```
+1. Assign a fresh NodeId (UUIDv7 → temporal order)
+2. Detect collision: is there a live node whose (parent, name) equals the new one?
+   - Yes, and it's a path already owned by us → no-op (this is the round-trip echo)
+   - Yes, but it's someone else's node → this is a "simultaneous create same path"
+     → create our node anyway; at read/projection time, the later creator gets a
+       conflict suffix (see §6.4). This matches v0's detect_path_collision behavior.
+3. Compute SHA256 of file bytes
+   - Text: start a content subdoc, init content Y.Text with the bytes
+   - Binary: push blob via MSG_BLOB_UPDATE; record blob_hash in the NodeEntry
+4. Insert NodeEntry { name, parent, deleted=false, kind, blob_hash, lamport, actor }
+5. Broadcast MSG_MANIFEST_SYNC(UPDATE) + (if text) MSG_UPDATE on the new content subdoc
+```
+
+### 5.2 Delete
+
+**Trigger:** `notify` watcher reports a path removal.
+
+```
+1. Find the live NodeId that projects to this path.
+2. Set deleted = true; bump (lamport, actor).
+3. Broadcast manifest update.
+4. Do NOT touch the content subdoc or the blob immediately — GC handles that.
+```
+
+This is the direct fix for `test_delete_*` family. No more "empty text = deleted" projection hack. A `deleted=true` node vanishes from every peer's filesystem projection the moment they apply the manifest update.
+
+### 5.3 Rename (same parent)
+
+**Trigger:** `notify` reports a `rename(from, to)` event OR a delete-then-create on the same parent within a debounce window where the content hash matches.
+
+```
+1. Resolve `from` → NodeId via the live projection.
+2. Update NodeEntry.name = new_last_segment; bump lamport/actor.
+3. Broadcast manifest update. The content subdoc and the blob are untouched.
+```
+
+Note: v0's content-hash rename detection *for fs events* is retained as a fallback — `notify` on Linux sometimes delivers rename as `Remove+Create`. But the CRDT-level effect is always a single `name` field update; content hashing only disambiguates which `Remove+Create` pair to collapse on the watcher side before it reaches the manifest layer.
+
+### 5.4 Move (different parent)
+
+```
+1. Resolve `from` → NodeId.
+2. Detect collision at destination (same rule as create).
+3. Update NodeEntry.parent = new_parent_nodeid; optionally .name too; bump lamport/actor.
+4. Broadcast manifest update.
+```
+
+### 5.5 Modify
+
+**Trigger:** `notify` reports a write.
+
+```
+Text:
+  1. Resolve path → NodeId.
+  2. Diff local text vs subdoc content → apply as Yrs Y.Text deltas.
+  3. Broadcast MSG_UPDATE on the content subdoc.
+  4. Bump NodeEntry.lamport (marks "this node was touched by actor", used by GC).
+
+Binary:
+  1. Resolve path → NodeId.
+  2. SHA256 the new bytes. If hash matches current blob_hash → no-op.
+  3. MSG_BLOB_UPDATE the new blob (CAS — server dedupes if seen).
+  4. Update NodeEntry.blob_hash; bump lamport/actor.
+  5. Broadcast manifest update.
+```
+
+### 5.6 Directory operations (emergent)
+
+Syncline v1 has **no explicit directory document**. All directory ops are expressed via the `parent` field of leaves:
+
+| User action                   | Manifest effect                                                          |
+|-------------------------------|--------------------------------------------------------------------------|
+| `mkdir foo/`                  | No manifest change — `foo/` only materializes when a file gets `parent = foo`. |
+| `mkdir foo/; touch foo/a.md`  | Create `a.md` with a synthesized "directory node" `foo` as its parent.   |
+| `mv foo/ bar/`                | One transaction: for every child with parent=foo_id, either rename foo→bar OR update each child's `parent` to point at the new directory node. v1 takes the **directory-node rename** path (one update, not N). |
+| `rm -rf foo/`                 | One transaction: set `deleted=true` on the directory node AND every descendant. |
+
+The directory node itself is a `NodeEntry { kind: Directory, blob_hash: None, ... }`. It has no content subdoc and no blob. Its only job is to carry the `name` field that the leaves reference as `parent`. This keeps directory rename O(1) in manifest updates, which matters for `test_rename_directory_with_files` (the v0 failure mode was N independent rename-detection heuristics, each racing against the others).
+
+**Known gap:** `test_create_empty_directory_syncs` — a directory node is *created* when a child appears, not when `mkdir` runs. An empty directory therefore does not sync. This is an intentional v1 scope cut; fix is in v1.1 alongside the journal work.
+
+### 5.7 Lamport advance rules
+
+```
+lamport_new = max(local_counter, observed_remote_lamport + 1)
+```
+
+On **every** manifest or subdoc update received, bump the local counter to at least `remote + 1`. On every local transaction, increment by one. This makes the counter a proper Lamport clock and gives LWW a well-defined order even across disconnected actors.
+
+---
+
+## 6. Conflict Resolution Rules
+
+All rules operate on the projection of the manifest to "what files exist on this disk, and what do they contain". LWW is the fallback; specific op pairs have named rules that are more intuitive.
+
+### 6.1 Field-level LWW
+
+For any single register (`name`, `parent`, `deleted`, `blob_hash`):
+
+```
+winner = argmax_(lamport, actor) over all field writes
+```
+
+This is the Yrs default for `Y.Map`; we inherit it. Tie-break on `actor` is stable across peers because actor UUIDs are globally unique.
+
+### 6.2 Concurrent rename to different names (`test_rename_vs_rename_different_names`)
+
+Both writes hit the same `name` register on the same NodeId → §6.1 picks one. The losing name is **not** resurrected as a conflict copy — the user only saw one name; showing the loser as an extra file would be noise. The authoritative outcome: one name wins, the original path is gone on both sides, no conflict file appears.
+
+### 6.3 Modify-wins-over-delete (`test_delete_vs_modify_offline_modification_wins`)
+
+```
+If a node has a write to `deleted=true` AND a subdoc content update (or blob_hash change)
+with higher lamport than the delete:
+   deleted := false   (the modification resurrects the node)
+```
+
+This is a projection rule, not a CRDT rule — both writes stand in the manifest; projection chooses "live" because the modification's lamport beats the delete's. Rationale: accidental or conflicting deletes in a shared vault should never destroy user edits. The user can always re-delete intentionally.
+
+### 6.4 Same-path collisions (create vs create, modify after remote create, etc.)
+
+If, at projection time, two live nodes share the same `(parent, name)`:
+
+```
+sorted = nodes.sort_by(lamport, actor)      # deterministic
+winner = sorted[0]
+for loser in sorted[1:]:
+    loser.projected_name := basename + ".conflict-<short_actor>-<lamport>" + ext
+```
+
+Both peers arrive at identical projected filenames because the sort is deterministic. This covers: `test_simultaneous_online_create_same_path`, `test_both_offline_same_name_conflict`, and the binary case `test_concurrent_binary_edits_preserves_both` (the two nodes have different `blob_hash`; both survive, both are written to disk under distinct names).
+
+### 6.5 Move + delete on same node
+
+Treated as two independent register updates. LWW on `deleted` dominates — if the delete has the higher lamport, the move is a no-op at projection; if the move is newer, §6.3 resurrects.
+
+### 6.6 Cycle prevention
+
+A move that would make a node its own ancestor is **rejected locally** before being applied to the manifest. If, by network race, a cycle is ever projected, the loop is broken at the edge with the lowest `(lamport, actor)` — that edge's `parent` is reverted to the pre-edit value. This is a purely local repair; the next manifest update broadcast will correct the peers.
+
+The Kleppmann-Howard tree CRDT would handle this without a local repair, but its extra machinery (per-op undo/redo log) is out of scope for v1. The local-repair path is sufficient for the test suite and for real-world fs hierarchies where cycles are vanishingly rare (filesystem move loops usually require adversarial timing).
+
+---
+
+## 7. Migration v0 → v1 (local, one-way)
+
+### 7.1 Trigger
+
+On client startup:
+
+```
+if .syncline/version missing or == "0":
+    run migration
+else if == "1":
+    proceed normally
+else:
+    abort with "downgrade not supported"
+```
+
+### 7.2 Steps
+
+1. **Take a backup.** Rename `.syncline/` to `.syncline.v0.bak/`. Never delete user data.
+2. **Fresh-init a new `.syncline/` with `version = 1`**, a new random `actor_id`, `lamport = 0`.
+3. **Walk the user-visible vault, ignoring `.syncline*`.** For every file found:
+   - Assign a fresh NodeId (UUIDv7).
+   - Classify as Text or Binary by the same mime-sniff rule v0 uses.
+   - Text → create a content subdoc, load file bytes into the `content` Y.Text.
+   - Binary → SHA256 the bytes, write to CAS blob store, record `blob_hash`.
+   - Insert NodeEntry with `parent` derived from the path structure (creating directory nodes as needed).
+4. **Connect to the server.** The server will either:
+   - Already know us as a v1 client (we've connected before) → ordinary manifest sync catches us up.
+   - Not recognize us → our manifest *is* the initial state; standard bidirectional sync handles the merge with other peers' manifests.
+5. **Server migration is independent.** The server has no `path_map.json`; it has the SQLite `updates` table. A v1 server treats any doc_id that is not the manifest as a legacy content subdoc and keeps serving it. New subdocs created under v1 follow the same schema. There is no schema change needed to SQLite.
+
+### 7.3 Safety
+
+- Migration is **idempotent within a client**: running it twice is a no-op because step 1 is skipped if `.syncline.v0.bak` already exists, and step 2 is skipped if `version = 1`.
+- Migration is **destructive to v0 sync state only**. The user's files on disk are never touched. `.syncline.v0.bak` is retained for manual rollback; users can delete it after confirming v1 works.
+- There is no "mixed mesh" phase. The `MSG_VERSION` handshake refuses v0 clients against a v1 server and vice versa. Deployments must flip atomically (or run two servers side-by-side during rollout, which is a user-space choice, not a protocol concern).
+
+### 7.4 What is not migrated
+
+- **v0 conflict files.** Any pre-existing files named `*.conflict-*` are re-imported as ordinary files. v1 does not try to parse or collapse them.
+- **v0 LWW blob history.** Only the *current* bytes of each binary are imported. Old blob versions from the v0 `blobs` SQLite table are dropped during server-side data sweep (documented operator task; not automatic).
+
+---
+
+## 8. Tombstone GC (Knowledge-Vector Protocol)
+
+### 8.1 Problem
+
+Tombstones in `nodes` (entries with `deleted=true`) grow unbounded if never removed. Removing them too early causes "zombie resurrection": a reconnecting client that still has the pre-delete state re-broadcasts it as new, and the network accepts it because the tombstone is gone.
+
+### 8.2 Protocol
+
+Each client maintains a **knowledge vector** `knowledge : Y.Map<ActorId, Lamport>` inside the manifest — the max lamport this client has seen from every actor it has ever observed. On every sync round (step 7 of §4.2), both peers merge their vectors.
+
+```
+For each actor A in the union of our and peer's vectors:
+    knowledge[A] := max(ours[A], peer's[A])
+```
+
+The minimum across all actors of `knowledge[A]` is the **global low-water-mark** (LWM). Any tombstone whose `tombstoned_at < LWM - SAFETY` is safe to GC: every actor has seen at least up to LWM, so no one holds pre-delete state for that tombstone.
+
+### 8.3 Parameters
+
+- **SAFETY = 30 days** in wall-clock equivalent. Because Lamport ≠ wall clock, we track tombstone age with a separate wall-clock stamp at `tombstoned_at` creation (stored inside `GcMeta`), and apply whichever floor is stricter: `lamport < LWM - lamport_safety` AND `wall_clock_age > 30 days`.
+- **Run on server** (authoritative), pushed to clients as a GC manifest update. Clients never GC unilaterally — they would race with reconnecting peers whose knowledge they don't have.
+
+### 8.4 What GC does
+
+For each GC-eligible tombstone:
+
+1. Emit a manifest update that deletes the `NodeEntry` from `nodes` entirely (not just `deleted=true` — the whole entry).
+2. Delete the corresponding content subdoc snapshot from `.syncline/content/`.
+3. Delete the blob from `.syncline/blobs/` **only if** no other live node references the same `blob_hash` (trivial refcount over `nodes`).
+
+### 8.5 Test-suite interaction
+
+The test suite does not exercise multi-day tombstone GC directly. What it does exercise — deletion propagation after hours/seconds, not after 30 days — is covered by the tombstone-present (`deleted=true`) rules in §5.2 and §6.3.
+
+---
+
+## 9. Test Plan
+
+All 49 tests in PR #38 (`feat/fs-operations-test-coverage`) must pass on v1. Below, each test is mapped to the v1 mechanism responsible for its outcome.
+
+### 9.1 `fs_file_operations.rs` (18 tests)
+
+| Test                                                          | v1 mechanism                                             |
+|---------------------------------------------------------------|----------------------------------------------------------|
+| create/modify/delete online & offline (6 tests)               | §5.1 / §5.5 / §5.2                                       |
+| `test_delete_binary_file_online_removes_on_peer`              | §5.2 — `deleted=true` on NodeEntry; projection hides it  |
+| `test_delete_removes_from_index`                              | §2.3 — no separate index; projection *is* the index      |
+| `test_rapid_create_then_delete_does_not_leak_to_peer`         | Watcher debounce + §5.2 (last-write wins on `deleted`)   |
+| rename text/binary, online/offline (4 tests)                  | §5.3                                                     |
+| `test_rename_empty_file_preserves_identity`                   | §5.3 — NodeId stable across rename; no content-hash needed |
+| `test_move_file_across_directories`                           | §5.4                                                     |
+| `test_modify_while_other_deletes_offline`                     | §6.3 modify-wins-over-delete                             |
+| remaining file-op variants (2 tests)                          | §5.1–§5.5                                                |
+
+### 9.2 `fs_directory_operations.rs` (7 tests)
+
+| Test                                                          | v1 mechanism                                             |
+|---------------------------------------------------------------|----------------------------------------------------------|
+| `test_create_empty_directory_syncs`                           | **Known gap** — documented in §1.2 & §5.6; test will remain ignored or asserts the gap explicitly |
+| `test_create_directory_with_files_syncs`                      | §5.6 — directory node created when first child lands    |
+| `test_delete_directory_removes_all_files_on_peer`             | §5.6 — one transaction tombstones dir + all descendants |
+| `test_empty_directory_cleaned_after_all_files_deleted`        | §5.6 — directory node tombstoned when last child dies   |
+| `test_rename_directory_with_files`                            | §5.6 — O(1) `name` update on directory node             |
+| `test_move_directory_to_new_parent`                           | §5.6 — `parent` update on directory node                |
+| `test_deep_nested_directory_creation`                         | §5.6 — directory nodes created chain-wise               |
+
+### 9.3 `fs_metadata_operations.rs` (5 tests)
+
+| Test                                                          | v1 mechanism                                             |
+|---------------------------------------------------------------|----------------------------------------------------------|
+| hidden-file filter                                            | Watcher-level ignore (unchanged from v0)                 |
+| permission propagation                                        | **Known gap** — §1.2; not in scope for v1                |
+| readonly / touch-no-op                                        | §5.5 — hash-unchanged modify is a no-op                  |
+
+### 9.4 `fs_edge_cases.rs` (15 tests)
+
+| Test                                                          | v1 mechanism                                             |
+|---------------------------------------------------------------|----------------------------------------------------------|
+| unicode / emoji / special-char filenames                      | `name` is a UTF-8 String; no v0-style path escaping      |
+| long filenames (200-char)                                     | No length limit in manifest; OS-level limits apply       |
+| 1MB text file                                                 | Y.Text handles it; SyncStep2 sends the full update       |
+| symlinks / hard links                                         | Followed / treated as content copy (watcher level)       |
+| case variants (e.g. `foo.md` vs `FOO.md` on case-sensitive FS)| Distinct NodeIds, distinct names in manifest             |
+| `test_delete_then_recreate_same_name_different_content`       | New NodeId on recreate; old is tombstoned (§5.2)         |
+| `test_identical_content_different_file_not_mistaken_for_rename` | NodeIds are assigned independently; identical content coincidence is harmless |
+
+### 9.5 `fs_conflict_scenarios.rs` (6 tests)
+
+| Test                                                          | v1 mechanism                                             |
+|---------------------------------------------------------------|----------------------------------------------------------|
+| `test_delete_vs_modify_offline_modification_wins`             | §6.3                                                     |
+| `test_rename_vs_rename_different_names`                       | §6.2                                                     |
+| `test_concurrent_binary_edits_preserves_both`                 | §6.4 — two NodeIds, both live, projected with conflict suffixes |
+| `test_three_client_fanout`                                    | Ordinary manifest broadcast                              |
+| `test_delete_propagates_to_late_reconnecting_client`          | §5.2 + manifest SyncStep2 on reconnect                   |
+| `test_simultaneous_online_create_same_path`                   | §6.4                                                     |
+
+### 9.6 New convergence tests introduced in v1
+
+Beyond the PR #38 suite, v1 adds:
+
+1. `test_manifest_verify_detects_divergence` — inject a manual desync, assert `MSG_MANIFEST_VERIFY` flags it within 30s.
+2. `test_migration_v0_to_v1_preserves_all_files` — populate a v0 vault, run migration, assert every file and its bytes are present in the v1 manifest projection.
+3. `test_tombstone_not_gc_before_lwm` — simulate an offline actor, assert its tombstone is retained until the LWM advances.
+4. `test_cycle_move_rejected_locally` — attempt `mv foo/ foo/bar/`, assert local rejection (not a panic, not a silent corruption).
+
+These are added in a follow-up test commit alongside the implementation.
+
+---
+
+## 10. Open questions (to resolve during implementation)
+
+1. **Directory node creation policy.** Strict "materialize on first child" (current spec) vs. eager "materialize on `mkdir`". Eager would unlock `test_create_empty_directory_syncs` at the cost of watcher churn. Decision deferred to the directory-ops implementation commit.
+2. **Manifest compaction cadence.** When to rewrite `manifest.bin` from `manifest.updates`. Proposal: every 1000 updates or every 10 MB of log, whichever comes first.
+3. **Cross-actor clock skew.** Wall-clock tombstone safety relies on NTP sync. Users with grossly skewed clocks could delay GC by days. Acceptable; documented operator limitation.
+4. **Blob GC on server.** The SQLite `blobs` table grows without bound. Server-side refcount from manifest projections is the obvious answer; cost/complexity tradeoff to assess during server work.
+
+---
+
+## 11. Implementation order (commit-level plan)
+
+1. **Data structures** — `NodeId`, `NodeEntry`, `Manifest` wrapper with Yrs bindings; no wire integration yet. Unit tests for LWW and projection.
+2. **Migration** — v0-layout → v1-manifest, pure function over a fixture vault; unit tests.
+3. **Manifest sync protocol** — `MSG_VERSION`, `MSG_MANIFEST_SYNC` wire-up client+server; integration test `test_two_clients_manifest_converges`.
+4. **Operation handlers** — wire the watcher to §5.1–§5.6 transactions.
+5. **Convergence verification** — `MSG_MANIFEST_VERIFY` + the injection test.
+6. **Test-suite green** — iterate until the 49 PR #38 tests pass.
+7. **Tombstone GC** — server-side; add the LWM test.
+
+Each step ships as an independent commit (or small series) on `release/v1`. Intermediate states may fail some PR #38 tests; that is expected. The branch target is "all 49 pass" before `release/v1` is proposed for merge into `main`.

--- a/syncline/Cargo.toml
+++ b/syncline/Cargo.toml
@@ -38,7 +38,7 @@ tower-http = { version = "0.5", features = ["fs", "trace"] }
 sqlx = { version = "0.7", features = ["runtime-tokio-rustls", "sqlite"] }
 futures = "0.3"
 futures-util = "0.3"
-uuid = { version = "1", features = ["v4", "serde"] }
+uuid = { version = "1", features = ["v4", "v7", "serde"] }
 tracing = "0.1"
 tracing-appender = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/syncline/src/lib.rs
+++ b/syncline/src/lib.rs
@@ -6,3 +6,5 @@ pub mod wasm_client;
 pub mod client;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod server;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod v1;

--- a/syncline/src/protocol.rs
+++ b/syncline/src/protocol.rs
@@ -12,6 +12,36 @@ pub const MSG_RESYNC: u8 = 6;
 /// If the server's content disagrees, it responds with a full SyncStep2.
 pub const MSG_CHECKSUM: u8 = 7;
 
+// ---------------------------------------------------------------------------
+// v1 message types (see docs/DESIGN_DOC_V1.md §4)
+// ---------------------------------------------------------------------------
+
+/// v1: manifest-scoped SyncStep1/SyncStep2/Update. Payload layout mirrors
+/// the v0 per-doc sync frames, but the doc_id field in the outer framing
+/// is always [`MANIFEST_DOC_ID`] and the payload begins with an inner
+/// sub-type byte from [`MANIFEST_STEP_1`] / [`MANIFEST_STEP_2`] /
+/// [`MANIFEST_UPDATE`].
+pub const MSG_MANIFEST_SYNC: u8 = 0x20;
+/// v1: convergence heartbeat — SHA-256 over the projected namespace
+/// (§4.4.1). Mismatch triggers a full manifest SyncStep1.
+pub const MSG_MANIFEST_VERIFY: u8 = 0x21;
+/// v1: protocol version handshake. Must be the first frame on a v1
+/// session. Payload is `[u8 major][u8 minor]`.
+pub const MSG_VERSION: u8 = 0xF0;
+
+/// Reserved doc-id used as the outer `doc_id` field in every v1
+/// manifest-sync frame.
+pub const MANIFEST_DOC_ID: &str = "__manifest__";
+
+/// Sub-type byte prefixing `MSG_MANIFEST_SYNC` payloads.
+pub const MANIFEST_STEP_1: u8 = 0;
+pub const MANIFEST_STEP_2: u8 = 1;
+pub const MANIFEST_UPDATE: u8 = 2;
+
+/// Current v1 protocol version.
+pub const V1_PROTOCOL_MAJOR: u8 = 1;
+pub const V1_PROTOCOL_MINOR: u8 = 0;
+
 /// Maximum blob size in bytes (50 MB).
 pub const MAX_BLOB_SIZE: usize = 50 * 1024 * 1024;
 

--- a/syncline/src/v1/ids.rs
+++ b/syncline/src/v1/ids.rs
@@ -1,0 +1,261 @@
+//! Identifier types for the v1 manifest CRDT.
+//!
+//! All three are thin newtypes so the type system prevents accidental
+//! confusion (a `Lamport` is not a `u64`, a `NodeId` is not a `String`).
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use uuid::Uuid;
+
+/// Per-file stable identity. UUIDv7 is used so IDs sort by creation time,
+/// which is useful for the LWW tie-break and for debugging.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct NodeId(pub Uuid);
+
+impl NodeId {
+    pub fn new() -> Self {
+        NodeId(Uuid::now_v7())
+    }
+
+    pub fn from_uuid(u: Uuid) -> Self {
+        NodeId(u)
+    }
+
+    pub fn as_uuid(&self) -> Uuid {
+        self.0
+    }
+
+    pub fn to_string_hyphenated(&self) -> String {
+        self.0.as_hyphenated().to_string()
+    }
+
+    pub fn parse_str(s: &str) -> Option<Self> {
+        Uuid::parse_str(s).ok().map(NodeId)
+    }
+}
+
+impl Default for NodeId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl fmt::Debug for NodeId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "NodeId({})", self.0.as_hyphenated())
+    }
+}
+
+impl fmt::Display for NodeId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0.as_hyphenated())
+    }
+}
+
+/// One per installation. Generated once, persisted in
+/// `.syncline/actor_id`, never changes. UUIDv4 — random, not temporal.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct ActorId(pub Uuid);
+
+impl ActorId {
+    pub fn new() -> Self {
+        ActorId(Uuid::new_v4())
+    }
+
+    pub fn from_uuid(u: Uuid) -> Self {
+        ActorId(u)
+    }
+
+    pub fn as_uuid(&self) -> Uuid {
+        self.0
+    }
+
+    pub fn to_string_hyphenated(&self) -> String {
+        self.0.as_hyphenated().to_string()
+    }
+
+    pub fn parse_str(s: &str) -> Option<Self> {
+        Uuid::parse_str(s).ok().map(ActorId)
+    }
+
+    /// Short form for use in conflict filenames (first 8 hex chars).
+    pub fn short(&self) -> String {
+        self.0.as_simple().to_string()[..8].to_string()
+    }
+}
+
+impl Default for ActorId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl fmt::Debug for ActorId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "ActorId({})", self.0.as_hyphenated())
+    }
+}
+
+impl fmt::Display for ActorId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0.as_hyphenated())
+    }
+}
+
+/// Per-actor monotonic counter. Combined with `ActorId` in an LWW tuple
+/// `(Lamport, ActorId)` with Lamport max-wins, ActorId lex tie-break.
+///
+/// Advance rule: on every observed remote update, set `self = max(self,
+/// remote + 1)`. On every local transaction, increment by one. The
+/// counter is persisted to `.syncline/lamport` after each transaction.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct Lamport(pub u64);
+
+impl Lamport {
+    pub const ZERO: Lamport = Lamport(0);
+
+    pub fn get(&self) -> u64 {
+        self.0
+    }
+
+    /// Produce the next local timestamp and advance `self`. Used at the
+    /// top of every local transaction.
+    pub fn tick(&mut self) -> Lamport {
+        self.0 += 1;
+        *self
+    }
+
+    /// Observe a remote timestamp; self becomes `max(self, remote + 1)`.
+    pub fn observe(&mut self, remote: Lamport) {
+        if remote.0 + 1 > self.0 {
+            self.0 = remote.0 + 1;
+        }
+    }
+}
+
+impl fmt::Debug for Lamport {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "L{}", self.0)
+    }
+}
+
+impl fmt::Display for Lamport {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// LWW ordering key. Max-wins on `lamport`, then lex-wins on `actor`.
+/// Used throughout projection.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub struct Stamp {
+    pub lamport: Lamport,
+    pub actor: ActorId,
+}
+
+impl Stamp {
+    pub fn new(lamport: Lamport, actor: ActorId) -> Self {
+        Self { lamport, actor }
+    }
+
+    /// Returns `true` if `self` beats `other` in LWW order.
+    pub fn beats(&self, other: &Stamp) -> bool {
+        match self.lamport.cmp(&other.lamport) {
+            std::cmp::Ordering::Greater => true,
+            std::cmp::Ordering::Less => false,
+            std::cmp::Ordering::Equal => self.actor > other.actor,
+        }
+    }
+}
+
+impl PartialOrd for Stamp {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Stamp {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.lamport
+            .cmp(&other.lamport)
+            .then_with(|| self.actor.cmp(&other.actor))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn node_id_roundtrip() {
+        let id = NodeId::new();
+        let s = id.to_string_hyphenated();
+        assert_eq!(NodeId::parse_str(&s), Some(id));
+    }
+
+    #[test]
+    fn uuidv7_sorts_temporally() {
+        let a = NodeId::new();
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        let b = NodeId::new();
+        assert!(a < b, "later UUIDv7 should sort after earlier one");
+    }
+
+    #[test]
+    fn actor_short_is_eight_chars() {
+        let a = ActorId::new();
+        assert_eq!(a.short().len(), 8);
+    }
+
+    #[test]
+    fn lamport_tick_is_monotonic() {
+        let mut l = Lamport::ZERO;
+        assert_eq!(l.tick(), Lamport(1));
+        assert_eq!(l.tick(), Lamport(2));
+        assert_eq!(l.tick(), Lamport(3));
+    }
+
+    #[test]
+    fn lamport_observe_advances_past_remote() {
+        let mut l = Lamport(5);
+        l.observe(Lamport(10));
+        assert_eq!(l, Lamport(11));
+    }
+
+    #[test]
+    fn lamport_observe_ignores_older_remote() {
+        let mut l = Lamport(100);
+        l.observe(Lamport(5));
+        assert_eq!(l, Lamport(100));
+    }
+
+    #[test]
+    fn stamp_beats_by_lamport() {
+        let a = ActorId::new();
+        let b = ActorId::new();
+        let s1 = Stamp::new(Lamport(1), a);
+        let s2 = Stamp::new(Lamport(2), b);
+        assert!(s2.beats(&s1));
+        assert!(!s1.beats(&s2));
+    }
+
+    #[test]
+    fn stamp_beats_by_actor_on_lamport_tie() {
+        let (lo, hi) = {
+            let a = ActorId::new();
+            let b = ActorId::new();
+            if a < b { (a, b) } else { (b, a) }
+        };
+        let s1 = Stamp::new(Lamport(5), lo);
+        let s2 = Stamp::new(Lamport(5), hi);
+        assert!(s2.beats(&s1));
+        assert!(!s1.beats(&s2));
+    }
+
+    #[test]
+    fn stamp_does_not_beat_self() {
+        let a = ActorId::new();
+        let s = Stamp::new(Lamport(5), a);
+        assert!(!s.beats(&s));
+    }
+}

--- a/syncline/src/v1/manifest.rs
+++ b/syncline/src/v1/manifest.rs
@@ -1,0 +1,565 @@
+//! The manifest Y.Doc — v1's single source of truth for the vault
+//! namespace. See `docs/DESIGN_DOC_V1.md` §2 and §3.2.
+//!
+//! The Yrs document has one top-level `Y.Map` named `"nodes"`. Each key
+//! is a `NodeId` (UUIDv7, hyphenated) and each value is a nested
+//! `Y.Map` holding the `NodeEntry` fields.
+//!
+//! Field layout inside an entry sub-map (all values are `Any` primitives):
+//!
+//! | key          | type    | meaning                                          |
+//! |--------------|---------|--------------------------------------------------|
+//! | `name`       | String  | last path segment                                |
+//! | `parent`     | String  | parent NodeId, empty string = vault root         |
+//! | `deleted`    | bool    | tombstone flag                                   |
+//! | `kind`       | String  | `"text"` / `"binary"` / `"directory"`            |
+//! | `blob`       | String  | hex SHA-256, absent unless `kind == "binary"`    |
+//! | `size`       | i64     | bytes (hint for UI / GC)                         |
+//! | `created_at` | i64     | lamport of the create event (immutable)          |
+//! | `c_actor`    | String  | actor that created the entry (immutable)         |
+//! | `del_lamp`   | i64     | lamport of the most recent `deleted=true` write  |
+//! | `del_actor`  | String  | actor of the most recent `deleted=true` write    |
+//! | `mod_lamp`   | i64     | lamport of the most recent content modification  |
+//! | `mod_actor`  | String  | actor of the most recent content modification    |
+//!
+//! The `(del_lamp, del_actor)` and `(mod_lamp, mod_actor)` stamps are
+//! compared at projection time to implement
+//! **modify-wins-over-delete** (§6.3 of the design doc).
+
+use super::ids::{ActorId, Lamport, NodeId, Stamp};
+use std::collections::HashMap;
+use yrs::{Any, Doc, Map, MapPrelim, MapRef, Out, ReadTxn, Transact};
+
+/// Classification of a node. Immutable after the node is created.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum NodeKind {
+    Text,
+    Binary,
+    Directory,
+}
+
+impl NodeKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            NodeKind::Text => "text",
+            NodeKind::Binary => "binary",
+            NodeKind::Directory => "directory",
+        }
+    }
+
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "text" => Some(NodeKind::Text),
+            "binary" => Some(NodeKind::Binary),
+            "directory" => Some(NodeKind::Directory),
+            _ => None,
+        }
+    }
+}
+
+/// A projected view of one entry in the manifest. This is what read
+/// paths and the projection code consume; never held long-term.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NodeEntry {
+    pub id: NodeId,
+    pub name: String,
+    pub parent: Option<NodeId>,
+    pub deleted: bool,
+    pub kind: NodeKind,
+    pub blob_hash: Option<String>,
+    pub size: u64,
+    pub created_at: Lamport,
+    pub created_by: ActorId,
+    pub delete_stamp: Option<Stamp>,
+    pub modify_stamp: Option<Stamp>,
+}
+
+impl NodeEntry {
+    /// Effective lamport for LWW comparisons at projection time. Takes
+    /// the max of `created_at` and any field-write stamp we've recorded.
+    pub fn effective_stamp(&self) -> Stamp {
+        let create = Stamp::new(self.created_at, self.created_by);
+        let candidates = [Some(create), self.delete_stamp, self.modify_stamp];
+        candidates.into_iter().flatten().max().unwrap()
+    }
+}
+
+/// Wraps a Yrs `Doc` with a typed API for the manifest schema. Owns the
+/// local actor id and lamport counter; each mutating method bumps the
+/// counter and stamps the written fields.
+pub struct Manifest {
+    doc: Doc,
+    nodes: MapRef,
+    actor: ActorId,
+    lamport: Lamport,
+}
+
+impl Manifest {
+    /// Create an empty manifest for `actor`. Lamport starts at 0.
+    pub fn new(actor: ActorId) -> Self {
+        let doc = Doc::new();
+        let nodes = doc.get_or_insert_map("nodes");
+        Self {
+            doc,
+            nodes,
+            actor,
+            lamport: Lamport::ZERO,
+        }
+    }
+
+    /// Rehydrate a manifest from a Yrs state update (as produced by
+    /// `encode_state_as_update`).
+    pub fn from_update(actor: ActorId, lamport: Lamport, update: &[u8]) -> anyhow::Result<Self> {
+        use yrs::updates::decoder::Decode;
+        let doc = Doc::new();
+        let nodes = doc.get_or_insert_map("nodes");
+        {
+            let mut txn = doc.transact_mut();
+            let update = yrs::Update::decode_v1(update)?;
+            txn.apply_update(update);
+        }
+        Ok(Self {
+            doc,
+            nodes,
+            actor,
+            lamport,
+        })
+    }
+
+    pub fn actor(&self) -> ActorId {
+        self.actor
+    }
+
+    pub fn lamport(&self) -> Lamport {
+        self.lamport
+    }
+
+    /// Expose the underlying Yrs doc so callers can subscribe to
+    /// updates, encode state, apply remote updates, etc.
+    pub fn doc(&self) -> &Doc {
+        &self.doc
+    }
+
+    /// Encode the full current state for a fresh peer.
+    pub fn encode_state_as_update(&self) -> Vec<u8> {
+        let txn = self.doc.transact();
+        txn.encode_state_as_update_v1(&yrs::StateVector::default())
+    }
+
+    /// Apply a remote Yrs update and advance our lamport past anything
+    /// the update carried. Returns `Ok(())` on success.
+    pub fn apply_update(&mut self, update: &[u8]) -> anyhow::Result<()> {
+        use yrs::updates::decoder::Decode;
+        let update = yrs::Update::decode_v1(update)?;
+        {
+            let mut txn = self.doc.transact_mut();
+            txn.apply_update(update);
+        }
+        // Scan for any lamport stamps newer than ours and advance.
+        let max_seen = self.max_lamport_in_doc();
+        if let Some(m) = max_seen {
+            self.lamport.observe(m);
+        }
+        Ok(())
+    }
+
+    fn max_lamport_in_doc(&self) -> Option<Lamport> {
+        let txn = self.doc.transact();
+        let mut max: Option<u64> = None;
+        for (_id, out) in self.nodes.iter(&txn) {
+            let Out::YMap(m) = out else { continue };
+            for field in ["created_at", "del_lamp", "mod_lamp"] {
+                if let Some(v) = read_u64(&m, &txn, field) {
+                    max = Some(max.map_or(v, |cur| cur.max(v)));
+                }
+            }
+        }
+        max.map(Lamport)
+    }
+
+    // ------------------------------------------------------------------
+    // Mutating API — every method bumps the local lamport once.
+    // ------------------------------------------------------------------
+
+    /// Insert a brand-new node. Returns the chosen `NodeId`.
+    pub fn create_node(
+        &mut self,
+        name: &str,
+        parent: Option<NodeId>,
+        kind: NodeKind,
+        blob_hash: Option<&str>,
+        size: u64,
+    ) -> NodeId {
+        let id = NodeId::new();
+        let lamp = self.lamport.tick();
+        let actor = self.actor;
+        let parent_str = parent
+            .map(|p| p.to_string_hyphenated())
+            .unwrap_or_default();
+
+        let entry = MapPrelim::from([
+            ("name", Any::from(name.to_string())),
+            ("parent", Any::from(parent_str)),
+            ("deleted", Any::from(false)),
+            ("kind", Any::from(kind.as_str().to_string())),
+            (
+                "blob",
+                Any::from(blob_hash.unwrap_or("").to_string()),
+            ),
+            ("size", Any::from(size as i64)),
+            ("created_at", Any::from(lamp.get() as i64)),
+            ("c_actor", Any::from(actor.to_string_hyphenated())),
+        ]);
+
+        let mut txn = self.doc.transact_mut();
+        self.nodes.insert(&mut txn, id.to_string_hyphenated(), entry);
+        id
+    }
+
+    /// Rename: update the `name` field on an existing node.
+    /// No-op if the node does not exist.
+    pub fn set_name(&mut self, id: NodeId, new_name: &str) -> bool {
+        let lamp = self.lamport.tick();
+        let actor = self.actor;
+        let actor_str = actor.to_string_hyphenated();
+        let mut txn = self.doc.transact_mut();
+        let Some(entry) = get_entry_map(&self.nodes, &txn, id) else {
+            return false;
+        };
+        entry.insert(&mut txn, "name", new_name.to_string());
+        entry.insert(&mut txn, "mod_lamp", lamp.get() as i64);
+        entry.insert(&mut txn, "mod_actor", actor_str);
+        true
+    }
+
+    /// Move: update the `parent` field on an existing node.
+    pub fn set_parent(&mut self, id: NodeId, new_parent: Option<NodeId>) -> bool {
+        let lamp = self.lamport.tick();
+        let actor_str = self.actor.to_string_hyphenated();
+        let parent_str = new_parent
+            .map(|p| p.to_string_hyphenated())
+            .unwrap_or_default();
+        let mut txn = self.doc.transact_mut();
+        let Some(entry) = get_entry_map(&self.nodes, &txn, id) else {
+            return false;
+        };
+        entry.insert(&mut txn, "parent", parent_str);
+        entry.insert(&mut txn, "mod_lamp", lamp.get() as i64);
+        entry.insert(&mut txn, "mod_actor", actor_str);
+        true
+    }
+
+    /// Set `deleted=true`. Records (del_lamp, del_actor) for
+    /// modify-wins-over-delete comparisons at projection time.
+    pub fn delete(&mut self, id: NodeId) -> bool {
+        let lamp = self.lamport.tick();
+        let actor_str = self.actor.to_string_hyphenated();
+        let mut txn = self.doc.transact_mut();
+        let Some(entry) = get_entry_map(&self.nodes, &txn, id) else {
+            return false;
+        };
+        entry.insert(&mut txn, "deleted", true);
+        entry.insert(&mut txn, "del_lamp", lamp.get() as i64);
+        entry.insert(&mut txn, "del_actor", actor_str);
+        true
+    }
+
+    /// Record that this actor modified the node's content. Used to
+    /// beat a stale delete at projection time (§6.3). Does not touch
+    /// `name` / `parent`.
+    pub fn record_modify(&mut self, id: NodeId) -> bool {
+        let lamp = self.lamport.tick();
+        let actor_str = self.actor.to_string_hyphenated();
+        let mut txn = self.doc.transact_mut();
+        let Some(entry) = get_entry_map(&self.nodes, &txn, id) else {
+            return false;
+        };
+        entry.insert(&mut txn, "mod_lamp", lamp.get() as i64);
+        entry.insert(&mut txn, "mod_actor", actor_str);
+        true
+    }
+
+    /// Update a binary's blob hash (after CAS push). Also stamps modify.
+    pub fn set_blob_hash(&mut self, id: NodeId, hash: &str, size: u64) -> bool {
+        let lamp = self.lamport.tick();
+        let actor_str = self.actor.to_string_hyphenated();
+        let mut txn = self.doc.transact_mut();
+        let Some(entry) = get_entry_map(&self.nodes, &txn, id) else {
+            return false;
+        };
+        entry.insert(&mut txn, "blob", hash.to_string());
+        entry.insert(&mut txn, "size", size as i64);
+        entry.insert(&mut txn, "mod_lamp", lamp.get() as i64);
+        entry.insert(&mut txn, "mod_actor", actor_str);
+        true
+    }
+
+    // ------------------------------------------------------------------
+    // Read API
+    // ------------------------------------------------------------------
+
+    pub fn get_entry(&self, id: NodeId) -> Option<NodeEntry> {
+        let txn = self.doc.transact();
+        let entry_map = match self.nodes.get(&txn, &id.to_string_hyphenated())? {
+            Out::YMap(m) => m,
+            _ => return None,
+        };
+        decode_entry(id, &entry_map, &txn)
+    }
+
+    pub fn all_entries(&self) -> HashMap<NodeId, NodeEntry> {
+        let txn = self.doc.transact();
+        let mut out = HashMap::new();
+        for (k, v) in self.nodes.iter(&txn) {
+            let Some(id) = NodeId::parse_str(&k) else {
+                continue;
+            };
+            let Out::YMap(m) = v else { continue };
+            if let Some(entry) = decode_entry(id, &m, &txn) {
+                out.insert(id, entry);
+            }
+        }
+        out
+    }
+
+    pub fn live_entries(&self) -> Vec<NodeEntry> {
+        self.all_entries()
+            .into_values()
+            .filter(|e| !e.deleted)
+            .collect()
+    }
+}
+
+fn get_entry_map<T: ReadTxn>(nodes: &MapRef, txn: &T, id: NodeId) -> Option<MapRef> {
+    match nodes.get(txn, &id.to_string_hyphenated())? {
+        Out::YMap(m) => Some(m),
+        _ => None,
+    }
+}
+
+fn decode_entry<T: ReadTxn>(id: NodeId, m: &MapRef, txn: &T) -> Option<NodeEntry> {
+    let name = match m.get(txn, "name") {
+        Some(Out::Any(Any::String(s))) => s.to_string(),
+        _ => return None,
+    };
+    let parent_str = match m.get(txn, "parent") {
+        Some(Out::Any(Any::String(s))) => s.to_string(),
+        _ => String::new(),
+    };
+    let parent = if parent_str.is_empty() {
+        None
+    } else {
+        NodeId::parse_str(&parent_str)
+    };
+    let deleted = matches!(m.get(txn, "deleted"), Some(Out::Any(Any::Bool(true))));
+    let kind = match m.get(txn, "kind") {
+        Some(Out::Any(Any::String(s))) => NodeKind::from_str(&s)?,
+        _ => return None,
+    };
+    let blob_str = match m.get(txn, "blob") {
+        Some(Out::Any(Any::String(s))) => s.to_string(),
+        _ => String::new(),
+    };
+    let blob_hash = if blob_str.is_empty() { None } else { Some(blob_str) };
+    let size = read_u64(m, txn, "size").unwrap_or(0);
+    let created_at = read_u64(m, txn, "created_at")
+        .map(Lamport)
+        .unwrap_or(Lamport::ZERO);
+    let created_by = match m.get(txn, "c_actor") {
+        Some(Out::Any(Any::String(s))) => ActorId::parse_str(&s)?,
+        _ => return None,
+    };
+    let delete_stamp = read_stamp(m, txn, "del_lamp", "del_actor");
+    let modify_stamp = read_stamp(m, txn, "mod_lamp", "mod_actor");
+
+    Some(NodeEntry {
+        id,
+        name,
+        parent,
+        deleted,
+        kind,
+        blob_hash,
+        size,
+        created_at,
+        created_by,
+        delete_stamp,
+        modify_stamp,
+    })
+}
+
+fn read_stamp<T: ReadTxn>(
+    m: &MapRef,
+    txn: &T,
+    lamp_key: &str,
+    actor_key: &str,
+) -> Option<Stamp> {
+    let lamp = read_u64(m, txn, lamp_key)?;
+    let actor = match m.get(txn, actor_key)? {
+        Out::Any(Any::String(s)) => ActorId::parse_str(&s)?,
+        _ => return None,
+    };
+    Some(Stamp::new(Lamport(lamp), actor))
+}
+
+fn read_u64<T: ReadTxn>(m: &MapRef, txn: &T, key: &str) -> Option<u64> {
+    match m.get(txn, key)? {
+        Out::Any(Any::BigInt(v)) => Some(v as u64),
+        Out::Any(Any::Number(v)) => Some(v as u64),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_manifest_has_no_entries() {
+        let m = Manifest::new(ActorId::new());
+        assert!(m.all_entries().is_empty());
+        assert!(m.live_entries().is_empty());
+    }
+
+    #[test]
+    fn create_node_returns_retrievable_entry() {
+        let mut m = Manifest::new(ActorId::new());
+        let id = m.create_node("note.md", None, NodeKind::Text, None, 42);
+        let e = m.get_entry(id).expect("entry must exist");
+        assert_eq!(e.id, id);
+        assert_eq!(e.name, "note.md");
+        assert_eq!(e.parent, None);
+        assert!(!e.deleted);
+        assert_eq!(e.kind, NodeKind::Text);
+        assert_eq!(e.blob_hash, None);
+        assert_eq!(e.size, 42);
+    }
+
+    #[test]
+    fn create_node_bumps_lamport() {
+        let mut m = Manifest::new(ActorId::new());
+        assert_eq!(m.lamport(), Lamport::ZERO);
+        m.create_node("a.md", None, NodeKind::Text, None, 0);
+        assert_eq!(m.lamport(), Lamport(1));
+        m.create_node("b.md", None, NodeKind::Text, None, 0);
+        assert_eq!(m.lamport(), Lamport(2));
+    }
+
+    #[test]
+    fn rename_updates_name_preserves_id() {
+        let mut m = Manifest::new(ActorId::new());
+        let id = m.create_node("old.md", None, NodeKind::Text, None, 0);
+        assert!(m.set_name(id, "new.md"));
+        let e = m.get_entry(id).unwrap();
+        assert_eq!(e.name, "new.md");
+        assert_eq!(e.id, id);
+        assert!(e.modify_stamp.is_some());
+    }
+
+    #[test]
+    fn set_parent_updates_parent() {
+        let mut m = Manifest::new(ActorId::new());
+        let dir = m.create_node("folder", None, NodeKind::Directory, None, 0);
+        let file = m.create_node("file.md", None, NodeKind::Text, None, 0);
+        assert!(m.set_parent(file, Some(dir)));
+        let e = m.get_entry(file).unwrap();
+        assert_eq!(e.parent, Some(dir));
+    }
+
+    #[test]
+    fn delete_sets_flag_and_stamp() {
+        let mut m = Manifest::new(ActorId::new());
+        let id = m.create_node("doomed.md", None, NodeKind::Text, None, 0);
+        assert!(m.delete(id));
+        let e = m.get_entry(id).unwrap();
+        assert!(e.deleted);
+        assert!(e.delete_stamp.is_some());
+        // live_entries filters it out
+        assert!(m.live_entries().iter().all(|e| e.id != id));
+    }
+
+    #[test]
+    fn record_modify_sets_mod_stamp() {
+        let mut m = Manifest::new(ActorId::new());
+        let id = m.create_node("f.md", None, NodeKind::Text, None, 0);
+        let before = m.get_entry(id).unwrap().modify_stamp;
+        m.record_modify(id);
+        let after = m.get_entry(id).unwrap().modify_stamp;
+        assert!(after > before);
+    }
+
+    #[test]
+    fn update_on_missing_node_is_noop() {
+        let mut m = Manifest::new(ActorId::new());
+        let ghost = NodeId::new();
+        assert!(!m.set_name(ghost, "nope"));
+        assert!(!m.delete(ghost));
+        assert!(!m.set_parent(ghost, None));
+    }
+
+    #[test]
+    fn encode_decode_roundtrip() {
+        let mut m1 = Manifest::new(ActorId::new());
+        let id = m1.create_node("r.md", None, NodeKind::Text, None, 7);
+        let state = m1.encode_state_as_update();
+
+        let m2 = Manifest::from_update(ActorId::new(), Lamport::ZERO, &state).unwrap();
+        let e = m2.get_entry(id).unwrap();
+        assert_eq!(e.name, "r.md");
+        assert_eq!(e.size, 7);
+    }
+
+    #[test]
+    fn apply_update_advances_lamport() {
+        let mut m1 = Manifest::new(ActorId::new());
+        m1.create_node("a", None, NodeKind::Text, None, 0);
+        m1.create_node("b", None, NodeKind::Text, None, 0);
+        m1.create_node("c", None, NodeKind::Text, None, 0);
+        assert_eq!(m1.lamport(), Lamport(3));
+
+        let mut m2 = Manifest::new(ActorId::new());
+        assert_eq!(m2.lamport(), Lamport::ZERO);
+        m2.apply_update(&m1.encode_state_as_update()).unwrap();
+        // Must be at least 3 after observing m1's stamps (lamport advance rule).
+        assert!(m2.lamport().get() >= 3);
+    }
+
+    #[test]
+    fn binary_node_preserves_blob_hash() {
+        let mut m = Manifest::new(ActorId::new());
+        let id = m.create_node(
+            "img.png",
+            None,
+            NodeKind::Binary,
+            Some("abcd1234"),
+            1024,
+        );
+        let e = m.get_entry(id).unwrap();
+        assert_eq!(e.kind, NodeKind::Binary);
+        assert_eq!(e.blob_hash.as_deref(), Some("abcd1234"));
+        m.set_blob_hash(id, "ef567890", 2048);
+        let e = m.get_entry(id).unwrap();
+        assert_eq!(e.blob_hash.as_deref(), Some("ef567890"));
+        assert_eq!(e.size, 2048);
+    }
+
+    #[test]
+    fn two_clients_converge_on_same_state() {
+        let mut m1 = Manifest::new(ActorId::new());
+        let mut m2 = Manifest::new(ActorId::new());
+
+        let id1 = m1.create_node("one.md", None, NodeKind::Text, None, 10);
+        let id2 = m2.create_node("two.md", None, NodeKind::Text, None, 20);
+
+        // Exchange updates
+        let u1 = m1.encode_state_as_update();
+        let u2 = m2.encode_state_as_update();
+        m2.apply_update(&u1).unwrap();
+        m1.apply_update(&u2).unwrap();
+
+        // Both see both entries.
+        for m in [&m1, &m2] {
+            assert!(m.get_entry(id1).is_some());
+            assert!(m.get_entry(id2).is_some());
+        }
+    }
+}

--- a/syncline/src/v1/migration.rs
+++ b/syncline/src/v1/migration.rs
@@ -1,0 +1,461 @@
+//! One-way migration from v0's on-disk layout to a v1 [`Manifest`].
+//!
+//! Reads the per-file Y.Doc snapshots v0 stores under
+//! `.syncline/data/<uuid>.bin`. Each snapshot has a `meta` Y.Map with
+//! `path` / `type` / `blob_hash` fields and, for text files, a
+//! `content` Y.Text. This module drains that into a fresh v1 manifest
+//! plus an in-memory `text_contents` map that the caller uses to seed
+//! the v1 content subdocs.
+//!
+//! Design-doc reference: §7. Migration is local to each client, one-
+//! way, and non-destructive: the caller is expected to rename the v0
+//! `.syncline/` directory to `.syncline.v0.bak/` before running this.
+
+use super::ids::{ActorId, NodeId};
+use super::manifest::{Manifest, NodeKind};
+use anyhow::{Context, Result};
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use yrs::{Any, Doc, GetString, Map, MapRef, Out, Transact};
+
+/// Result of migrating one v0 vault.
+pub struct Migration {
+    /// The fresh v1 manifest, populated with one node per live v0 file
+    /// plus directory nodes for every path prefix that has children.
+    pub manifest: Manifest,
+    /// For each text-kind NodeId, the body extracted from v0's `content`
+    /// Y.Text. The caller populates content subdocs from these.
+    pub text_contents: HashMap<NodeId, String>,
+    /// For each binary-kind NodeId, the SHA-256 hex hash from v0's
+    /// `meta.blob_hash`. The caller uploads blobs as needed.
+    pub binary_hashes: HashMap<NodeId, String>,
+    /// Per-file problems that didn't abort the migration but are worth
+    /// surfacing in logs.
+    pub warnings: Vec<String>,
+}
+
+/// Walk a v0 vault's `.syncline/data/*.bin` snapshots and build a v1
+/// [`Manifest`]. Does not touch the filesystem beyond reading.
+pub fn migrate_v0_vault(vault_root: &Path, actor: ActorId) -> Result<Migration> {
+    let data_dir = vault_root.join(".syncline").join("data");
+    if !data_dir.exists() {
+        // Fresh vault — nothing to migrate.
+        return Ok(Migration {
+            manifest: Manifest::new(actor),
+            text_contents: HashMap::new(),
+            binary_hashes: HashMap::new(),
+            warnings: Vec::new(),
+        });
+    }
+
+    let mut manifest = Manifest::new(actor);
+    let mut text_contents = HashMap::new();
+    let mut binary_hashes = HashMap::new();
+    let mut warnings = Vec::new();
+    // Cache of path-prefix → NodeId for directory nodes, so we reuse
+    // the same directory NodeId across all files that live under it.
+    let mut dir_nodes: HashMap<String, NodeId> = HashMap::new();
+
+    let snapshots = collect_snapshot_paths(&data_dir)?;
+    for snap in snapshots {
+        match read_snapshot(&snap) {
+            Ok(Some(v0)) => {
+                // v0 had a bug where a deleted file kept its .bin around
+                // with an empty meta.path. Skip those.
+                if v0.rel_path.is_empty() {
+                    warnings.push(format!(
+                        "skipped snapshot {} with empty meta.path",
+                        snap.display()
+                    ));
+                    continue;
+                }
+                // v0's "delete = empty text content" projection is also
+                // ghosted: if a text file has empty content AND no
+                // blob_hash (so isn't a binary), treat as deleted.
+                // Discussion in §7.4.
+                if matches!(v0.kind, NodeKind::Text)
+                    && v0.content.as_deref().map(str::is_empty).unwrap_or(true)
+                {
+                    warnings.push(format!(
+                        "skipped ghost-deleted v0 text file {:?}",
+                        v0.rel_path
+                    ));
+                    continue;
+                }
+
+                let parent = ensure_parent_chain(
+                    &mut manifest,
+                    &mut dir_nodes,
+                    &v0.rel_path,
+                );
+
+                let leaf_name = leaf_segment(&v0.rel_path).to_string();
+                let size = match v0.kind {
+                    NodeKind::Text => v0.content.as_ref().map(|s| s.len()).unwrap_or(0) as u64,
+                    NodeKind::Binary => 0,
+                    NodeKind::Directory => 0,
+                };
+
+                let node_id = manifest.create_node(
+                    &leaf_name,
+                    parent,
+                    v0.kind,
+                    v0.blob_hash.as_deref(),
+                    size,
+                );
+
+                match v0.kind {
+                    NodeKind::Text => {
+                        if let Some(body) = v0.content {
+                            text_contents.insert(node_id, body);
+                        }
+                    }
+                    NodeKind::Binary => {
+                        if let Some(h) = v0.blob_hash {
+                            binary_hashes.insert(node_id, h);
+                        }
+                    }
+                    NodeKind::Directory => {
+                        // v0 had no directory docs — unreachable here.
+                    }
+                }
+            }
+            Ok(None) => {
+                warnings.push(format!(
+                    "skipped snapshot {} — missing meta fields",
+                    snap.display()
+                ));
+            }
+            Err(e) => {
+                warnings.push(format!(
+                    "snapshot {} failed to decode: {}",
+                    snap.display(),
+                    e
+                ));
+            }
+        }
+    }
+
+    Ok(Migration {
+        manifest,
+        text_contents,
+        binary_hashes,
+        warnings,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn collect_snapshot_paths(data_dir: &Path) -> Result<Vec<PathBuf>> {
+    let mut out = Vec::new();
+    for entry in fs::read_dir(data_dir).context("reading .syncline/data")? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_file() && path.extension().and_then(|s| s.to_str()) == Some("bin") {
+            out.push(path);
+        }
+    }
+    // Deterministic order — stable NodeId assignment when the caller
+    // cares about reproducibility in tests.
+    out.sort();
+    Ok(out)
+}
+
+struct V0Snapshot {
+    rel_path: String,
+    kind: NodeKind,
+    blob_hash: Option<String>,
+    content: Option<String>,
+}
+
+fn read_snapshot(path: &Path) -> Result<Option<V0Snapshot>> {
+    use yrs::updates::decoder::Decode;
+    let bytes = fs::read(path).with_context(|| format!("reading {}", path.display()))?;
+    let update = yrs::Update::decode_v1(&bytes)
+        .with_context(|| format!("decoding v1 update in {}", path.display()))?;
+    let doc = Doc::new();
+    {
+        let mut txn = doc.transact_mut();
+        txn.apply_update(update);
+    }
+
+    let meta: MapRef = doc.get_or_insert_map("meta");
+    let rel_path = match read_meta_string(&doc, &meta, "path") {
+        Some(s) => s,
+        None => return Ok(None),
+    };
+    let kind_str = read_meta_string(&doc, &meta, "type").unwrap_or_else(|| "text".to_string());
+    let kind = match kind_str.as_str() {
+        "binary" => NodeKind::Binary,
+        _ => NodeKind::Text,
+    };
+    let blob_hash = read_meta_string(&doc, &meta, "blob_hash")
+        .filter(|s| !s.is_empty());
+
+    let content = if matches!(kind, NodeKind::Text) {
+        let t = doc.get_or_insert_text("content");
+        let txn = doc.transact();
+        Some(t.get_string(&txn))
+    } else {
+        None
+    };
+
+    Ok(Some(V0Snapshot {
+        rel_path,
+        kind,
+        blob_hash,
+        content,
+    }))
+}
+
+fn read_meta_string(doc: &Doc, meta: &MapRef, key: &str) -> Option<String> {
+    let txn = doc.transact();
+    match meta.get(&txn, key) {
+        Some(Out::Any(Any::String(s))) => Some(s.to_string()),
+        _ => None,
+    }
+}
+
+/// Returns the leaf segment of a relative path (`"a/b/c.md"` → `"c.md"`).
+fn leaf_segment(rel: &str) -> &str {
+    rel.rsplit('/').next().unwrap_or(rel)
+}
+
+/// Ensure every ancestor directory of `rel_path` exists as a Directory
+/// node in the manifest. Returns the parent NodeId of the leaf (None
+/// if the leaf sits at the vault root).
+fn ensure_parent_chain(
+    manifest: &mut Manifest,
+    dir_nodes: &mut HashMap<String, NodeId>,
+    rel_path: &str,
+) -> Option<NodeId> {
+    let segments: Vec<&str> = rel_path.split('/').collect();
+    if segments.len() <= 1 {
+        return None;
+    }
+    let prefix_segments = &segments[..segments.len() - 1];
+
+    let mut parent: Option<NodeId> = None;
+    let mut accum = String::new();
+    for seg in prefix_segments {
+        if !accum.is_empty() {
+            accum.push('/');
+        }
+        accum.push_str(seg);
+
+        let id = if let Some(id) = dir_nodes.get(&accum) {
+            *id
+        } else {
+            let id = manifest.create_node(seg, parent, NodeKind::Directory, None, 0);
+            dir_nodes.insert(accum.clone(), id);
+            id
+        };
+        parent = Some(id);
+    }
+    parent
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::client::storage::save_doc;
+    use crate::v1::projection::project;
+    use std::path::Path;
+    use tempfile::TempDir;
+    use uuid::Uuid;
+    use yrs::{Doc, Map, Text, Transact};
+
+    /// Build a minimal v0 layout: `.syncline/data/<uuid>.bin` per file.
+    fn make_v0_snapshot(
+        data_dir: &Path,
+        rel_path: &str,
+        kind: &str,
+        content: Option<&str>,
+        blob_hash: Option<&str>,
+    ) {
+        let doc = Doc::new();
+        let meta = doc.get_or_insert_map("meta");
+        {
+            let mut txn = doc.transact_mut();
+            meta.insert(&mut txn, "path", rel_path.to_string());
+            meta.insert(&mut txn, "type", kind.to_string());
+            if let Some(h) = blob_hash {
+                meta.insert(&mut txn, "blob_hash", h.to_string());
+            }
+        }
+        if let Some(body) = content {
+            let t = doc.get_or_insert_text("content");
+            let mut txn = doc.transact_mut();
+            t.insert(&mut txn, 0, body);
+        }
+        fs::create_dir_all(data_dir).unwrap();
+        let path = data_dir.join(format!("{}.bin", Uuid::new_v4()));
+        save_doc(&doc, &path).unwrap();
+    }
+
+    #[test]
+    fn migrate_fresh_vault_is_empty() {
+        let vault = TempDir::new().unwrap();
+        let m = migrate_v0_vault(vault.path(), ActorId::new()).unwrap();
+        assert!(m.manifest.live_entries().is_empty());
+        assert!(m.text_contents.is_empty());
+        assert!(m.binary_hashes.is_empty());
+    }
+
+    #[test]
+    fn migrate_single_text_file() {
+        let vault = TempDir::new().unwrap();
+        let data = vault.path().join(".syncline/data");
+        make_v0_snapshot(&data, "hello.md", "text", Some("world"), None);
+
+        let m = migrate_v0_vault(vault.path(), ActorId::new()).unwrap();
+        assert_eq!(m.manifest.live_entries().len(), 1);
+        let entry = &m.manifest.live_entries()[0];
+        assert_eq!(entry.name, "hello.md");
+        assert_eq!(entry.parent, None);
+        assert_eq!(entry.kind, NodeKind::Text);
+        let body = m.text_contents.get(&entry.id).expect("body migrated");
+        assert_eq!(body, "world");
+    }
+
+    #[test]
+    fn migrate_nested_path_creates_directory_nodes() {
+        let vault = TempDir::new().unwrap();
+        let data = vault.path().join(".syncline/data");
+        make_v0_snapshot(&data, "a/b/c.md", "text", Some("deep"), None);
+
+        let m = migrate_v0_vault(vault.path(), ActorId::new()).unwrap();
+        let entries = m.manifest.live_entries();
+        // c.md + a + b = 3 nodes
+        assert_eq!(entries.len(), 3);
+        // Projection must reassemble the full path.
+        let p = project(&m.manifest);
+        let file_row = p
+            .by_path
+            .get("a/b/c.md")
+            .expect("projection should rebuild nested path");
+        assert_eq!(file_row.kind, NodeKind::Text);
+    }
+
+    #[test]
+    fn migrate_shared_directory_reuses_node() {
+        let vault = TempDir::new().unwrap();
+        let data = vault.path().join(".syncline/data");
+        make_v0_snapshot(&data, "folder/one.md", "text", Some("1"), None);
+        make_v0_snapshot(&data, "folder/two.md", "text", Some("2"), None);
+
+        let m = migrate_v0_vault(vault.path(), ActorId::new()).unwrap();
+        let dir_count = m
+            .manifest
+            .live_entries()
+            .iter()
+            .filter(|e| e.kind == NodeKind::Directory && e.name == "folder")
+            .count();
+        assert_eq!(dir_count, 1, "shared folder must reuse the same dir node");
+
+        let p = project(&m.manifest);
+        assert!(p.by_path.contains_key("folder/one.md"));
+        assert!(p.by_path.contains_key("folder/two.md"));
+    }
+
+    #[test]
+    fn migrate_binary_file_preserves_hash() {
+        let vault = TempDir::new().unwrap();
+        let data = vault.path().join(".syncline/data");
+        make_v0_snapshot(&data, "img.png", "binary", None, Some("cafebabe"));
+
+        let m = migrate_v0_vault(vault.path(), ActorId::new()).unwrap();
+        assert_eq!(m.manifest.live_entries().len(), 1);
+        let entry = &m.manifest.live_entries()[0];
+        assert_eq!(entry.kind, NodeKind::Binary);
+        assert_eq!(entry.blob_hash.as_deref(), Some("cafebabe"));
+        assert_eq!(
+            m.binary_hashes.get(&entry.id).map(|s| s.as_str()),
+            Some("cafebabe")
+        );
+    }
+
+    #[test]
+    fn migrate_skips_ghost_deleted_empty_text() {
+        let vault = TempDir::new().unwrap();
+        let data = vault.path().join(".syncline/data");
+        // v0 bug: delete stored an empty text doc with a valid meta.path.
+        make_v0_snapshot(&data, "was_deleted.md", "text", Some(""), None);
+        make_v0_snapshot(&data, "alive.md", "text", Some("still here"), None);
+
+        let m = migrate_v0_vault(vault.path(), ActorId::new()).unwrap();
+        let names: Vec<_> = m
+            .manifest
+            .live_entries()
+            .iter()
+            .map(|e| e.name.clone())
+            .collect();
+        assert_eq!(names, vec!["alive.md".to_string()]);
+        assert!(m.warnings.iter().any(|w| w.contains("ghost-deleted")));
+    }
+
+    #[test]
+    fn migrate_skips_snapshot_with_empty_path() {
+        let vault = TempDir::new().unwrap();
+        let data = vault.path().join(".syncline/data");
+        make_v0_snapshot(&data, "", "text", Some("no path"), None);
+
+        let m = migrate_v0_vault(vault.path(), ActorId::new()).unwrap();
+        assert!(m.manifest.live_entries().is_empty());
+        assert!(m.warnings.iter().any(|w| w.contains("empty meta.path")));
+    }
+
+    #[test]
+    fn migrate_mixed_vault_projects_correctly() {
+        let vault = TempDir::new().unwrap();
+        let data = vault.path().join(".syncline/data");
+        make_v0_snapshot(&data, "note.md", "text", Some("root note"), None);
+        make_v0_snapshot(&data, "folder/sub.md", "text", Some("sub note"), None);
+        make_v0_snapshot(&data, "folder/pic.png", "binary", None, Some("deadbeef"));
+
+        let m = migrate_v0_vault(vault.path(), ActorId::new()).unwrap();
+        let p = project(&m.manifest);
+
+        assert_eq!(p.len(), 3, "three user files projected");
+        assert!(p.by_path.contains_key("note.md"));
+        assert!(p.by_path.contains_key("folder/sub.md"));
+        assert!(p.by_path.contains_key("folder/pic.png"));
+        assert_eq!(
+            p.by_path["folder/pic.png"].blob_hash.as_deref(),
+            Some("deadbeef")
+        );
+    }
+
+    #[test]
+    fn migrate_stable_regardless_of_scan_order() {
+        // Two snapshots with paths chosen so their temp filenames could
+        // be processed in either order; migration must still reuse the
+        // shared `folder` dir node.
+        let vault = TempDir::new().unwrap();
+        let data = vault.path().join(".syncline/data");
+        for i in 0..10 {
+            make_v0_snapshot(
+                &data,
+                &format!("folder/file_{i:02}.md"),
+                "text",
+                Some(&format!("body {i}")),
+                None,
+            );
+        }
+        let m = migrate_v0_vault(vault.path(), ActorId::new()).unwrap();
+
+        let dir_count = m
+            .manifest
+            .live_entries()
+            .iter()
+            .filter(|e| e.kind == NodeKind::Directory)
+            .count();
+        assert_eq!(dir_count, 1);
+
+        let p = project(&m.manifest);
+        assert_eq!(p.len(), 10);
+    }
+}

--- a/syncline/src/v1/mod.rs
+++ b/syncline/src/v1/mod.rs
@@ -19,8 +19,10 @@
 
 pub mod ids;
 pub mod manifest;
+pub mod migration;
 pub mod projection;
 
 pub use ids::{ActorId, Lamport, NodeId};
 pub use manifest::{Manifest, NodeEntry, NodeKind};
+pub use migration::{migrate_v0_vault, Migration};
 pub use projection::{ProjectedEntry, Projection};

--- a/syncline/src/v1/mod.rs
+++ b/syncline/src/v1/mod.rs
@@ -21,8 +21,14 @@ pub mod ids;
 pub mod manifest;
 pub mod migration;
 pub mod projection;
+pub mod sync;
 
 pub use ids::{ActorId, Lamport, NodeId};
 pub use manifest::{Manifest, NodeEntry, NodeKind};
 pub use migration::{migrate_v0_vault, Migration};
 pub use projection::{ProjectedEntry, Projection};
+pub use sync::{
+    decode_version_handshake, encode_manifest_step1, encode_manifest_step2,
+    encode_manifest_update, encode_version_handshake, handle_manifest_payload,
+    manifest_step1_payload, manifest_step2_payload, split_manifest_payload,
+};

--- a/syncline/src/v1/mod.rs
+++ b/syncline/src/v1/mod.rs
@@ -20,12 +20,17 @@
 pub mod ids;
 pub mod manifest;
 pub mod migration;
+pub mod ops;
 pub mod projection;
 pub mod sync;
 
 pub use ids::{ActorId, Lamport, NodeId};
 pub use manifest::{Manifest, NodeEntry, NodeKind};
 pub use migration::{migrate_v0_vault, Migration};
+pub use ops::{
+    create_binary, create_text, delete as delete_path, record_modify_binary, record_modify_text,
+    rename,
+};
 pub use projection::{ProjectedEntry, Projection};
 pub use sync::{
     decode_version_handshake, encode_manifest_step1, encode_manifest_step2,

--- a/syncline/src/v1/mod.rs
+++ b/syncline/src/v1/mod.rs
@@ -33,7 +33,8 @@ pub use ops::{
 };
 pub use projection::{ProjectedEntry, Projection};
 pub use sync::{
-    decode_version_handshake, encode_manifest_step1, encode_manifest_step2,
-    encode_manifest_update, encode_version_handshake, handle_manifest_payload,
-    manifest_step1_payload, manifest_step2_payload, split_manifest_payload,
+    decode_verify_payload, decode_version_handshake, encode_manifest_step1,
+    encode_manifest_step2, encode_manifest_update, encode_verify_payload,
+    encode_version_handshake, handle_manifest_payload, handle_verify_payload,
+    manifest_step1_payload, manifest_step2_payload, projection_hash, split_manifest_payload,
 };

--- a/syncline/src/v1/mod.rs
+++ b/syncline/src/v1/mod.rs
@@ -1,0 +1,26 @@
+//! Syncline v1 — manifest-CRDT core.
+//!
+//! This module is the entry point for the v1 rewrite described in
+//! `docs/DESIGN_DOC_V1.md`. It contains only pure data structures and
+//! projection logic; wire integration, migration, and operation handlers
+//! land in follow-up commits on `release/v1`.
+//!
+//! Layering:
+//!
+//! - [`ids`]        — `NodeId`, `ActorId`, `Lamport` newtypes.
+//! - [`manifest`]   — Yrs-backed manifest Y.Doc with `NodeEntry` CRUD.
+//! - [`projection`] — projects the manifest into the vault namespace
+//!                    (path → NodeEntry map), applying conflict-copy
+//!                    suffixes and the modify-wins-over-delete rule.
+//!
+//! None of this is wired into the client or server yet.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+pub mod ids;
+pub mod manifest;
+pub mod projection;
+
+pub use ids::{ActorId, Lamport, NodeId};
+pub use manifest::{Manifest, NodeEntry, NodeKind};
+pub use projection::{ProjectedEntry, Projection};

--- a/syncline/src/v1/ops.rs
+++ b/syncline/src/v1/ops.rs
@@ -1,0 +1,418 @@
+//! v1 operation layer — path-level intents (create / delete / rename /
+//! modify) expressed against a [`Manifest`].
+//!
+//! The manifest mutators in `manifest.rs` operate on `NodeId`s; this
+//! module translates user-facing *paths* into those writes and owns
+//! the emergent-directory rule (§5.6 of the design doc). Name /
+//! parent changes go through `set_name` / `set_parent`; blob updates
+//! go through `set_blob_hash` and stamp modify. Conflict handling
+//! (§6) remains projection-time.
+//!
+//! All operations are idempotent only in the CRDT sense: a second
+//! call with the same intent may produce a second write and bump
+//! lamports again. Callers that care should diff against the
+//! projection first.
+
+use super::ids::NodeId;
+use super::manifest::{Manifest, NodeKind};
+use super::projection::project;
+use anyhow::{anyhow, Result};
+
+/// Create a fresh text entry at `path`. Missing parent directories
+/// are materialised as Directory nodes.
+///
+/// Errors:
+/// - `path` is empty or has an empty segment.
+/// - a live entry already projects to `path`.
+pub fn create_text(manifest: &mut Manifest, path: &str, size: u64) -> Result<NodeId> {
+    create_at_path(manifest, path, NodeKind::Text, None, size)
+}
+
+/// Create a fresh binary entry at `path` with its CAS blob hash.
+pub fn create_binary(
+    manifest: &mut Manifest,
+    path: &str,
+    blob_hash: &str,
+    size: u64,
+) -> Result<NodeId> {
+    create_at_path(manifest, path, NodeKind::Binary, Some(blob_hash), size)
+}
+
+/// Mark the entry currently projected at `path` as deleted.
+pub fn delete(manifest: &mut Manifest, path: &str) -> Result<()> {
+    let id = resolve_path(manifest, path)?;
+    if !manifest.delete(id) {
+        return Err(anyhow!("manifest delete failed for {:?}", id));
+    }
+    Ok(())
+}
+
+/// Rename or move the entry at `from` to `to`. A same-parent rename
+/// updates only `name`; a cross-parent move updates `parent` too, and
+/// creates the target's parent chain if needed.
+///
+/// Errors:
+/// - `from` does not resolve.
+/// - `to` is already occupied by a different live entry.
+/// - `to` is malformed (empty leaf).
+pub fn rename(manifest: &mut Manifest, from: &str, to: &str) -> Result<()> {
+    if from == to {
+        return Ok(());
+    }
+    let src_id = resolve_path(manifest, from)?;
+    {
+        let proj = project(manifest);
+        if proj.by_path.contains_key(to) {
+            return Err(anyhow!("target path {:?} already occupied", to));
+        }
+    }
+
+    let (parent_path, leaf) = split_path(to);
+    if leaf.is_empty() {
+        return Err(anyhow!("rename target {:?} has empty leaf", to));
+    }
+
+    let current = manifest
+        .get_entry(src_id)
+        .ok_or_else(|| anyhow!("source {:?} vanished mid-rename", src_id))?;
+    let new_parent = ensure_parent_chain(manifest, parent_path)?;
+
+    if current.name != leaf {
+        manifest.set_name(src_id, leaf);
+    }
+    if current.parent != new_parent {
+        manifest.set_parent(src_id, new_parent);
+    }
+    Ok(())
+}
+
+/// Stamp a text-content modification on the entry at `path`. Used to
+/// beat a stale delete under the modify-wins-over-delete rule (§6.3).
+pub fn record_modify_text(manifest: &mut Manifest, path: &str) -> Result<()> {
+    let id = resolve_path(manifest, path)?;
+    manifest.record_modify(id);
+    Ok(())
+}
+
+/// Update the blob hash of a binary entry at `path`. Also stamps
+/// modify so a stale delete can't resurrect an older blob.
+pub fn record_modify_binary(
+    manifest: &mut Manifest,
+    path: &str,
+    blob_hash: &str,
+    size: u64,
+) -> Result<()> {
+    let id = resolve_path(manifest, path)?;
+    manifest.set_blob_hash(id, blob_hash, size);
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------------
+
+fn resolve_path(manifest: &Manifest, path: &str) -> Result<NodeId> {
+    let proj = project(manifest);
+    proj.by_path
+        .get(path)
+        .map(|r| r.id)
+        .ok_or_else(|| anyhow!("no entry at path {:?}", path))
+}
+
+fn create_at_path(
+    manifest: &mut Manifest,
+    path: &str,
+    kind: NodeKind,
+    blob_hash: Option<&str>,
+    size: u64,
+) -> Result<NodeId> {
+    if path.is_empty() {
+        return Err(anyhow!("empty path"));
+    }
+    {
+        let proj = project(manifest);
+        if proj.by_path.contains_key(path) {
+            return Err(anyhow!("path {:?} already exists", path));
+        }
+    }
+    let (parent_path, leaf) = split_path(path);
+    if leaf.is_empty() {
+        return Err(anyhow!("path {:?} has empty leaf", path));
+    }
+    let parent = ensure_parent_chain(manifest, parent_path)?;
+    Ok(manifest.create_node(leaf, parent, kind, blob_hash, size))
+}
+
+fn split_path(path: &str) -> (&str, &str) {
+    match path.rfind('/') {
+        Some(i) => (&path[..i], &path[i + 1..]),
+        None => ("", path),
+    }
+}
+
+/// Ensure every segment of `parent_path` is materialised as a live
+/// directory node. Returns the leaf parent's NodeId, or `None` when
+/// the target lives at the vault root.
+fn ensure_parent_chain(manifest: &mut Manifest, parent_path: &str) -> Result<Option<NodeId>> {
+    if parent_path.is_empty() {
+        return Ok(None);
+    }
+
+    let mut parent: Option<NodeId> = None;
+    for seg in parent_path.split('/') {
+        if seg.is_empty() {
+            return Err(anyhow!("empty segment in path {:?}", parent_path));
+        }
+        parent = Some(find_or_create_directory(manifest, parent, seg));
+    }
+    Ok(parent)
+}
+
+fn find_or_create_directory(
+    manifest: &mut Manifest,
+    parent: Option<NodeId>,
+    name: &str,
+) -> NodeId {
+    let existing = manifest.all_entries().into_values().find(|e| {
+        !e.deleted && e.kind == NodeKind::Directory && e.name == name && e.parent == parent
+    });
+    if let Some(e) = existing {
+        e.id
+    } else {
+        manifest.create_node(name, parent, NodeKind::Directory, None, 0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::ids::ActorId;
+    use super::super::sync::{handle_manifest_payload, manifest_step1_payload};
+    use super::*;
+
+    #[test]
+    fn create_text_at_root() {
+        let mut m = Manifest::new(ActorId::new());
+        let id = create_text(&mut m, "note.md", 5).unwrap();
+        let e = m.get_entry(id).unwrap();
+        assert_eq!(e.name, "note.md");
+        assert_eq!(e.parent, None);
+        assert_eq!(e.size, 5);
+        let p = project(&m);
+        assert!(p.by_path.contains_key("note.md"));
+    }
+
+    #[test]
+    fn create_text_at_nested_path_creates_dir_chain() {
+        let mut m = Manifest::new(ActorId::new());
+        let id = create_text(&mut m, "a/b/c.md", 0).unwrap();
+        let e = m.get_entry(id).unwrap();
+        assert_eq!(e.name, "c.md");
+        let p = project(&m);
+        assert!(p.by_path.contains_key("a/b/c.md"));
+    }
+
+    #[test]
+    fn create_rejects_empty_path() {
+        let mut m = Manifest::new(ActorId::new());
+        assert!(create_text(&mut m, "", 0).is_err());
+    }
+
+    #[test]
+    fn create_rejects_trailing_slash() {
+        let mut m = Manifest::new(ActorId::new());
+        assert!(create_text(&mut m, "dir/", 0).is_err());
+    }
+
+    #[test]
+    fn create_rejects_duplicate_path() {
+        let mut m = Manifest::new(ActorId::new());
+        create_text(&mut m, "f.md", 0).unwrap();
+        assert!(create_text(&mut m, "f.md", 0).is_err());
+    }
+
+    #[test]
+    fn create_binary_preserves_blob() {
+        let mut m = Manifest::new(ActorId::new());
+        let id = create_binary(&mut m, "img.png", "deadbeef", 1024).unwrap();
+        let e = m.get_entry(id).unwrap();
+        assert_eq!(e.kind, NodeKind::Binary);
+        assert_eq!(e.blob_hash.as_deref(), Some("deadbeef"));
+        assert_eq!(e.size, 1024);
+    }
+
+    #[test]
+    fn siblings_share_parent_directory() {
+        let mut m = Manifest::new(ActorId::new());
+        create_text(&mut m, "folder/a.md", 0).unwrap();
+        create_text(&mut m, "folder/b.md", 0).unwrap();
+        let dir_count = m
+            .live_entries()
+            .iter()
+            .filter(|e| e.kind == NodeKind::Directory && e.name == "folder")
+            .count();
+        assert_eq!(dir_count, 1);
+    }
+
+    #[test]
+    fn delete_removes_from_projection() {
+        let mut m = Manifest::new(ActorId::new());
+        create_text(&mut m, "doomed.md", 0).unwrap();
+        delete(&mut m, "doomed.md").unwrap();
+        let p = project(&m);
+        assert!(!p.by_path.contains_key("doomed.md"));
+    }
+
+    #[test]
+    fn delete_errors_when_missing() {
+        let mut m = Manifest::new(ActorId::new());
+        assert!(delete(&mut m, "ghost.md").is_err());
+    }
+
+    #[test]
+    fn rename_same_parent_updates_name() {
+        let mut m = Manifest::new(ActorId::new());
+        let id = create_text(&mut m, "old.md", 0).unwrap();
+        rename(&mut m, "old.md", "new.md").unwrap();
+        let e = m.get_entry(id).unwrap();
+        assert_eq!(e.name, "new.md");
+        assert_eq!(e.parent, None);
+        let p = project(&m);
+        assert!(p.by_path.contains_key("new.md"));
+        assert!(!p.by_path.contains_key("old.md"));
+    }
+
+    #[test]
+    fn rename_cross_parent_updates_parent() {
+        let mut m = Manifest::new(ActorId::new());
+        let id = create_text(&mut m, "src/file.md", 0).unwrap();
+        rename(&mut m, "src/file.md", "dst/file.md").unwrap();
+        let e = m.get_entry(id).unwrap();
+        assert_eq!(e.name, "file.md");
+        let p = project(&m);
+        assert!(p.by_path.contains_key("dst/file.md"));
+        assert!(!p.by_path.contains_key("src/file.md"));
+    }
+
+    #[test]
+    fn rename_creates_target_directory_chain() {
+        let mut m = Manifest::new(ActorId::new());
+        create_text(&mut m, "note.md", 0).unwrap();
+        rename(&mut m, "note.md", "a/b/note.md").unwrap();
+        let p = project(&m);
+        assert!(p.by_path.contains_key("a/b/note.md"));
+    }
+
+    #[test]
+    fn rename_rejects_occupied_target() {
+        let mut m = Manifest::new(ActorId::new());
+        create_text(&mut m, "a.md", 0).unwrap();
+        create_text(&mut m, "b.md", 0).unwrap();
+        assert!(rename(&mut m, "a.md", "b.md").is_err());
+    }
+
+    #[test]
+    fn rename_rejects_missing_source() {
+        let mut m = Manifest::new(ActorId::new());
+        assert!(rename(&mut m, "ghost.md", "new.md").is_err());
+    }
+
+    #[test]
+    fn rename_same_path_is_noop() {
+        let mut m = Manifest::new(ActorId::new());
+        create_text(&mut m, "x.md", 0).unwrap();
+        let before = m.lamport();
+        rename(&mut m, "x.md", "x.md").unwrap();
+        // No lamport tick — intentional no-op.
+        assert_eq!(m.lamport(), before);
+    }
+
+    #[test]
+    fn record_modify_text_bumps_stamp() {
+        let mut m = Manifest::new(ActorId::new());
+        let id = create_text(&mut m, "m.md", 0).unwrap();
+        let before = m.get_entry(id).unwrap().modify_stamp;
+        record_modify_text(&mut m, "m.md").unwrap();
+        let after = m.get_entry(id).unwrap().modify_stamp;
+        assert!(after > before);
+    }
+
+    #[test]
+    fn record_modify_binary_updates_blob_and_size() {
+        let mut m = Manifest::new(ActorId::new());
+        let id = create_binary(&mut m, "pic.png", "aaaa", 10).unwrap();
+        record_modify_binary(&mut m, "pic.png", "bbbb", 42).unwrap();
+        let e = m.get_entry(id).unwrap();
+        assert_eq!(e.blob_hash.as_deref(), Some("bbbb"));
+        assert_eq!(e.size, 42);
+        assert!(e.modify_stamp.is_some());
+    }
+
+    #[test]
+    fn modify_beats_earlier_delete() {
+        // Scenario: A deletes, B observes the delete via sync, then B
+        // modifies the (tombstoned) entry. B's modify stamp is
+        // strictly newer than A's delete stamp, so projection must
+        // resurrect the entry on both peers.
+        let mut a = Manifest::new(ActorId::new());
+        let id = create_text(&mut a, "race.md", 0).unwrap();
+        let mut b =
+            Manifest::from_update(ActorId::new(), a.lamport(), &a.encode_state_as_update())
+                .unwrap();
+
+        // A deletes first.
+        delete(&mut a, "race.md").unwrap();
+
+        // B observes A's delete.
+        let sb = manifest_step1_payload(&b);
+        let r_for_b = handle_manifest_payload(&mut a, &sb).unwrap().unwrap();
+        handle_manifest_payload(&mut b, &r_for_b).unwrap();
+        // Sanity: B now sees the tombstone.
+        let be = b.get_entry(id).unwrap();
+        assert!(be.deleted, "B should see A's delete before modifying");
+
+        // B modifies the entry by the NodeId it was already holding
+        // (the path no longer resolves because projection filtered the
+        // tombstoned entry — in real use the editor kept the handle).
+        // B's mod_lamp ends up strictly > A's del_lamp.
+        assert!(b.record_modify(id));
+
+        // Sync the modify back to A.
+        let sa = manifest_step1_payload(&a);
+        let r_for_a = handle_manifest_payload(&mut b, &sa).unwrap().unwrap();
+        handle_manifest_payload(&mut a, &r_for_a).unwrap();
+
+        // Both peers agree: modify won over delete.
+        for (label, m) in [("a", &a), ("b", &b)] {
+            let p = project(m);
+            assert!(
+                p.by_path.contains_key("race.md"),
+                "peer {label}: modify-wins-over-delete violated (node {id:?})"
+            );
+        }
+    }
+
+    #[test]
+    fn ops_converge_under_sync() {
+        let mut a = Manifest::new(ActorId::new());
+        let mut b = Manifest::new(ActorId::new());
+
+        create_text(&mut a, "a1.md", 0).unwrap();
+        create_text(&mut a, "shared/from_a.md", 0).unwrap();
+        create_text(&mut b, "b1.md", 0).unwrap();
+        create_text(&mut b, "shared/from_b.md", 0).unwrap();
+
+        let sa = manifest_step1_payload(&a);
+        let sb = manifest_step1_payload(&b);
+        let r_for_a = handle_manifest_payload(&mut b, &sa).unwrap().unwrap();
+        let r_for_b = handle_manifest_payload(&mut a, &sb).unwrap().unwrap();
+        handle_manifest_payload(&mut a, &r_for_a).unwrap();
+        handle_manifest_payload(&mut b, &r_for_b).unwrap();
+
+        let pa = project(&a);
+        let pb = project(&b);
+        for p in ["a1.md", "b1.md", "shared/from_a.md", "shared/from_b.md"] {
+            assert!(pa.by_path.contains_key(p), "A missing {p}");
+            assert!(pb.by_path.contains_key(p), "B missing {p}");
+        }
+    }
+}

--- a/syncline/src/v1/projection.rs
+++ b/syncline/src/v1/projection.rs
@@ -1,0 +1,376 @@
+//! Project a [`Manifest`] into the vault namespace. This is the
+//! read-only layer that takes the raw CRDT state, applies the
+//! conflict-resolution rules from §6 of the design doc, and returns
+//! "what files should exist on disk, and what are their paths".
+//!
+//! The projection is pure and deterministic given identical input —
+//! two peers running with the same manifest will produce identical
+//! path strings, including conflict suffixes.
+
+use super::ids::{NodeId, Stamp};
+use super::manifest::{Manifest, NodeEntry, NodeKind};
+use std::collections::HashMap;
+
+/// One row of the projection.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ProjectedEntry {
+    pub id: NodeId,
+    pub path: String,
+    pub kind: NodeKind,
+    pub blob_hash: Option<String>,
+    pub size: u64,
+    /// `true` if this row was moved into the conflict name-space
+    /// because another entry already owns the winning path.
+    pub is_conflict_copy: bool,
+}
+
+/// Full projection of a manifest. Keyed by the final (post-conflict-
+/// suffix) path so callers can directly decide what to write to disk.
+#[derive(Clone, Debug, Default)]
+pub struct Projection {
+    pub by_path: HashMap<String, ProjectedEntry>,
+    pub by_id: HashMap<NodeId, ProjectedEntry>,
+}
+
+impl Projection {
+    pub fn contains_path(&self, p: &str) -> bool {
+        self.by_path.contains_key(p)
+    }
+
+    pub fn get_by_id(&self, id: NodeId) -> Option<&ProjectedEntry> {
+        self.by_id.get(&id)
+    }
+
+    pub fn len(&self) -> usize {
+        self.by_path.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.by_path.is_empty()
+    }
+}
+
+/// Project the manifest. Applies, in order:
+/// 1. Modify-wins-over-delete (§6.3).
+/// 2. Path assembly via parent chains.
+/// 3. Same-path collision → deterministic conflict suffixes (§6.4).
+pub fn project(manifest: &Manifest) -> Projection {
+    let all = manifest.all_entries();
+
+    // Step 1: decide which entries are live after §6.3.
+    let live: Vec<&NodeEntry> = all
+        .values()
+        .filter(|e| is_live(e))
+        .collect();
+
+    // Step 2: assemble paths. Directories contribute to paths but are
+    // not themselves projected as files (they are emergent — §5.6).
+    let mut rows: Vec<Row> = Vec::new();
+    for e in &live {
+        if e.kind == NodeKind::Directory {
+            continue; // directories don't get a row of their own
+        }
+        let Some(path) = build_path(e, &all) else {
+            continue; // broken parent chain — drop
+        };
+        rows.push(Row {
+            entry: (*e).clone(),
+            base_path: path,
+        });
+    }
+
+    // Step 3: collapse same-path collisions deterministically.
+    // Group by base_path, sort by stamp ascending, winner = argmin, losers get suffixes.
+    let mut groups: HashMap<String, Vec<Row>> = HashMap::new();
+    for r in rows {
+        groups.entry(r.base_path.clone()).or_default().push(r);
+    }
+
+    let mut out = Projection::default();
+    for (base_path, mut group) in groups {
+        // Sort ascending by stamp; winner = first.
+        group.sort_by(|a, b| {
+            a.entry
+                .effective_stamp()
+                .cmp(&b.entry.effective_stamp())
+                .then_with(|| a.entry.id.cmp(&b.entry.id))
+        });
+
+        for (i, row) in group.into_iter().enumerate() {
+            let is_conflict = i > 0;
+            let final_path = if is_conflict {
+                conflict_path(&base_path, row.entry.effective_stamp(), row.entry.id)
+            } else {
+                base_path.clone()
+            };
+            let projected = ProjectedEntry {
+                id: row.entry.id,
+                path: final_path.clone(),
+                kind: row.entry.kind,
+                blob_hash: row.entry.blob_hash.clone(),
+                size: row.entry.size,
+                is_conflict_copy: is_conflict,
+            };
+            out.by_id.insert(projected.id, projected.clone());
+            out.by_path.insert(final_path, projected);
+        }
+    }
+
+    out
+}
+
+struct Row {
+    entry: NodeEntry,
+    base_path: String,
+}
+
+fn is_live(entry: &NodeEntry) -> bool {
+    if !entry.deleted {
+        return true;
+    }
+    // §6.3: a modification with a stamp beating the delete resurrects.
+    match (entry.delete_stamp, entry.modify_stamp) {
+        (Some(d), Some(m)) => m.beats(&d),
+        (Some(_), None) => false,
+        // deleted=true without a delete_stamp shouldn't happen in practice,
+        // but if it does, fall back to the raw flag.
+        (None, _) => false,
+    }
+}
+
+fn build_path(entry: &NodeEntry, all: &HashMap<NodeId, NodeEntry>) -> Option<String> {
+    let mut segments: Vec<String> = vec![entry.name.clone()];
+    let mut cursor = entry.parent;
+    // Guard against pathological cycles (shouldn't occur — see §6.6).
+    let mut hops = 0;
+    const MAX_HOPS: usize = 1024;
+    while let Some(pid) = cursor {
+        hops += 1;
+        if hops > MAX_HOPS {
+            return None;
+        }
+        let parent = all.get(&pid)?;
+        if parent.deleted && parent.kind == NodeKind::Directory {
+            // Parent directory is tombstoned → child is orphaned; drop.
+            // (Cascade delete is expressed explicitly in §5.6 so this is
+            // merely a safety net.)
+            return None;
+        }
+        segments.push(parent.name.clone());
+        cursor = parent.parent;
+    }
+    segments.reverse();
+    Some(segments.join("/"))
+}
+
+/// Conflict-copy naming — deterministic across peers.
+///
+/// `foo.md` → `foo.conflict-<actor8>-<lamp>.md`
+/// `bin`    → `bin.conflict-<actor8>-<lamp>`
+fn conflict_path(base: &str, stamp: Stamp, id: NodeId) -> String {
+    let (stem, ext) = split_ext(base);
+    let actor_short = stamp.actor.short();
+    let lamp = stamp.lamport.get();
+    let node_short = &id.to_string_hyphenated()[..8];
+    if let Some(ext) = ext {
+        format!("{stem}.conflict-{actor_short}-{lamp}-{node_short}.{ext}")
+    } else {
+        format!("{stem}.conflict-{actor_short}-{lamp}-{node_short}")
+    }
+}
+
+fn split_ext(path: &str) -> (&str, Option<&str>) {
+    // Split on the last '.', but only in the final segment (don't
+    // corrupt "foo.bar/baz").
+    let last_slash = path.rfind('/').map(|i| i + 1).unwrap_or(0);
+    let last = &path[last_slash..];
+    if let Some(dot) = last.rfind('.') {
+        if dot == 0 {
+            return (path, None); // ".hidden" → no extension
+        }
+        let stem_end = last_slash + dot;
+        return (&path[..stem_end], Some(&path[stem_end + 1..]));
+    }
+    (path, None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::v1::ids::ActorId;
+
+    #[test]
+    fn empty_manifest_projects_empty() {
+        let m = Manifest::new(ActorId::new());
+        let p = project(&m);
+        assert!(p.is_empty());
+    }
+
+    #[test]
+    fn single_file_projects_to_its_name() {
+        let mut m = Manifest::new(ActorId::new());
+        let id = m.create_node("hello.md", None, NodeKind::Text, None, 5);
+        let p = project(&m);
+        assert_eq!(p.len(), 1);
+        let row = p.get_by_id(id).unwrap();
+        assert_eq!(row.path, "hello.md");
+        assert!(!row.is_conflict_copy);
+    }
+
+    #[test]
+    fn file_under_directory_has_joined_path() {
+        let mut m = Manifest::new(ActorId::new());
+        let dir = m.create_node("folder", None, NodeKind::Directory, None, 0);
+        let f = m.create_node("note.md", Some(dir), NodeKind::Text, None, 0);
+        let p = project(&m);
+        // Directory itself is not projected as a file.
+        assert_eq!(p.len(), 1);
+        let row = p.get_by_id(f).unwrap();
+        assert_eq!(row.path, "folder/note.md");
+    }
+
+    #[test]
+    fn deep_nesting_assembles_full_path() {
+        let mut m = Manifest::new(ActorId::new());
+        let l1 = m.create_node("l1", None, NodeKind::Directory, None, 0);
+        let l2 = m.create_node("l2", Some(l1), NodeKind::Directory, None, 0);
+        let l3 = m.create_node("l3", Some(l2), NodeKind::Directory, None, 0);
+        let leaf = m.create_node("leaf.md", Some(l3), NodeKind::Text, None, 0);
+        let p = project(&m);
+        assert_eq!(p.get_by_id(leaf).unwrap().path, "l1/l2/l3/leaf.md");
+    }
+
+    #[test]
+    fn deleted_file_is_not_projected() {
+        let mut m = Manifest::new(ActorId::new());
+        let id = m.create_node("gone.md", None, NodeKind::Text, None, 0);
+        m.delete(id);
+        let p = project(&m);
+        assert!(p.is_empty());
+    }
+
+    #[test]
+    fn modify_after_delete_resurrects() {
+        let mut m = Manifest::new(ActorId::new());
+        let id = m.create_node("phoenix.md", None, NodeKind::Text, None, 0);
+        m.delete(id); // delete with some lamport
+        m.record_modify(id); // modify with a later lamport → resurrects
+        let p = project(&m);
+        assert_eq!(p.len(), 1);
+        assert_eq!(p.get_by_id(id).unwrap().path, "phoenix.md");
+    }
+
+    #[test]
+    fn delete_after_modify_stays_deleted() {
+        let mut m = Manifest::new(ActorId::new());
+        let id = m.create_node("rip.md", None, NodeKind::Text, None, 0);
+        m.record_modify(id);
+        m.delete(id);
+        let p = project(&m);
+        assert!(p.is_empty());
+    }
+
+    #[test]
+    fn same_path_collision_gets_conflict_suffix() {
+        // Two nodes created independently with the same (parent, name).
+        // Rebuild by merging two manifests.
+        let mut m1 = Manifest::new(ActorId::new());
+        let id1 = m1.create_node("same.md", None, NodeKind::Text, None, 0);
+
+        let mut m2 = Manifest::new(ActorId::new());
+        let id2 = m2.create_node("same.md", None, NodeKind::Text, None, 0);
+
+        // Merge
+        let u1 = m1.encode_state_as_update();
+        let u2 = m2.encode_state_as_update();
+        m1.apply_update(&u2).unwrap();
+        m2.apply_update(&u1).unwrap();
+
+        // Both peers must produce the same projection deterministically.
+        let p1 = project(&m1);
+        let p2 = project(&m2);
+
+        assert_eq!(p1.len(), 2, "both nodes live, one conflict");
+        assert_eq!(p2.len(), 2);
+
+        // Same set of paths on both sides.
+        let mut paths1: Vec<_> = p1.by_path.keys().cloned().collect();
+        let mut paths2: Vec<_> = p2.by_path.keys().cloned().collect();
+        paths1.sort();
+        paths2.sort();
+        assert_eq!(paths1, paths2, "deterministic projection across peers");
+
+        // One path is exactly "same.md", the other is a conflict copy.
+        assert!(paths1.contains(&"same.md".to_string()));
+        assert!(paths1.iter().any(|p| p.contains(".conflict-")));
+
+        // Each node id exists exactly once across the two projections.
+        let ids1: Vec<_> = p1.by_id.keys().cloned().collect();
+        assert!(ids1.contains(&id1));
+        assert!(ids1.contains(&id2));
+    }
+
+    #[test]
+    fn conflict_suffix_preserves_extension() {
+        let (stem, ext) = split_ext("foo/bar/baz.tar.gz");
+        assert_eq!(stem, "foo/bar/baz.tar");
+        assert_eq!(ext, Some("gz"));
+
+        let (stem, ext) = split_ext("noext");
+        assert_eq!(stem, "noext");
+        assert_eq!(ext, None);
+
+        let (stem, ext) = split_ext(".hidden");
+        assert_eq!(stem, ".hidden");
+        assert_eq!(ext, None);
+    }
+
+    #[test]
+    fn binary_with_blob_hash_projected_correctly() {
+        let mut m = Manifest::new(ActorId::new());
+        let id = m.create_node(
+            "image.png",
+            None,
+            NodeKind::Binary,
+            Some("cafebabe"),
+            1024,
+        );
+        let p = project(&m);
+        let row = p.get_by_id(id).unwrap();
+        assert_eq!(row.kind, NodeKind::Binary);
+        assert_eq!(row.blob_hash.as_deref(), Some("cafebabe"));
+        assert_eq!(row.size, 1024);
+        assert_eq!(row.path, "image.png");
+    }
+
+    #[test]
+    fn rename_reflected_in_projection() {
+        let mut m = Manifest::new(ActorId::new());
+        let id = m.create_node("old.md", None, NodeKind::Text, None, 0);
+        m.set_name(id, "new.md");
+        let p = project(&m);
+        assert_eq!(p.get_by_id(id).unwrap().path, "new.md");
+    }
+
+    #[test]
+    fn move_to_new_parent_reflected() {
+        let mut m = Manifest::new(ActorId::new());
+        let a = m.create_node("A", None, NodeKind::Directory, None, 0);
+        let b = m.create_node("B", None, NodeKind::Directory, None, 0);
+        let f = m.create_node("f.md", Some(a), NodeKind::Text, None, 0);
+        assert_eq!(project(&m).get_by_id(f).unwrap().path, "A/f.md");
+        m.set_parent(f, Some(b));
+        assert_eq!(project(&m).get_by_id(f).unwrap().path, "B/f.md");
+    }
+
+    #[test]
+    fn orphan_with_deleted_parent_dir_is_hidden() {
+        let mut m = Manifest::new(ActorId::new());
+        let dir = m.create_node("doomed", None, NodeKind::Directory, None, 0);
+        let f = m.create_node("child.md", Some(dir), NodeKind::Text, None, 0);
+        m.delete(dir);
+        let p = project(&m);
+        // Child becomes unprojectable under the cascade-safety net.
+        assert!(p.get_by_id(f).is_none());
+    }
+}

--- a/syncline/src/v1/sync.rs
+++ b/syncline/src/v1/sync.rs
@@ -1,0 +1,382 @@
+//! v1 manifest sync — wire encoders, decoders, and the incoming-frame
+//! dispatcher that drives the Yrs SyncStep1/SyncStep2/Update handshake
+//! for the manifest Y.Doc.
+//!
+//! See `docs/DESIGN_DOC_V1.md` §4.
+//!
+//! # Framing
+//!
+//! Outer frames are built via [`crate::protocol::encode_message`]:
+//!
+//! ```text
+//! [msg_type u8][doc_id_len u16 BE][doc_id utf8][payload]
+//! ```
+//!
+//! For the manifest, `msg_type` is [`MSG_MANIFEST_SYNC`] and `doc_id`
+//! is the reserved [`MANIFEST_DOC_ID`] (`"__manifest__"`). The payload
+//! begins with a sub-type byte:
+//!
+//! | sub-type | name                | inner payload             |
+//! |----------|---------------------|---------------------------|
+//! | `0x00`   | [`MANIFEST_STEP_1`] | yrs state vector (`v1`)   |
+//! | `0x01`   | [`MANIFEST_STEP_2`] | yrs update bytes (`v1`)   |
+//! | `0x02`   | [`MANIFEST_UPDATE`] | yrs update bytes (`v1`)   |
+//!
+//! [`MSG_VERSION`] carries a separate two-byte `[major][minor]`
+//! handshake frame.
+
+use super::manifest::Manifest;
+use crate::protocol::{
+    MANIFEST_STEP_1, MANIFEST_STEP_2, MANIFEST_UPDATE, V1_PROTOCOL_MAJOR, V1_PROTOCOL_MINOR,
+};
+use yrs::updates::decoder::Decode;
+use yrs::updates::encoder::Encode;
+use yrs::{ReadTxn, StateVector, Transact};
+
+/// Encode the payload for an `MSG_VERSION` frame.
+pub fn encode_version_handshake() -> Vec<u8> {
+    vec![V1_PROTOCOL_MAJOR, V1_PROTOCOL_MINOR]
+}
+
+/// Decode a version handshake payload. Returns `(major, minor)`.
+pub fn decode_version_handshake(payload: &[u8]) -> Option<(u8, u8)> {
+    if payload.len() != 2 {
+        return None;
+    }
+    Some((payload[0], payload[1]))
+}
+
+/// Build a SyncStep1 payload from a pre-encoded state vector.
+pub fn encode_manifest_step1(state_vector: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(1 + state_vector.len());
+    out.push(MANIFEST_STEP_1);
+    out.extend_from_slice(state_vector);
+    out
+}
+
+/// Build a SyncStep2 payload from a pre-encoded yrs update.
+pub fn encode_manifest_step2(update: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(1 + update.len());
+    out.push(MANIFEST_STEP_2);
+    out.extend_from_slice(update);
+    out
+}
+
+/// Build an incremental Update payload from a pre-encoded yrs update.
+pub fn encode_manifest_update(update: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(1 + update.len());
+    out.push(MANIFEST_UPDATE);
+    out.extend_from_slice(update);
+    out
+}
+
+/// Split a manifest-sync payload into its sub-type byte and inner yrs
+/// bytes. Returns `None` on an empty payload.
+pub fn split_manifest_payload(payload: &[u8]) -> Option<(u8, &[u8])> {
+    if payload.is_empty() {
+        None
+    } else {
+        Some((payload[0], &payload[1..]))
+    }
+}
+
+/// Build a SyncStep1 payload carrying this manifest's current state
+/// vector.
+pub fn manifest_step1_payload(manifest: &Manifest) -> Vec<u8> {
+    let sv_bytes = {
+        let txn = manifest.doc().transact();
+        txn.state_vector().encode_v1()
+    };
+    encode_manifest_step1(&sv_bytes)
+}
+
+/// Build a SyncStep2 payload carrying the updates needed to advance a
+/// remote peer from `remote_sv_bytes` to our current state.
+pub fn manifest_step2_payload(
+    manifest: &Manifest,
+    remote_sv_bytes: &[u8],
+) -> anyhow::Result<Vec<u8>> {
+    let remote_sv = StateVector::decode_v1(remote_sv_bytes)?;
+    let update = {
+        let txn = manifest.doc().transact();
+        txn.encode_state_as_update_v1(&remote_sv)
+    };
+    Ok(encode_manifest_step2(&update))
+}
+
+/// Dispatch an incoming manifest-sync payload. Applies remote state to
+/// `manifest` as appropriate and returns an optional response payload
+/// (already prefixed with its sub-type byte — the caller wraps it in
+/// [`crate::protocol::encode_message`] with [`crate::protocol::MSG_MANIFEST_SYNC`]
+/// and [`crate::protocol::MANIFEST_DOC_ID`]).
+///
+/// - `MANIFEST_STEP_1` → returns a `MANIFEST_STEP_2` with the updates
+///   the remote peer is missing.
+/// - `MANIFEST_STEP_2` / `MANIFEST_UPDATE` → applied; no response.
+pub fn handle_manifest_payload(
+    manifest: &mut Manifest,
+    payload: &[u8],
+) -> anyhow::Result<Option<Vec<u8>>> {
+    let (sub_type, inner) = split_manifest_payload(payload)
+        .ok_or_else(|| anyhow::anyhow!("empty manifest sync payload"))?;
+    match sub_type {
+        MANIFEST_STEP_1 => Ok(Some(manifest_step2_payload(manifest, inner)?)),
+        MANIFEST_STEP_2 | MANIFEST_UPDATE => {
+            manifest.apply_update(inner)?;
+            Ok(None)
+        }
+        other => Err(anyhow::anyhow!(
+            "unknown manifest sync sub-type {:#x}",
+            other
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::ids::{ActorId, NodeId};
+    use super::super::manifest::{Manifest, NodeKind};
+    use super::*;
+    use crate::protocol::{
+        decode_message, encode_message, MANIFEST_DOC_ID, MSG_MANIFEST_SYNC, MSG_VERSION,
+    };
+
+    #[test]
+    fn version_handshake_roundtrip() {
+        let payload = encode_version_handshake();
+        assert_eq!(payload, vec![V1_PROTOCOL_MAJOR, V1_PROTOCOL_MINOR]);
+        let (major, minor) = decode_version_handshake(&payload).unwrap();
+        assert_eq!((major, minor), (V1_PROTOCOL_MAJOR, V1_PROTOCOL_MINOR));
+    }
+
+    #[test]
+    fn version_handshake_rejects_wrong_length() {
+        assert!(decode_version_handshake(&[]).is_none());
+        assert!(decode_version_handshake(&[1]).is_none());
+        assert!(decode_version_handshake(&[1, 0, 0]).is_none());
+    }
+
+    #[test]
+    fn version_handshake_wraps_in_outer_frame() {
+        let payload = encode_version_handshake();
+        let frame = encode_message(MSG_VERSION, MANIFEST_DOC_ID, &payload);
+        let (t, d, p) = decode_message(&frame).unwrap();
+        assert_eq!(t, MSG_VERSION);
+        assert_eq!(d, MANIFEST_DOC_ID);
+        assert_eq!(p, payload.as_slice());
+    }
+
+    #[test]
+    fn split_payload_extracts_sub_type() {
+        let inner = vec![0xDE, 0xAD, 0xBE, 0xEF];
+        let framed = encode_manifest_step1(&inner);
+        let (sub, body) = split_manifest_payload(&framed).unwrap();
+        assert_eq!(sub, MANIFEST_STEP_1);
+        assert_eq!(body, inner.as_slice());
+
+        let framed = encode_manifest_step2(&inner);
+        let (sub, body) = split_manifest_payload(&framed).unwrap();
+        assert_eq!(sub, MANIFEST_STEP_2);
+        assert_eq!(body, inner.as_slice());
+
+        let framed = encode_manifest_update(&inner);
+        let (sub, body) = split_manifest_payload(&framed).unwrap();
+        assert_eq!(sub, MANIFEST_UPDATE);
+        assert_eq!(body, inner.as_slice());
+    }
+
+    #[test]
+    fn split_payload_rejects_empty() {
+        assert!(split_manifest_payload(&[]).is_none());
+    }
+
+    #[test]
+    fn step1_payload_reflects_current_state() {
+        let mut m = Manifest::new(ActorId::new());
+        m.create_node("a.md", None, NodeKind::Text, None, 0);
+        let payload = manifest_step1_payload(&m);
+        let (sub, sv_bytes) = split_manifest_payload(&payload).unwrap();
+        assert_eq!(sub, MANIFEST_STEP_1);
+        // Must decode as a valid state vector.
+        let _ = StateVector::decode_v1(sv_bytes).expect("valid state vector");
+    }
+
+    #[test]
+    fn step1_then_step2_transfers_missing_updates() {
+        // m1 has an entry; m2 is empty. m2 sends its SV to m1; m1 replies
+        // with a Step2 containing what m2 is missing.
+        let mut m1 = Manifest::new(ActorId::new());
+        let id = m1.create_node("hello.md", None, NodeKind::Text, None, 5);
+
+        let mut m2 = Manifest::new(ActorId::new());
+        let step1 = manifest_step1_payload(&m2);
+
+        let response = handle_manifest_payload(&mut m1, &step1)
+            .expect("step1 handled")
+            .expect("step1 yields a step2 response");
+        let (sub, _update_bytes) = split_manifest_payload(&response).unwrap();
+        assert_eq!(sub, MANIFEST_STEP_2);
+
+        // Applying that response to m2 should make the entry visible.
+        handle_manifest_payload(&mut m2, &response).unwrap();
+        assert!(m2.get_entry(id).is_some());
+    }
+
+    #[test]
+    fn step2_and_update_produce_no_response() {
+        let mut m1 = Manifest::new(ActorId::new());
+        m1.create_node("x.md", None, NodeKind::Text, None, 0);
+
+        let mut m2 = Manifest::new(ActorId::new());
+        // Craft a step2 payload from m1's full state.
+        let full_state = m1.encode_state_as_update();
+        let step2 = encode_manifest_step2(&full_state);
+        let resp = handle_manifest_payload(&mut m2, &step2).unwrap();
+        assert!(resp.is_none());
+
+        // And an incremental UPDATE frame likewise produces no response.
+        let update = encode_manifest_update(&full_state);
+        let resp = handle_manifest_payload(&mut m2, &update).unwrap();
+        assert!(resp.is_none());
+    }
+
+    #[test]
+    fn unknown_sub_type_is_rejected() {
+        let mut m = Manifest::new(ActorId::new());
+        let bogus = vec![0xFF, 0x00, 0x00];
+        assert!(handle_manifest_payload(&mut m, &bogus).is_err());
+    }
+
+    #[test]
+    fn handler_rejects_empty_payload() {
+        let mut m = Manifest::new(ActorId::new());
+        assert!(handle_manifest_payload(&mut m, &[]).is_err());
+    }
+
+    /// Full bidirectional sync simulation: each peer sends its SyncStep1,
+    /// receives the other's SyncStep2, applies it, and converges.
+    #[test]
+    fn bidirectional_sync_converges() {
+        let mut m1 = Manifest::new(ActorId::new());
+        let mut m2 = Manifest::new(ActorId::new());
+
+        let id1 = m1.create_node("from_m1.md", None, NodeKind::Text, None, 1);
+        let id2 = m2.create_node("from_m2.md", None, NodeKind::Text, None, 2);
+
+        // Each peer asks the other for what it's missing.
+        let m1_step1 = manifest_step1_payload(&m1);
+        let m2_step1 = manifest_step1_payload(&m2);
+
+        // Exchange SyncStep2 responses.
+        let m2_response_for_m1 = handle_manifest_payload(&mut m2, &m1_step1)
+            .unwrap()
+            .unwrap();
+        let m1_response_for_m2 = handle_manifest_payload(&mut m1, &m2_step1)
+            .unwrap()
+            .unwrap();
+
+        // Apply the responses.
+        assert!(handle_manifest_payload(&mut m1, &m2_response_for_m1)
+            .unwrap()
+            .is_none());
+        assert!(handle_manifest_payload(&mut m2, &m1_response_for_m2)
+            .unwrap()
+            .is_none());
+
+        // Both peers now see both entries.
+        for m in [&m1, &m2] {
+            assert!(m.get_entry(id1).is_some(), "entry1 missing from a peer");
+            assert!(m.get_entry(id2).is_some(), "entry2 missing from a peer");
+        }
+    }
+
+    /// Concurrent edits on both peers still converge after a second
+    /// round of SyncStep1 ↔ SyncStep2.
+    #[test]
+    fn bidirectional_sync_converges_with_concurrent_edits() {
+        let a1 = ActorId::new();
+        let a2 = ActorId::new();
+        let mut m1 = Manifest::new(a1);
+        let mut m2 = Manifest::new(a2);
+
+        // Both create a node while disconnected.
+        let id1 = m1.create_node("a.md", None, NodeKind::Text, None, 10);
+        let id2 = m2.create_node("b.md", None, NodeKind::Text, None, 20);
+
+        // Round 1: mutual SyncStep1 / SyncStep2.
+        let s1 = manifest_step1_payload(&m1);
+        let s2 = manifest_step1_payload(&m2);
+        let r_for_m1 = handle_manifest_payload(&mut m2, &s1).unwrap().unwrap();
+        let r_for_m2 = handle_manifest_payload(&mut m1, &s2).unwrap().unwrap();
+        handle_manifest_payload(&mut m1, &r_for_m1).unwrap();
+        handle_manifest_payload(&mut m2, &r_for_m2).unwrap();
+
+        // Now concurrently: m1 renames id2, m2 deletes id1.
+        assert!(m1.set_name(id2, "b-renamed.md"));
+        assert!(m2.delete(id1));
+
+        // Round 2: mutual SyncStep1 / SyncStep2 again.
+        let s1 = manifest_step1_payload(&m1);
+        let s2 = manifest_step1_payload(&m2);
+        let r_for_m1 = handle_manifest_payload(&mut m2, &s1).unwrap().unwrap();
+        let r_for_m2 = handle_manifest_payload(&mut m1, &s2).unwrap().unwrap();
+        handle_manifest_payload(&mut m1, &r_for_m1).unwrap();
+        handle_manifest_payload(&mut m2, &r_for_m2).unwrap();
+
+        // Convergence check: both peers agree on all observable fields.
+        for target in [id1, id2] {
+            let e1 = m1.get_entry(target).expect("m1 has entry");
+            let e2 = m2.get_entry(target).expect("m2 has entry");
+            assert_eq!(e1.name, e2.name, "name diverged for {:?}", target);
+            assert_eq!(e1.deleted, e2.deleted, "deleted diverged for {:?}", target);
+            assert_eq!(e1.parent, e2.parent, "parent diverged for {:?}", target);
+        }
+    }
+
+    /// Full wire-framed round-trip: wrap each payload in an outer
+    /// `encode_message` frame, transport as bytes, decode, dispatch.
+    #[test]
+    fn wire_framed_sync_roundtrip() {
+        let mut m1 = Manifest::new(ActorId::new());
+        let id = m1.create_node("wire.md", None, NodeKind::Text, None, 0);
+        let mut m2 = Manifest::new(ActorId::new());
+
+        // m2 sends a framed SyncStep1.
+        let s1_payload = manifest_step1_payload(&m2);
+        let frame = encode_message(MSG_MANIFEST_SYNC, MANIFEST_DOC_ID, &s1_payload);
+
+        // m1 receives bytes off the wire.
+        let (msg_type, doc_id, payload) = decode_message(&frame).unwrap();
+        assert_eq!(msg_type, MSG_MANIFEST_SYNC);
+        assert_eq!(doc_id, MANIFEST_DOC_ID);
+
+        // m1 dispatches and produces a response payload.
+        let resp_payload = handle_manifest_payload(&mut m1, payload)
+            .unwrap()
+            .expect("step1 must elicit step2");
+        let resp_frame = encode_message(MSG_MANIFEST_SYNC, MANIFEST_DOC_ID, &resp_payload);
+
+        // m2 receives the response and applies it.
+        let (_t, _d, p) = decode_message(&resp_frame).unwrap();
+        handle_manifest_payload(&mut m2, p).unwrap();
+
+        assert!(m2.get_entry(id).is_some());
+    }
+
+    /// Smoke test: NodeId parsing sanity (catches accidental formatting
+    /// drift between encode/decode).
+    #[test]
+    fn node_id_survives_manifest_sync() {
+        let mut m1 = Manifest::new(ActorId::new());
+        let id = m1.create_node("id.md", None, NodeKind::Text, None, 0);
+        let mut m2 = Manifest::new(ActorId::new());
+        let s1 = manifest_step1_payload(&m2);
+        let r = handle_manifest_payload(&mut m1, &s1).unwrap().unwrap();
+        handle_manifest_payload(&mut m2, &r).unwrap();
+        let e = m2.get_entry(id).unwrap();
+        assert_eq!(e.id, id);
+        // And NodeId formatting remains valid.
+        let s = id.to_string_hyphenated();
+        assert_eq!(NodeId::parse_str(&s), Some(id));
+    }
+}

--- a/syncline/src/v1/sync.rs
+++ b/syncline/src/v1/sync.rs
@@ -26,9 +26,11 @@
 //! handshake frame.
 
 use super::manifest::Manifest;
+use super::projection::project;
 use crate::protocol::{
     MANIFEST_STEP_1, MANIFEST_STEP_2, MANIFEST_UPDATE, V1_PROTOCOL_MAJOR, V1_PROTOCOL_MINOR,
 };
+use sha2::{Digest, Sha256};
 use yrs::updates::decoder::Decode;
 use yrs::updates::encoder::Encode;
 use yrs::{ReadTxn, StateVector, Transact};
@@ -129,6 +131,77 @@ pub fn handle_manifest_payload(
             "unknown manifest sync sub-type {:#x}",
             other
         )),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Convergence verification (MSG_MANIFEST_VERIFY — §4.4.1)
+// ---------------------------------------------------------------------------
+
+/// SHA-256 over the canonical projection of `manifest`. Two peers that
+/// project to the same set of user-visible files produce an identical
+/// hash; divergent tombstones that never surface in the projection do
+/// **not** cause a mismatch.
+///
+/// Canonical form: projected entries sorted by path, each encoded as
+/// `path || 0x00 || node-id(hyphenated) || 0x00 || kind || 0x00 ||
+/// blob-hash-or-empty || 0x00 || size(u64 BE) || 0x00`. The
+/// zero-byte separators prevent `"a" + "bc"` from colliding with
+/// `"ab" + "c"`.
+pub fn projection_hash(manifest: &Manifest) -> [u8; 32] {
+    let proj = project(manifest);
+    let mut entries: Vec<_> = proj.by_path.iter().collect();
+    entries.sort_by(|(a, _), (b, _)| a.as_str().cmp(b.as_str()));
+
+    let mut hasher = Sha256::new();
+    for (path, entry) in entries {
+        hasher.update(path.as_bytes());
+        hasher.update([0u8]);
+        hasher.update(entry.id.to_string_hyphenated().as_bytes());
+        hasher.update([0u8]);
+        hasher.update(entry.kind.as_str().as_bytes());
+        hasher.update([0u8]);
+        hasher.update(entry.blob_hash.as_deref().unwrap_or("").as_bytes());
+        hasher.update([0u8]);
+        hasher.update(entry.size.to_be_bytes());
+        hasher.update([0u8]);
+    }
+    hasher.finalize().into()
+}
+
+/// Encode the payload for a `MSG_MANIFEST_VERIFY` frame: just the
+/// 32-byte projection hash.
+pub fn encode_verify_payload(hash: &[u8; 32]) -> Vec<u8> {
+    hash.to_vec()
+}
+
+/// Decode a `MSG_MANIFEST_VERIFY` payload into its 32-byte hash.
+pub fn decode_verify_payload(payload: &[u8]) -> Option<[u8; 32]> {
+    if payload.len() != 32 {
+        return None;
+    }
+    let mut out = [0u8; 32];
+    out.copy_from_slice(payload);
+    Some(out)
+}
+
+/// Handle an incoming `MSG_MANIFEST_VERIFY` payload. If the remote
+/// hash matches the local projection hash, returns `Ok(None)`
+/// (convergence confirmed). If they disagree, returns
+/// `Ok(Some(manifest_sync_payload))` — a `MANIFEST_STEP_1` payload
+/// ready to be wrapped in a `MSG_MANIFEST_SYNC` frame to force a
+/// full re-sync.
+pub fn handle_verify_payload(
+    manifest: &Manifest,
+    payload: &[u8],
+) -> anyhow::Result<Option<Vec<u8>>> {
+    let remote = decode_verify_payload(payload)
+        .ok_or_else(|| anyhow::anyhow!("malformed MSG_MANIFEST_VERIFY payload"))?;
+    let local = projection_hash(manifest);
+    if local == remote {
+        Ok(None)
+    } else {
+        Ok(Some(manifest_step1_payload(manifest)))
     }
 }
 
@@ -361,6 +434,150 @@ mod tests {
         handle_manifest_payload(&mut m2, p).unwrap();
 
         assert!(m2.get_entry(id).is_some());
+    }
+
+    // -----------------------------------------------------------------
+    // Convergence verification (MSG_MANIFEST_VERIFY)
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn projection_hash_is_deterministic() {
+        let mut m1 = Manifest::new(ActorId::new());
+        m1.create_node("a.md", None, NodeKind::Text, None, 10);
+        m1.create_node("b.md", None, NodeKind::Text, None, 20);
+        let h1 = projection_hash(&m1);
+        let h2 = projection_hash(&m1);
+        assert_eq!(h1, h2);
+    }
+
+    #[test]
+    fn projection_hash_differs_when_content_differs() {
+        let mut m1 = Manifest::new(ActorId::new());
+        m1.create_node("a.md", None, NodeKind::Text, None, 10);
+        let h1 = projection_hash(&m1);
+
+        let mut m2 = Manifest::new(ActorId::new());
+        m2.create_node("a.md", None, NodeKind::Text, None, 11);
+        let h2 = projection_hash(&m2);
+
+        assert_ne!(h1, h2, "size difference must affect projection hash");
+    }
+
+    #[test]
+    fn projection_hash_matches_after_full_sync() {
+        let mut m1 = Manifest::new(ActorId::new());
+        m1.create_node("a.md", None, NodeKind::Text, None, 10);
+        m1.create_node("b.md", None, NodeKind::Text, None, 20);
+
+        let mut m2 = Manifest::new(ActorId::new());
+        m2.create_node("c.md", None, NodeKind::Text, None, 30);
+
+        // Full bidirectional sync via the manifest protocol.
+        let s1 = manifest_step1_payload(&m1);
+        let s2 = manifest_step1_payload(&m2);
+        let r1 = handle_manifest_payload(&mut m2, &s1).unwrap().unwrap();
+        let r2 = handle_manifest_payload(&mut m1, &s2).unwrap().unwrap();
+        handle_manifest_payload(&mut m1, &r1).unwrap();
+        handle_manifest_payload(&mut m2, &r2).unwrap();
+
+        assert_eq!(
+            projection_hash(&m1),
+            projection_hash(&m2),
+            "post-sync peers must agree on projection hash"
+        );
+    }
+
+    #[test]
+    fn verify_payload_roundtrip() {
+        let m = Manifest::new(ActorId::new());
+        let h = projection_hash(&m);
+        let payload = encode_verify_payload(&h);
+        assert_eq!(payload.len(), 32);
+        let decoded = decode_verify_payload(&payload).unwrap();
+        assert_eq!(decoded, h);
+    }
+
+    #[test]
+    fn verify_payload_rejects_wrong_length() {
+        assert!(decode_verify_payload(&[]).is_none());
+        assert!(decode_verify_payload(&[0u8; 31]).is_none());
+        assert!(decode_verify_payload(&[0u8; 33]).is_none());
+    }
+
+    #[test]
+    fn handle_verify_on_match_returns_none() {
+        let mut m1 = Manifest::new(ActorId::new());
+        m1.create_node("a.md", None, NodeKind::Text, None, 0);
+        let mut m2 = Manifest::new(ActorId::new());
+        // Seed m2 with the same state.
+        m2.apply_update(&m1.encode_state_as_update()).unwrap();
+
+        let remote_hash = projection_hash(&m2);
+        let payload = encode_verify_payload(&remote_hash);
+        let resp = handle_verify_payload(&m1, &payload).unwrap();
+        assert!(resp.is_none(), "matching hashes must not trigger re-sync");
+    }
+
+    #[test]
+    fn handle_verify_on_mismatch_returns_step1() {
+        let mut m1 = Manifest::new(ActorId::new());
+        m1.create_node("a.md", None, NodeKind::Text, None, 0);
+        let mut m2 = Manifest::new(ActorId::new());
+        m2.create_node("different.md", None, NodeKind::Text, None, 0);
+
+        let remote_hash = projection_hash(&m2);
+        let payload = encode_verify_payload(&remote_hash);
+        let resp = handle_verify_payload(&m1, &payload)
+            .unwrap()
+            .expect("mismatch must trigger a sync");
+        // The returned payload is a MANIFEST_STEP_1 ready to wrap.
+        let (sub, _inner) = split_manifest_payload(&resp).unwrap();
+        assert_eq!(sub, MANIFEST_STEP_1);
+    }
+
+    #[test]
+    fn handle_verify_rejects_malformed_payload() {
+        let m = Manifest::new(ActorId::new());
+        assert!(handle_verify_payload(&m, &[0u8; 10]).is_err());
+    }
+
+    #[test]
+    fn verify_then_sync_converges_mismatched_peers() {
+        // Simulates the full §4.4.1 flow: a heartbeat VERIFY is sent,
+        // the receiver notices divergence, returns a SyncStep1, the
+        // originator then responds with a SyncStep2, and both peers
+        // should now share a matching projection hash.
+        let mut m1 = Manifest::new(ActorId::new());
+        m1.create_node("a.md", None, NodeKind::Text, None, 10);
+        let mut m2 = Manifest::new(ActorId::new());
+        m2.create_node("b.md", None, NodeKind::Text, None, 20);
+
+        // m2 heartbeats its projection hash to m1.
+        let verify_payload = encode_verify_payload(&projection_hash(&m2));
+        let step1_from_m1 = handle_verify_payload(&m1, &verify_payload)
+            .unwrap()
+            .expect("hashes should diverge");
+
+        // m2 receives m1's step1, replies with step2 of what m1 is
+        // missing from m2's state. m1 applies — m1 is now a superset.
+        let step2_for_m1 = handle_manifest_payload(&mut m2, &step1_from_m1)
+            .unwrap()
+            .unwrap();
+        handle_manifest_payload(&mut m1, &step2_for_m1).unwrap();
+
+        // Second leg: m2 still lacks "a.md". m2 sends its own step1
+        // so m1 can respond with what m2 is missing.
+        let step1_from_m2 = manifest_step1_payload(&m2);
+        let step2_for_m2 = handle_manifest_payload(&mut m1, &step1_from_m2)
+            .unwrap()
+            .unwrap();
+        handle_manifest_payload(&mut m2, &step2_for_m2).unwrap();
+
+        assert_eq!(
+            projection_hash(&m1),
+            projection_hash(&m2),
+            "peers must converge after VERIFY-driven re-sync"
+        );
     }
 
     /// Smoke test: NodeId parsing sanity (catches accidental formatting

--- a/syncline/tests/v1_protocol_e2e.rs
+++ b/syncline/tests/v1_protocol_e2e.rs
@@ -1,0 +1,322 @@
+//! End-to-end integration test for the v1 manifest sync stack.
+//!
+//! Exercises the protocol as it would run on the wire: two (or three)
+//! simulated peers drive real path-level operations through
+//! `v1::ops`, then exchange `MSG_MANIFEST_SYNC` and `MSG_MANIFEST_VERIFY`
+//! frames through the outer `protocol::encode_message` / `decode_message`
+//! framing. Convergence is asserted by the projection hash plus per-path
+//! field agreement.
+//!
+//! Lives outside `src/v1/` so it exercises the crate's public surface
+//! the same way the client/server code will once v1 is wired through.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use syncline::protocol::{
+    decode_message, encode_message, MANIFEST_DOC_ID, MSG_MANIFEST_SYNC, MSG_MANIFEST_VERIFY,
+    MSG_VERSION,
+};
+use syncline::v1::{
+    create_binary, create_text, delete_path, encode_verify_payload, encode_version_handshake,
+    handle_manifest_payload, handle_verify_payload, manifest_step1_payload, projection_hash,
+    record_modify_text, rename, ActorId, Manifest,
+};
+
+/// Single-peer wrapper that carries a Manifest plus an outgoing frame
+/// queue. Mimics the read side of what a real client loop would do.
+struct Peer {
+    label: &'static str,
+    manifest: Manifest,
+}
+
+impl Peer {
+    fn new(label: &'static str) -> Self {
+        Self {
+            label,
+            manifest: Manifest::new(ActorId::new()),
+        }
+    }
+
+    /// Build a SyncStep1 frame (outer-framed bytes).
+    fn frame_step1(&self) -> Vec<u8> {
+        encode_message(
+            MSG_MANIFEST_SYNC,
+            MANIFEST_DOC_ID,
+            &manifest_step1_payload(&self.manifest),
+        )
+    }
+
+    /// Build a VERIFY frame.
+    fn frame_verify(&self) -> Vec<u8> {
+        let hash = projection_hash(&self.manifest);
+        encode_message(
+            MSG_MANIFEST_VERIFY,
+            MANIFEST_DOC_ID,
+            &encode_verify_payload(&hash),
+        )
+    }
+
+    /// Receive a framed message and produce the response frame (if any).
+    fn receive(&mut self, frame: &[u8]) -> Option<Vec<u8>> {
+        let (msg_type, doc_id, payload) =
+            decode_message(frame).expect("malformed frame arrived at peer");
+        assert_eq!(
+            doc_id, MANIFEST_DOC_ID,
+            "{}: expected manifest doc-id",
+            self.label
+        );
+        match msg_type {
+            MSG_VERSION => None,
+            MSG_MANIFEST_SYNC => handle_manifest_payload(&mut self.manifest, payload)
+                .expect("handle manifest payload")
+                .map(|resp| encode_message(MSG_MANIFEST_SYNC, MANIFEST_DOC_ID, &resp)),
+            MSG_MANIFEST_VERIFY => handle_verify_payload(&self.manifest, payload)
+                .expect("handle verify payload")
+                .map(|resp| encode_message(MSG_MANIFEST_SYNC, MANIFEST_DOC_ID, &resp)),
+            other => panic!("{}: unexpected msg_type {:#x}", self.label, other),
+        }
+    }
+}
+
+/// Drive a full bidirectional exchange between two peers: each sends
+/// its SyncStep1; each applies the other's SyncStep2.
+fn bidirectional_sync(a: &mut Peer, b: &mut Peer) {
+    let a1 = a.frame_step1();
+    let b1 = b.frame_step1();
+    // a's step1 -> b produces step2 for a
+    let step2_for_a = b.receive(&a1).expect("b must reply to a's step1");
+    let step2_for_b = a.receive(&b1).expect("a must reply to b's step1");
+    assert!(a.receive(&step2_for_a).is_none(), "step2 must not reply");
+    assert!(b.receive(&step2_for_b).is_none(), "step2 must not reply");
+}
+
+fn assert_converged(peers: &[&Peer]) {
+    let head = projection_hash(&peers[0].manifest);
+    for p in &peers[1..] {
+        assert_eq!(
+            projection_hash(&p.manifest),
+            head,
+            "peer {} diverged from {}",
+            p.label,
+            peers[0].label
+        );
+    }
+}
+
+#[test]
+fn version_handshake_frames_roundtrip() {
+    let hs = encode_version_handshake();
+    let frame = encode_message(MSG_VERSION, MANIFEST_DOC_ID, &hs);
+    let (t, d, p) = decode_message(&frame).unwrap();
+    assert_eq!(t, MSG_VERSION);
+    assert_eq!(d, MANIFEST_DOC_ID);
+    assert_eq!(p, hs.as_slice());
+}
+
+#[test]
+fn two_peer_create_converges() {
+    let mut a = Peer::new("A");
+    let mut b = Peer::new("B");
+
+    create_text(&mut a.manifest, "hello.md", 5).unwrap();
+    create_binary(&mut b.manifest, "pic.png", "cafebabe", 1024).unwrap();
+
+    bidirectional_sync(&mut a, &mut b);
+    assert_converged(&[&a, &b]);
+}
+
+#[test]
+fn two_peer_nested_path_converges() {
+    let mut a = Peer::new("A");
+    let mut b = Peer::new("B");
+
+    create_text(&mut a.manifest, "notes/day/one.md", 0).unwrap();
+    create_text(&mut b.manifest, "notes/day/two.md", 0).unwrap();
+    create_text(&mut b.manifest, "notes/week/plans.md", 0).unwrap();
+
+    bidirectional_sync(&mut a, &mut b);
+    assert_converged(&[&a, &b]);
+}
+
+#[test]
+fn rename_propagates_across_peers() {
+    let mut a = Peer::new("A");
+    let mut b = Peer::new("B");
+
+    create_text(&mut a.manifest, "old.md", 0).unwrap();
+    bidirectional_sync(&mut a, &mut b);
+    assert_converged(&[&a, &b]);
+
+    // A renames; B picks it up after sync.
+    rename(&mut a.manifest, "old.md", "renamed/deep/new.md").unwrap();
+    bidirectional_sync(&mut a, &mut b);
+    assert_converged(&[&a, &b]);
+}
+
+#[test]
+fn delete_propagates_and_converges() {
+    let mut a = Peer::new("A");
+    let mut b = Peer::new("B");
+
+    create_text(&mut a.manifest, "doomed.md", 0).unwrap();
+    bidirectional_sync(&mut a, &mut b);
+    assert_converged(&[&a, &b]);
+
+    delete_path(&mut a.manifest, "doomed.md").unwrap();
+    bidirectional_sync(&mut a, &mut b);
+    assert_converged(&[&a, &b]);
+}
+
+#[test]
+fn verify_heartbeat_no_op_when_synced() {
+    let mut a = Peer::new("A");
+    let mut b = Peer::new("B");
+
+    create_text(&mut a.manifest, "x.md", 0).unwrap();
+    bidirectional_sync(&mut a, &mut b);
+
+    // Heartbeat — should produce no response frame.
+    let v = a.frame_verify();
+    assert!(
+        b.receive(&v).is_none(),
+        "matching hashes must not trigger re-sync"
+    );
+    assert_converged(&[&a, &b]);
+}
+
+#[test]
+fn verify_heartbeat_drives_reconvergence() {
+    let mut a = Peer::new("A");
+    let mut b = Peer::new("B");
+
+    create_text(&mut a.manifest, "diverged.md", 0).unwrap();
+    // No initial sync — peers intentionally diverge.
+
+    // A sends VERIFY. B compares, notices mismatch, responds with STEP_1.
+    let verify_frame = a.frame_verify();
+    let step1_from_b = b
+        .receive(&verify_frame)
+        .expect("mismatch should trigger re-sync");
+
+    // A receives B's STEP_1 and returns STEP_2.
+    let step2_for_b = a
+        .receive(&step1_from_b)
+        .expect("A must answer B's step1 with step2");
+    assert!(
+        b.receive(&step2_for_b).is_none(),
+        "step2 does not trigger another response"
+    );
+
+    // B now has A's data. But A may still lack B's — if B also created,
+    // run a second leg. Here B had nothing, so one-way is enough.
+    assert_converged(&[&a, &b]);
+}
+
+#[test]
+fn three_peer_full_mesh_converges() {
+    // Simulates a "hub" sync: each pair exchanges, so everyone learns
+    // everyone's state. Mimics what a server-relayed fan-out would
+    // deliver once the manifest is fully broadcast.
+    let mut a = Peer::new("A");
+    let mut b = Peer::new("B");
+    let mut c = Peer::new("C");
+
+    create_text(&mut a.manifest, "from_a.md", 1).unwrap();
+    create_text(&mut b.manifest, "from_b.md", 2).unwrap();
+    create_text(&mut c.manifest, "from_c.md", 3).unwrap();
+    create_text(&mut a.manifest, "shared/a.md", 0).unwrap();
+    create_text(&mut b.manifest, "shared/b.md", 0).unwrap();
+
+    // Full mesh: every pair runs a bidirectional sync. Two passes are
+    // needed so the knowledge transits from A→B→C and back.
+    for _ in 0..2 {
+        bidirectional_sync(&mut a, &mut b);
+        bidirectional_sync(&mut b, &mut c);
+        bidirectional_sync(&mut a, &mut c);
+    }
+
+    assert_converged(&[&a, &b, &c]);
+}
+
+#[test]
+fn modify_beats_delete_end_to_end() {
+    let mut a = Peer::new("A");
+    let mut b = Peer::new("B");
+
+    let id = create_text(&mut a.manifest, "race.md", 0).unwrap();
+    bidirectional_sync(&mut a, &mut b);
+
+    // A deletes; B first observes it, then modifies the node. B's
+    // modify stamp ends up strictly > A's delete stamp so the node
+    // resurrects on both peers.
+    delete_path(&mut a.manifest, "race.md").unwrap();
+    bidirectional_sync(&mut a, &mut b);
+    assert!(b.manifest.get_entry(id).unwrap().deleted);
+
+    assert!(b.manifest.record_modify(id));
+    bidirectional_sync(&mut a, &mut b);
+
+    // Both peers must agree the file is live now.
+    assert_converged(&[&a, &b]);
+    use syncline::v1::projection::project;
+    assert!(project(&a.manifest).by_path.contains_key("race.md"));
+    assert!(project(&b.manifest).by_path.contains_key("race.md"));
+}
+
+#[test]
+fn concurrent_modify_then_sync_preserves_both_writes() {
+    // Both peers modify different files concurrently — a classic
+    // "happy path" CRDT case. After sync, every modify stamp is
+    // preserved.
+    let mut a = Peer::new("A");
+    let mut b = Peer::new("B");
+
+    let id1 = create_text(&mut a.manifest, "a.md", 0).unwrap();
+    let id2 = create_text(&mut a.manifest, "b.md", 0).unwrap();
+    bidirectional_sync(&mut a, &mut b);
+
+    // Concurrent modifies.
+    record_modify_text(&mut a.manifest, "a.md").unwrap();
+    record_modify_text(&mut b.manifest, "b.md").unwrap();
+    bidirectional_sync(&mut a, &mut b);
+
+    assert_converged(&[&a, &b]);
+    // Both modify stamps visible on both peers.
+    for m in [&a.manifest, &b.manifest] {
+        assert!(m.get_entry(id1).unwrap().modify_stamp.is_some());
+        assert!(m.get_entry(id2).unwrap().modify_stamp.is_some());
+    }
+}
+
+#[test]
+fn reconnect_scenario_resyncs_via_verify() {
+    // Peer A does work, disconnects (no sync), comes back, and a
+    // VERIFY heartbeat from B correctly triggers the catch-up flow.
+    let mut a = Peer::new("A");
+    let mut b = Peer::new("B");
+
+    create_text(&mut a.manifest, "shared.md", 0).unwrap();
+    bidirectional_sync(&mut a, &mut b);
+
+    // "Disconnected" — only A mutates.
+    create_text(&mut a.manifest, "offline1.md", 0).unwrap();
+    create_text(&mut a.manifest, "offline2.md", 0).unwrap();
+
+    // On reconnect, B sends VERIFY. A notices mismatch, replies with
+    // A's own STEP_1. This is the "hey, I'm out of sync too, let's
+    // swap state vectors" signal.
+    let v_from_b = b.frame_verify();
+    let step1_from_a = a.receive(&v_from_b).expect("A mismatches with B");
+    // B applies A's step1: returns STEP_2 of what A lacks (nothing, A
+    // is the superset). A applies the empty update.
+    let step2_for_a = b.receive(&step1_from_a).expect("B returns step2 for A");
+    assert!(a.receive(&step2_for_a).is_none());
+
+    // Second leg: B initiates its own STEP_1 to *fetch* A's offline
+    // updates. A returns STEP_2 with offline1.md + offline2.md.
+    let b_step1 = b.frame_step1();
+    let step2_for_b = a.receive(&b_step1).expect("A returns step2 for B");
+    assert!(b.receive(&step2_for_b).is_none());
+
+    assert_converged(&[&a, &b]);
+}


### PR DESCRIPTION
## Summary

First PR on the `release/v1` branch. Adds `docs/DESIGN_DOC_V1.md` — the design document for the v1 rewrite.

v1 replaces v0's JSON `path_map` + server-side `__index__` Y.Text with a single replicated **manifest Y.Doc**. Every file becomes a stable `NodeId` (UUIDv7) whose `name` / `parent` / `deleted` fields are LWW registers on a Yrs `Map`. Content subdocs carry text bodies; a CAS blob store holds binaries.

The design doc covers the 9 sections agreed upstream:

1. Goals & non-goals (including the explicit v1.1 deferral of the journal and of empty-dir sync)
2. Architecture overview (manifest / content subdocs / CAS layers)
3. Data format (on-disk `.syncline/` layout, manifest schema, wire framing with version handshake)
4. Sync protocol changes (`MSG_VERSION`, `MSG_MANIFEST_SYNC`, `MSG_MANIFEST_VERIFY`)
5. Operation semantics (create, delete, rename, move, modify, directories as emergent)
6. Conflict resolution rules (field LWW, modify-wins-over-delete, same-path collisions)
7. Migration v0 → v1 (per-client, one-way, non-destructive of user files)
8. Tombstone GC (knowledge-vector protocol, 30-day floor, server-driven)
9. Test plan — every one of the 49 tests in PR #38 mapped to the v1 mechanism responsible for its outcome

v0 and v1 are protocol-incompatible. Migration is local to each client; a mesh must flip atomically.

## Non-goals for this PR

- **No code.** This is the design-only PR. Implementation lands in follow-up commits on the same branch.

## Follow-up commits planned on `release/v1`

1. Data structures (manifest types, `NodeEntry`, projection)
2. Migration v0 → v1
3. Manifest sync protocol (`MSG_VERSION` + `MSG_MANIFEST_SYNC`)
4. Operation handlers (watcher → manifest transactions)
5. Convergence verification (`MSG_MANIFEST_VERIFY` + Merkle-style root hash)
6. Pass all 49 PR #38 tests
7. Tombstone GC

## Test plan

- [ ] Review the design doc end-to-end
- [ ] Confirm the 9 sections match the agreed scope
- [ ] Confirm the test-matrix in §9 covers the full 49-test suite from PR #38
- [ ] Flag any non-goal that should actually be a v1 goal

See also: `/co-ceo/research/crdt-filesystem-design.md` (internal clean-room reference — v1 implements Part I of that document; Part II's journal is v1.1).