### PR TITLE
fix(client): scan_once respects tombstones on reconnect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5225,7 +5225,7 @@ dependencies = [
 
 [[package]]
 name = "syncline"
-version = "1.0.0-alpha.1"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/syncline/src/client_v1.rs
+++ b/syncline/src/client_v1.rs
@@ -699,6 +699,42 @@ async fn scan_once(
             continue;
         }
         visited_rel.insert(rel_str.clone());
+
+        // Tombstone-shadow check (§5.2 LWW on `deleted`).
+        //
+        // If the manifest already holds a tombstoned NodeId at this
+        // exact raw path, the on-disk file is a stale copy from
+        // before the delete propagated — typical when a peer
+        // reconnects with files it kept while the network was
+        // deleting them out from under it. The tombstone wins;
+        // remove the local file and skip both the text and binary
+        // create branches below. Without this, scan_once would mint
+        // a *fresh* NodeId for the stale path and broadcast it back
+        // to every peer, resurrecting the file network-wide.
+        //
+        // Modify-wins-over-delete (§6.3) is still honoured: if the
+        // node has a `modify_stamp` strictly newer than its
+        // `delete_stamp`, projection treats it as live and the entry
+        // shows up in `proj.by_path`, so we never reach this branch.
+        if let Some(shadow) = manifest.find_entry_by_path(&rel_str) {
+            if shadow.deleted && !proj.by_path.contains_key(&rel_str) {
+                debug!(
+                    node = ?shadow.id,
+                    path = %rel_str,
+                    "removing stale on-disk file shadowing manifest tombstone",
+                );
+                if let Err(e) = fs::remove_file(abs) {
+                    if e.kind() != std::io::ErrorKind::NotFound {
+                        warn!(
+                            path = %rel_str,
+                            "failed to remove stale tombstoned file: {e}",
+                        );
+                    }
+                }
+                continue;
+            }
+        }
+
         let ext = rel
             .extension()
             .and_then(|e| e.to_str())

--- a/syncline/src/v1/manifest.rs
+++ b/syncline/src/v1/manifest.rs
@@ -328,6 +328,77 @@ impl Manifest {
             .filter(|e| !e.deleted)
             .collect()
     }
+
+    /// Look up an entry by its disk-relative path, **including
+    /// tombstoned entries**.
+    ///
+    /// This differs from `Projection::by_path` (which filters
+    /// tombstones away under §6.1 LWW) in that it walks the raw
+    /// `(name, parent)` chain on every entry and yields a match
+    /// regardless of `deleted` state.
+    ///
+    /// Used by `scan_once` to detect that an on-disk file
+    /// corresponds to a tombstoned NodeId — and therefore must be
+    /// removed locally rather than promoted into a fresh sibling
+    /// NodeId via `create_text` / `create_binary`. Without this
+    /// lookup, a peer that reconnects with stale files from before a
+    /// delete propagated would resurrect every one of them on the
+    /// entire network. See `DESIGN_DOC_V1.md` §5.2.
+    ///
+    /// On collision (a live and a tombstoned entry both project to
+    /// the same raw path — possible during a same-path simultaneous
+    /// create) the **live** entry is returned. Directory entries are
+    /// not considered (directories never appear in
+    /// `Projection::by_path`).
+    pub fn find_entry_by_path(&self, path: &str) -> Option<NodeEntry> {
+        let all = self.all_entries();
+        let mut best: Option<NodeEntry> = None;
+        for entry in all.values() {
+            if entry.kind == NodeKind::Directory {
+                continue;
+            }
+            let Some(p) = build_path_ignoring_tombstones(entry, &all) else {
+                continue;
+            };
+            if p != path {
+                continue;
+            }
+            match &best {
+                Some(b) if !b.deleted && entry.deleted => {}
+                _ => {
+                    best = Some(entry.clone());
+                }
+            }
+        }
+        best
+    }
+}
+
+/// Build a disk-relative path for `entry` by walking the parent chain,
+/// **without** the projection's tombstoned-directory bail-out. The
+/// scanner needs to recognise a tombstoned leaf even when its
+/// directory chain itself is partially tombstoned but still on disk.
+/// Returns `None` if the chain is broken (parent NodeId not present)
+/// or pathologically deep.
+fn build_path_ignoring_tombstones(
+    entry: &NodeEntry,
+    all: &HashMap<NodeId, NodeEntry>,
+) -> Option<String> {
+    let mut segments: Vec<String> = vec![entry.name.clone()];
+    let mut cursor = entry.parent;
+    let mut hops = 0usize;
+    const MAX_HOPS: usize = 1024;
+    while let Some(pid) = cursor {
+        hops += 1;
+        if hops > MAX_HOPS {
+            return None;
+        }
+        let parent = all.get(&pid)?;
+        segments.push(parent.name.clone());
+        cursor = parent.parent;
+    }
+    segments.reverse();
+    Some(segments.join("/"))
 }
 
 fn get_entry_map<T: ReadTxn>(nodes: &MapRef, txn: &T, id: NodeId) -> Option<MapRef> {
@@ -540,6 +611,62 @@ mod tests {
         let e = m.get_entry(id).unwrap();
         assert_eq!(e.blob_hash.as_deref(), Some("ef567890"));
         assert_eq!(e.size, 2048);
+    }
+
+    #[test]
+    fn find_entry_by_path_returns_tombstoned() {
+        let mut m = Manifest::new(ActorId::new());
+        let id = m.create_node("ghost.md", None, NodeKind::Text, None, 0);
+        m.delete(id);
+        let found = m.find_entry_by_path("ghost.md").expect("tombstone reachable");
+        assert_eq!(found.id, id);
+        assert!(found.deleted);
+    }
+
+    #[test]
+    fn find_entry_by_path_returns_live() {
+        let mut m = Manifest::new(ActorId::new());
+        let id = m.create_node("alive.md", None, NodeKind::Text, None, 0);
+        let found = m.find_entry_by_path("alive.md").unwrap();
+        assert_eq!(found.id, id);
+        assert!(!found.deleted);
+    }
+
+    #[test]
+    fn find_entry_by_path_returns_none_when_absent() {
+        let m = Manifest::new(ActorId::new());
+        assert!(m.find_entry_by_path("nope.md").is_none());
+    }
+
+    #[test]
+    fn find_entry_by_path_prefers_live_over_tombstoned() {
+        let mut m = Manifest::new(ActorId::new());
+        let dead = m.create_node("collide.md", None, NodeKind::Text, None, 0);
+        m.delete(dead);
+        let live = m.create_node("collide.md", None, NodeKind::Text, None, 0);
+        let found = m.find_entry_by_path("collide.md").unwrap();
+        assert_eq!(found.id, live);
+        assert!(!found.deleted);
+    }
+
+    #[test]
+    fn find_entry_by_path_walks_directory_chain() {
+        let mut m = Manifest::new(ActorId::new());
+        let dir = m.create_node("folder", None, NodeKind::Directory, None, 0);
+        let file = m.create_node("note.md", Some(dir), NodeKind::Text, None, 0);
+        m.delete(file);
+        let found = m.find_entry_by_path("folder/note.md").unwrap();
+        assert_eq!(found.id, file);
+        assert!(found.deleted);
+    }
+
+    #[test]
+    fn find_entry_by_path_skips_directory_kind() {
+        // A directory's "path" must not collide with a file lookup —
+        // directories are emergent (§5.6), never projected as files.
+        let mut m = Manifest::new(ActorId::new());
+        let _dir = m.create_node("folder", None, NodeKind::Directory, None, 0);
+        assert!(m.find_entry_by_path("folder").is_none());
     }
 
     #[test]

--- a/syncline/tests/e2e.rs
+++ b/syncline/tests/e2e.rs
@@ -505,6 +505,164 @@ async fn test_offline_creation_and_deletion() {
     assert!(!env.client_path(1).join("base.md").exists());
 }
 
+/// Symmetric inverse of `test_offline_creation_and_deletion`: this time
+/// Client 0 (online) is the deleter and Client 1 (offline) is the
+/// survivor that holds a stale copy on disk.
+///
+/// Reproduces the late-reconnect tombstone resurrection bug: a peer
+/// that goes offline before a delete propagates, then reconnects with
+/// the (now-tombstoned) file still on disk, must NOT resurrect it via
+/// `scan_once` creating a fresh NodeId. Instead, the local stale copy
+/// must be removed when the manifest tombstone arrives.
+///
+/// Spec: DESIGN_DOC_V1.md §5.2 (delete protocol) + §9.5 test plan
+/// (`test_delete_propagates_to_late_reconnecting_client`). The v1
+/// test was named in the design doc but never implemented; v0 had
+/// the same class of bug documented as KNOWN_BUGS #9 (was fixed for
+/// v0, regressed in v1).
+#[tokio::test]
+async fn test_delete_propagates_to_late_reconnecting_client() {
+    let mut env = TestEnv::new(2).await;
+
+    // Synced state: both peers have the file.
+    let path0 = env.client_path(0).join("doomed.md");
+    fs::write(&path0, "delete me later").unwrap();
+    assert!(wait_for_convergence(&env.dirs(), Duration::from_secs(8)).await);
+    assert!(env.client_path(1).join("doomed.md").exists());
+
+    // Peer 1 goes offline.
+    env.clients[1].kill().await.unwrap();
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    // Peer 0 (online) deletes the file. Server gets the tombstone.
+    fs::remove_file(&path0).unwrap();
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    // Peer 1 reconnects. It still has `doomed.md` on disk from the
+    // pre-delete sync. After reconnect + manifest sync + scan, the
+    // tombstone must win and the local file must be removed — NOT
+    // recreated as a fresh NodeId on the server.
+    let dir1 = env.client_dirs[1].path().to_path_buf();
+    env.clients[1] = spawn_client(&dir1, env.port).await;
+
+    assert!(wait_for_convergence(&env.dirs(), Duration::from_secs(20)).await);
+
+    assert!(
+        !env.client_path(0).join("doomed.md").exists(),
+        "peer 0: doomed.md must stay deleted after peer 1 reconnect (resurrection bug)",
+    );
+    assert!(
+        !env.client_path(1).join("doomed.md").exists(),
+        "peer 1: doomed.md must be removed when reconnect surfaces the tombstone (resurrection bug)",
+    );
+}
+
+/// Binary variant of `test_delete_propagates_to_late_reconnecting_client`.
+/// Targets the parallel resurrection path in `process_binary_file`:
+/// when the per-walk projection (which filters tombstoned entries)
+/// reports `None` for a binary path, the scanner currently calls
+/// `create_binary` and produces a fresh NodeId, broadcasting the
+/// tombstoned blob back as a new node.
+#[tokio::test]
+async fn test_delete_propagates_to_late_reconnecting_client_binary() {
+    let mut env = TestEnv::new(2).await;
+
+    // Tiny "PNG" — header + a few payload bytes. Mirrors
+    // test_binary_file_sync's fixture for consistency.
+    let png_data: Vec<u8> = vec![
+        0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
+        0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
+        0xCA, 0xFE, 0xBA, 0xBE,
+    ];
+    let path0 = env.client_path(0).join("doomed.png");
+    fs::write(&path0, &png_data).unwrap();
+
+    // Binary sync needs a longer settle (CAS blob round-trip).
+    tokio::time::sleep(Duration::from_secs(8)).await;
+    assert!(env.client_path(1).join("doomed.png").exists());
+
+    env.clients[1].kill().await.unwrap();
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    fs::remove_file(&path0).unwrap();
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    let dir1 = env.client_dirs[1].path().to_path_buf();
+    env.clients[1] = spawn_client(&dir1, env.port).await;
+
+    assert!(wait_for_convergence(&env.dirs(), Duration::from_secs(20)).await);
+
+    assert!(
+        !env.client_path(0).join("doomed.png").exists(),
+        "peer 0: doomed.png must stay deleted (binary resurrection bug)",
+    );
+    assert!(
+        !env.client_path(1).join("doomed.png").exists(),
+        "peer 1: doomed.png must be removed on reconnect (binary resurrection bug)",
+    );
+}
+
+/// Scaled-down replica of the 2026-04-25 vault chaos: many files
+/// deleted while one peer is offline, and on reconnect the offline
+/// peer must accept the tombstones rather than re-broadcasting all of
+/// them as new nodes (which is what produced the +200-file overwrite
+/// in production).
+///
+/// Uses 25 files to keep CI runtime bounded. The mechanism under test
+/// is identical to the single-file case; we just want to ensure the
+/// fix applies uniformly, not only to one entry.
+#[tokio::test]
+async fn test_bulk_delete_propagates_to_late_reconnecting_client() {
+    let mut env = TestEnv::new(2).await;
+
+    const N: usize = 25;
+    let names: Vec<String> = (0..N).map(|i| format!("doomed_{i:03}.md")).collect();
+
+    for (i, name) in names.iter().enumerate() {
+        fs::write(
+            env.client_path(0).join(name),
+            format!("payload-{i}"),
+        )
+        .unwrap();
+    }
+    assert!(wait_for_convergence(&env.dirs(), Duration::from_secs(20)).await);
+    for name in &names {
+        assert!(
+            env.client_path(1).join(name).exists(),
+            "{name} must reach peer 1 in the synced phase",
+        );
+    }
+
+    env.clients[1].kill().await.unwrap();
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    for name in &names {
+        fs::remove_file(env.client_path(0).join(name)).unwrap();
+    }
+    tokio::time::sleep(Duration::from_secs(5)).await;
+
+    let dir1 = env.client_dirs[1].path().to_path_buf();
+    env.clients[1] = spawn_client(&dir1, env.port).await;
+
+    assert!(wait_for_convergence(&env.dirs(), Duration::from_secs(45)).await);
+
+    let mut still_alive: Vec<String> = Vec::new();
+    for name in &names {
+        if env.client_path(0).join(name).exists()
+            || env.client_path(1).join(name).exists()
+        {
+            still_alive.push(name.clone());
+        }
+    }
+    assert!(
+        still_alive.is_empty(),
+        "{} of {} tombstoned files were resurrected after peer 1 reconnect: {:?}",
+        still_alive.len(),
+        N,
+        still_alive,
+    );
+}
+
 /// Client A syncs a file to the server, then Client B (a fresh directory with its own
 /// pre-existing file of the same name) connects. The conflict is resolved by keeping the
 /// server content as the canonical file and renaming B's local content.


### PR DESCRIPTION
## Summary

Fixes the late-reconnect tombstone resurrection bug. When a peer goes
offline, files are deleted on the online side, and the offline peer
reconnects with stale on-disk copies, those files are currently
**resurrected** on every peer instead of being deleted. Real-world
hit on 2026-04-25: an iPhone reconnect re-pushed 200+ tombstoned
files into the vault.

Companion to `docs/KNOWN_BUGS.md` #9 (fixed for v0, regressed in v1)
and `docs/DESIGN_DOC_V1.md` §5.2 (delete protocol) / §9.5
(`test_delete_propagates_to_late_reconnecting_client` — listed in the
v1 test plan but never implemented).

## Mechanism

`Projection::by_path` filters tombstoned entries away (correctly,
per §6.1 LWW). `scan_once` consulted only the projection when
deciding whether a disk path was already known, found nothing for
tombstoned paths, and fell into the "truly new file" branch — minting
a fresh NodeId for each stale file with a local lamport advanced past
the tombstone's stamp, so the new node won every subsequent LWW
comparison. The freshly minted nodes broadcast back to the network
and re-materialised on every peer.

## Fix

- New `Manifest::find_entry_by_path` (with a private path-builder
  that traverses tombstoned directories, unlike
  `projection::build_path`) for raw-path lookup including
  tombstoned entries.
- In `scan_once`, before falling into the create-fresh-NodeId
  branch, consult `find_entry_by_path`. If a tombstoned shadow
  matches and the live projection has nothing at that path, remove
  the local file and skip — tombstone wins.
- The check sits above the text/binary fork so
  `process_binary_file` inherits the same protection without
  touching its internals.
- Modify-wins-over-delete (§6.3) is preserved: when a node has
  `modify_stamp` newer than `delete_stamp`, projection treats it as
  live → it appears in `proj.by_path` → we never reach the new
  check.

## Tests

Three new integration tests in `syncline/tests/e2e.rs` (added in the
first commit, expected to **FAIL** on parent; now PASS on the fix
commit — TDD):

- `test_delete_propagates_to_late_reconnecting_client` (text)
- `test_delete_propagates_to_late_reconnecting_client_binary` (PNG)
- `test_bulk_delete_propagates_to_late_reconnecting_client` (25 files)

Plus six unit tests for `find_entry_by_path` in
`syncline/src/v1/manifest.rs` covering tombstoned, live, absent,
live-vs-tombstoned collision, nested directory chain, and
directory-kind exclusion.

Local results: 203/203 unit tests pass, 24/24 `tests/e2e.rs`,
11/11 `tests/v1_protocol_e2e.rs`, clean `cargo build --release`.

## Out of scope

- Persistent `on_disk` map across sessions (P1 polish — would harden
  the existing stale-cleanup pass against a session restart).
- Knowledge-vector tombstone GC with low-water-mark / 30-day floor
  (P2 — design completion per §8 of the design doc).

## Test plan

- [x] `cargo test -p syncline --lib` (203 pass)
- [x] `cargo test -p syncline --test e2e -- --test-threads=1` (24 pass)
- [x] `cargo test -p syncline --test v1_protocol_e2e` (11 pass)
- [x] `cargo build --release -p syncline` (clean)
- [x] New integration tests fail on parent commit, pass on fix