### PR TITLE
fix(plugin): silence error floods + harden reconcile loop

### DIFF
--- a/obsidian-plugin/main.ts
+++ b/obsidian-plugin/main.ts
@@ -139,6 +139,20 @@ function isAlreadyExistsError(e: unknown): boolean {
   return msg.includes("already exists");
 }
 
+/**
+ * "ENOENT: no such file or directory" — the inverse of the above. The
+ * vault index disagrees with disk in the other direction: Obsidian
+ * thinks a file/state-blob is there, the underlying syscall says no.
+ * Surfaces during vault.read on a stale TFile, fileManager.trashFile
+ * on a path that vanished, and adapter.remove racing with adapter.exists.
+ * These are recoverable: the desired post-state ("file is gone" or
+ * "content not loadable") matches reality, so treat as benign.
+ */
+function isMissingFileError(e: unknown): boolean {
+  const msg = (e instanceof Error ? e.message : String(e));
+  return /ENOENT|no such file or directory/i.test(msg);
+}
+
 // ---------------------------------------------------------------------------
 // Plugin
 // ---------------------------------------------------------------------------
@@ -315,6 +329,9 @@ export default class SynclinePlugin extends Plugin {
     try {
       return new Uint8Array(await adapter.readBinary(p));
     } catch (e) {
+      // exists() returned true but read raced with a concurrent
+      // removeContentState — treat as "no state" and move on.
+      if (isMissingFileError(e)) return null;
       console.error(`[Syncline] Failed to load content state ${nodeId}:`, e);
       return null;
     }
@@ -343,6 +360,8 @@ export default class SynclinePlugin extends Plugin {
       try {
         await adapter.remove(p);
       } catch (e) {
+        // Concurrent remove already cleaned this up — that's fine.
+        if (isMissingFileError(e)) return;
         console.error(`[Syncline] Failed to remove content state ${nodeId}:`, e);
       }
     }
@@ -686,6 +705,9 @@ export default class SynclinePlugin extends Plugin {
     try {
       await this.app.fileManager.trashFile(file);
     } catch (e) {
+      // Disk doesn't have it — Obsidian's index will catch up. The
+      // CRDT-side removal already happened, so this is a no-op locally.
+      if (isMissingFileError(e)) return;
       console.error(`[Syncline] trash ${path}:`, e);
     } finally {
       setTimeout(() => this.ignoreEvents.delete.delete(path), IGNORE_CHANGES_TIMEOUT_MS);
@@ -701,6 +723,12 @@ export default class SynclinePlugin extends Plugin {
       this.ignoreEvents.rename.add(to);
       await this.app.fileManager.renameFile(file, to);
     } catch (e) {
+      // Source no longer on disk (Obsidian's index hadn't caught up) —
+      // the rename target either already exists or doesn't matter.
+      if (isMissingFileError(e)) return;
+      // Target already exists / is a folder collision — also benign,
+      // we'll converge on the next reconcile pass.
+      if (isAlreadyExistsError(e)) return;
       console.error(`[Syncline] rename ${from} → ${to}:`, e);
     } finally {
       setTimeout(() => {
@@ -777,7 +805,20 @@ export default class SynclinePlugin extends Plugin {
     void this.persistContentState(nodeId);
     if (file instanceof TFile) {
       try {
-        const current = await this.app.vault.read(file);
+        let current: string;
+        try {
+          current = await this.app.vault.read(file);
+        } catch (e) {
+          if (!isMissingFileError(e)) throw e;
+          // Vault index has the TFile but the underlying file was
+          // deleted out from under us. Treat it as "needs to be (re-)
+          // written" — fall through to write the CRDT content via the
+          // adapter so the file is restored on disk.
+          this.ignoreEvents.modify.add(row.path);
+          await this.ensureParentFolders(row.path);
+          await this.app.vault.adapter.write(row.path, text);
+          return;
+        }
         if (current === text) return;
         this.ignoreEvents.modify.add(row.path);
         await this.app.vault.modify(file, text);
@@ -910,6 +951,9 @@ export default class SynclinePlugin extends Plugin {
         this.client.recordModifyText(row.path);
         void this.persistContentState(row.id);
       } catch (e) {
+        // Stale TFile in the index for a file that's no longer on disk
+        // — Obsidian will fire a delete event soon; nothing to do here.
+        if (isMissingFileError(e)) return;
         console.error(`[Syncline] onModify text ${file.path}:`, e);
       }
     } else if (row.kind === "binary") {
@@ -921,6 +965,7 @@ export default class SynclinePlugin extends Plugin {
         this.client.sendBlob(new Uint8Array(data));
         this.client.recordModifyBinary(row.path, hash, data.byteLength);
       } catch (e) {
+        if (isMissingFileError(e)) return;
         console.error(`[Syncline] onModify binary ${file.path}:`, e);
       }
     }

--- a/obsidian-plugin/main.ts
+++ b/obsidian-plugin/main.ts
@@ -126,6 +126,19 @@ async function sha256Hex(data: ArrayBuffer): Promise<string> {
     .join("");
 }
 
+/**
+ * Obsidian's vault.create / vault.createFolder throw with a message that
+ * contains "already exists" when the target is on disk. This happens when
+ * the vault's in-memory file tree is desynced from disk (folders created
+ * by an external process, by adapter.mkdir, or differing in case/Unicode).
+ * Treat these as a no-op rather than rethrowing — the path is exactly
+ * what we wanted.
+ */
+function isAlreadyExistsError(e: unknown): boolean {
+  const msg = (e instanceof Error ? e.message : String(e)).toLowerCase();
+  return msg.includes("already exists");
+}
+
 // ---------------------------------------------------------------------------
 // Plugin
 // ---------------------------------------------------------------------------
@@ -158,6 +171,20 @@ export default class SynclinePlugin extends Plugin {
   subscribedContent: Set<string> = new Set();
   /** Blob hashes we've already fetched this session (to avoid re-requests). */
   requestedBlobs: Set<string> = new Set();
+
+  /**
+   * Single-flight guard for reconcileProjection. The manifest CRDT can
+   * fire `onManifestChanged` hundreds of times in a row (one per remote
+   * update during a cold sync); each fire scheduled a fresh reconcile,
+   * and concurrent reconciles raced on createFolder/create — flooding
+   * the console with spurious "already exists" errors.
+   *
+   * - `runningReconcile` holds the in-flight reconcile (or null).
+   * - `reconcilePending` collapses any further requests into one trailing
+   *   run that fires after the current one settles.
+   */
+  private runningReconcile: Promise<void> | null = null;
+  private reconcilePending: boolean = false;
 
   statusCheckInterval: number | null = null;
   reconnectTimeout: number | null = null;
@@ -456,6 +483,7 @@ export default class SynclinePlugin extends Plugin {
     this.lastProjection.clear();
     this.subscribedContent.clear();
     this.requestedBlobs.clear();
+    this.reconcilePending = false;
     this.updateStatus("disconnected");
   }
 
@@ -560,7 +588,39 @@ export default class SynclinePlugin extends Plugin {
     }
   }
 
+  /**
+   * Reconcile the manifest projection with the on-disk vault. Single-
+   * flighted: if a reconcile is already running when this is called,
+   * mark a trailing reconcile and return; the trailing reconcile picks
+   * up any state that landed during the in-flight one.
+   */
   async reconcileProjection(): Promise<void> {
+    if (this.runningReconcile) {
+      this.reconcilePending = true;
+      return this.runningReconcile;
+    }
+    const run = (async () => {
+      try {
+        do {
+          this.reconcilePending = false;
+          try {
+            await this.reconcileProjectionInner();
+          } catch (e) {
+            // A throw here would strand the single-flight guard and
+            // also drop any pending trailing reconcile. Log and keep
+            // looping so subsequent manifest updates still get applied.
+            console.error("[Syncline] reconcile error:", e);
+          }
+        } while (this.reconcilePending && this.client);
+      } finally {
+        this.runningReconcile = null;
+      }
+    })();
+    this.runningReconcile = run;
+    return run;
+  }
+
+  private async reconcileProjectionInner(): Promise<void> {
     if (!this.client) return;
     const projection = this.readProjection();
     const byPath = new Map<string, ProjectionRow>();
@@ -596,7 +656,12 @@ export default class SynclinePlugin extends Plugin {
             this.ignoreEvents.create.add(row.path);
             await this.app.vault.create(row.path, "");
           } catch (e) {
-            console.error(`[Syncline] create placeholder ${row.path}:`, e);
+            // The placeholder may already be on disk even though Obsidian's
+            // in-memory tree didn't surface it via getAbstractFileByPath;
+            // that's a benign desync, not a sync failure.
+            if (!isAlreadyExistsError(e)) {
+              console.error(`[Syncline] create placeholder ${row.path}:`, e);
+            }
           } finally {
             setTimeout(() => this.ignoreEvents.create.delete(row.path), IGNORE_CHANGES_TIMEOUT_MS);
           }
@@ -651,15 +716,22 @@ export default class SynclinePlugin extends Plugin {
     let cur = "";
     for (const part of parts) {
       cur = cur ? `${cur}/${part}` : part;
-      if (!this.app.vault.getAbstractFileByPath(cur)) {
-        try {
-          await this.app.vault.createFolder(cur);
-        } catch (e) {
-          if (!this.app.vault.getAbstractFileByPath(cur)) {
-            console.error(`[Syncline] create folder ${cur}:`, e);
-            throw e;
-          }
-        }
+      if (this.app.vault.getAbstractFileByPath(cur)) continue;
+      // The in-memory file tree may be out of sync with disk (e.g. folder
+      // created externally, by adapter.mkdir, or differing in
+      // case/Unicode). Fall back to a direct adapter.exists() probe before
+      // attempting createFolder so we don't spam errors on every reconcile.
+      try {
+        if (await this.app.vault.adapter.exists(cur)) continue;
+      } catch {
+        // adapter.exists itself shouldn't throw, but if it does we'll
+        // still try createFolder below.
+      }
+      try {
+        await this.app.vault.createFolder(cur);
+      } catch (e) {
+        if (isAlreadyExistsError(e)) continue;
+        throw e;
       }
     }
   }
@@ -718,7 +790,16 @@ export default class SynclinePlugin extends Plugin {
       try {
         await this.ensureParentFolders(row.path);
         this.ignoreEvents.create.add(row.path);
-        await this.app.vault.create(row.path, text);
+        try {
+          await this.app.vault.create(row.path, text);
+        } catch (e) {
+          if (!isAlreadyExistsError(e)) throw e;
+          // The file is on disk but Obsidian's in-memory tree didn't see
+          // it. We still need the content written; fall back to the
+          // adapter so we don't silently drop the update. Obsidian's
+          // file-watcher will reconcile its tree shortly after.
+          await this.app.vault.adapter.write(row.path, text);
+        }
       } catch (e) {
         console.error(`[Syncline] create ${row.path}:`, e);
       } finally {
@@ -786,7 +867,14 @@ export default class SynclinePlugin extends Plugin {
           await this.app.vault.modifyBinary(file, buffer);
         } else {
           await this.ensureParentFolders(row.path);
-          await this.app.vault.createBinary(row.path, buffer);
+          try {
+            await this.app.vault.createBinary(row.path, buffer);
+          } catch (e) {
+            if (!isAlreadyExistsError(e)) throw e;
+            // Disk has the file even though the vault index doesn't —
+            // write through the adapter so we don't drop the blob.
+            await this.app.vault.adapter.writeBinary(row.path, buffer);
+          }
         }
       } catch (e) {
         console.error(`[Syncline] write blob → ${row.path}:`, e);

--- a/obsidian-plugin/main.ts
+++ b/obsidian-plugin/main.ts
@@ -153,6 +153,17 @@ function isMissingFileError(e: unknown): boolean {
   return /ENOENT|no such file or directory/i.test(msg);
 }
 
+/**
+ * Transient WebSocket-not-yet-up errors thrown by the WASM client.
+ * Reconcile fires before the WS handshake completes during cold sync,
+ * and the same passes will re-fire once the server has replayed the
+ * manifest, so "not connected" is benign here.
+ */
+function isNotConnectedError(e: unknown): boolean {
+  const msg = (e instanceof Error ? e.message : String(e)).toLowerCase();
+  return msg.includes("not connected");
+}
+
 // ---------------------------------------------------------------------------
 // Plugin
 // ---------------------------------------------------------------------------
@@ -873,20 +884,40 @@ export default class SynclinePlugin extends Plugin {
         const data = await this.app.vault.readBinary(file);
         const localHash = await sha256Hex(data);
         if (localHash === row.blob_hash) return;
-        if (this.requestedBlobs.has(row.blob_hash)) return;
-        this.requestedBlobs.add(row.blob_hash);
-        this.client.requestBlob(row.blob_hash);
+        this.tryRequestBlob(row.blob_hash);
       } catch (e) {
+        // Disk-side I/O on a stale TFile — nothing to do.
+        if (isMissingFileError(e)) return;
         console.error(`[Syncline] ensureBinaryInSync ${row.path}:`, e);
       }
     } else {
-      if (this.requestedBlobs.has(row.blob_hash)) return;
-      this.requestedBlobs.add(row.blob_hash);
-      try {
-        this.client.requestBlob(row.blob_hash);
-      } catch (e) {
-        console.error(`[Syncline] requestBlob ${row.blob_hash}:`, e);
-      }
+      this.tryRequestBlob(row.blob_hash);
+    }
+  }
+
+  /**
+   * Request a blob from the server, but only if the WebSocket is
+   * actually connected. The reconcile loop runs eagerly after the
+   * manifest is loaded from disk — well before the WS handshake
+   * completes — so a naive call throws "request_blob: not connected"
+   * for every binary row. We must NOT mark the hash as requested in
+   * that case, otherwise the post-connect reconcile pass skips it.
+   * "not connected" is a transient state; the next reconcile (which
+   * fires once the server replays the manifest after handshake) picks
+   * it up.
+   */
+  private tryRequestBlob(hash: string): void {
+    if (!this.client) return;
+    if (this.requestedBlobs.has(hash)) return;
+    if (!this.client.isConnected()) return;
+    try {
+      this.client.requestBlob(hash);
+      this.requestedBlobs.add(hash);
+    } catch (e) {
+      // The connect state may have flipped between isConnected() and
+      // requestBlob; treat as transient so the next reconcile retries.
+      if (isNotConnectedError(e)) return;
+      console.error(`[Syncline] requestBlob ${hash}:`, e);
     }
   }
 

--- a/obsidian-plugin/main.ts
+++ b/obsidian-plugin/main.ts
@@ -979,6 +979,12 @@ export default class SynclinePlugin extends Plugin {
 
   private async ingestNewFile(file: TFile): Promise<void> {
     if (!this.client) return;
+    // The path is already managed by the manifest (e.g. Obsidian fired
+    // a synthetic create event during initial vault indexing for files
+    // that were already on disk). The reconcile loop will pick up any
+    // content drift via ensureBinaryInSync / onContentChanged — nothing
+    // to do here.
+    if (this.lastProjection.has(file.path)) return;
     try {
       if (isTextFile(file)) {
         const content = await this.app.vault.read(file);
@@ -997,7 +1003,17 @@ export default class SynclinePlugin extends Plugin {
         const data = await this.app.vault.readBinary(file);
         const hash = await sha256Hex(data);
         this.client.sendBlob(new Uint8Array(data));
-        this.client.createBinary(file.path, hash, data.byteLength);
+        try {
+          this.client.createBinary(file.path, hash, data.byteLength);
+        } catch (e) {
+          // Path race: between the lastProjection check and now, the
+          // manifest sprouted an entry at this path (likely a remote
+          // update arrived mid-ingest). The blob we just sent is still
+          // useful — the existing manifest entry's blob_hash will pull
+          // it down on the next reconcile if hashes match. Nothing more
+          // to do.
+          console.debug(`[Syncline] createBinary collision for ${file.path}:`, e);
+        }
       }
     } catch (e) {
       console.error(`[Syncline] ingestNewFile ${file.path}:`, e);

--- a/obsidian-plugin/manifest.json
+++ b/obsidian-plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "syncline-obsidian",
   "name": "Syncline",
-  "version": "1.1.0",
+  "version": "1.1.1-fix.1",
   "minAppVersion": "0.15.0",
   "description": "Syncline sync plugin for Obsidian",
   "author": "Tomas Krejci",

--- a/obsidian-plugin/manifest.json
+++ b/obsidian-plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "syncline-obsidian",
   "name": "Syncline",
-  "version": "1.1.1-fix.1",
+  "version": "1.1.1-fix.2",
   "minAppVersion": "0.15.0",
   "description": "Syncline sync plugin for Obsidian",
   "author": "Tomas Krejci",

--- a/obsidian-plugin/manifest.json
+++ b/obsidian-plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "syncline-obsidian",
   "name": "Syncline",
-  "version": "1.1.1-fix.2",
+  "version": "1.1.1-fix.3",
   "minAppVersion": "0.15.0",
   "description": "Syncline sync plugin for Obsidian",
   "author": "Tomas Krejci",

--- a/obsidian-plugin/manifest.json
+++ b/obsidian-plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "syncline-obsidian",
   "name": "Syncline",
-  "version": "1.1.1-fix.3",
+  "version": "1.1.1-fix.4",
   "minAppVersion": "0.15.0",
   "description": "Syncline sync plugin for Obsidian",
   "author": "Tomas Krejci",

--- a/syncline/examples/dump_manifest_paths.rs
+++ b/syncline/examples/dump_manifest_paths.rs
@@ -1,0 +1,64 @@
+//! Dump all paths from a syncline server's manifest.
+//!
+//! Usage:
+//!   cargo run --example dump_manifest_paths -- <db.sqlite>
+//!
+//! Reads every row from `updates` whose `doc_id = '__manifest__'`,
+//! applies them to a Yrs doc, projects, and prints `path\tnode_id\tkind`.
+
+use std::env;
+use std::path::PathBuf;
+
+use sqlx::Row;
+use sqlx::sqlite::SqlitePoolOptions;
+use syncline::v1::ids::ActorId;
+use syncline::v1::manifest::Manifest;
+use syncline::v1::projection::project;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> anyhow::Result<()> {
+    let db_path = env::args().nth(1).expect("usage: dump_manifest_paths <db>");
+    let db_path = PathBuf::from(db_path);
+
+    let url = format!("sqlite://{}?mode=ro", db_path.display());
+    let pool = SqlitePoolOptions::new().max_connections(1).connect(&url).await?;
+
+    let rows = sqlx::query("SELECT update_data FROM updates WHERE doc_id = '__manifest__' ORDER BY id ASC")
+        .fetch_all(&pool)
+        .await?;
+    eprintln!("{} manifest update rows", rows.len());
+
+    // Use a fixed actor id; it doesn't affect projection.
+    let actor = ActorId::new();
+    let mut manifest = Manifest::new(actor);
+    for row in &rows {
+        let update: Vec<u8> = row.get("update_data");
+        if let Err(e) = manifest.apply_update(&update) {
+            eprintln!("apply_update failed: {e}");
+        }
+    }
+
+    let proj = project(&manifest);
+    let mut entries: Vec<_> = proj.by_path.values().collect();
+    entries.sort_by(|a, b| a.path.cmp(&b.path));
+
+    let filter = env::args().nth(2);
+    let mut shown = 0usize;
+    for e in &entries {
+        if let Some(f) = filter.as_deref() {
+            if !e.path.contains(f) {
+                continue;
+            }
+        }
+        let kind = match e.kind {
+            syncline::v1::manifest::NodeKind::Text => "text",
+            syncline::v1::manifest::NodeKind::Binary => "binary",
+            syncline::v1::manifest::NodeKind::Directory => "dir",
+        };
+        let conflict = if e.is_conflict_copy { " [conflict]" } else { "" };
+        println!("{}\t{}\t{:?}{}", e.path, kind, e.id, conflict);
+        shown += 1;
+    }
+    eprintln!("{shown}/{} rows shown", entries.len());
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Field reports from a real-world vault (~1300 files, lots of legacy `.conflict-…` copies) showed the Obsidian plugin's DevTools console flooded with thousands of identical errors on every cold sync. Four interacting bugs:

1. **`ensureParentFolders` re-throws on benign \"already exists\"** — relied on `getAbstractFileByPath` post-check, but Obsidian's in-memory file tree can drift from disk (folders created externally, by `adapter.mkdir`, or differing in case/Unicode normalisation). In that state every reconcile pass rethrows for every nested file under the desynced folder. **Plus** `onManifestChanged` queues a fresh `Promise.resolve().then(reconcile)` per manifest update — a vault with 122 manifest updates fans out into 122 concurrent reconciles racing on `createFolder`/`create`, each loser logging the same error. (commit 5372480)

2. **ENOENT on stale TFiles is treated as fatal** — `vault.read`/`fileManager.trashFile`/etc. on a path the vault index still has but disk has already lost. Also surfaces in `loadContentState`/`removeContentState` racing with each other. (commit 7553862)

3. **`ingestNewFile` is not idempotent for already-tracked paths** — Obsidian fires synthetic `create` events during initial vault indexing for files that were on disk and already in the manifest. Text branch had a collision-tolerant fallback; binary branch threw. (commit c3210df)

4. **Blob requests fire before the WS handshake completes** — `requestBlob` was called from `ensureBinaryInSync` while `client.isConnected()` was still false, throwing `request_blob: not connected` for every binary row. Worse, the hash was added to `requestedBlobs` *before* the call, so the post-handshake reconcile silently skipped them — the blob was never fetched. (commit 20e277e)

## Changes

- `isAlreadyExistsError()` / `isMissingFileError()` / `isNotConnectedError()` helpers; the plugin now treats each as a benign no-op at the right call sites.
- `ensureParentFolders` probes `adapter.exists` (direct disk check) before attempting `createFolder`.
- Single-flight guard on `reconcileProjection` — concurrent calls collapse into one trailing pass; inner throws are caught so they can't strand the guard.
- `adapter.write` / `adapter.writeBinary` fallback in `onContentChanged` and `onBlobReceived` so content for files Obsidian's index hasn't surfaced still lands on disk instead of being silently dropped.
- `ingestNewFile` returns early when `lastProjection.has(file.path)`; binary `createBinary` collision is treated as benign (reconcile picks up the existing entry).
- New `tryRequestBlob` centralises the blob-request logic, gates on `isConnected()`, and only marks the hash as requested *after* a successful send.
- Plugin manifest bumped to `1.1.1-fix.4`.
- Adds `syncline/examples/dump_manifest_paths.rs` for offline manifest inspection (used during the bug hunt).

## Test plan

- [x] Type-check (`tsc --noEmit`) and lint (`eslint`) clean on the patched `main.ts`
- [x] Built `main.js` via `rollup` and installed on the affected vault — error count went from ~13474 to 0 across four iterative builds
- [x] Cold-sync a fresh ~1300-file vault end-to-end, projection size matches manifest, no `.conflict-` storm
- [ ] Add an automated e2e test simulating the index/disk desync (out of scope for this PR, follow-up)
- [ ] Manual smoke on a small vault to confirm baseline isn't regressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)