### PR TITLE
fix(sync): reciprocate content STEP_1 to unblock client→server pushes

### DIFF
--- a/syncline/src/client_v1.rs
+++ b/syncline/src/client_v1.rs
@@ -532,7 +532,34 @@ async fn run_session(
                             }
                         }
                         MSG_SYNC_STEP_1 => {
-                            debug!("unexpected STEP_1 for {}", doc_id);
+                            // Server (or peer) is asking for the diff
+                            // we have past their state vector. This is
+                            // the second leg of the Yrs sync protocol —
+                            // without it, content authored locally but
+                            // never re-edited never flows back to the
+                            // server. (See the corresponding server
+                            // change in handle_content_step1.)
+                            match content.encode_diff_v1(node_id, payload) {
+                                Ok(diff) => {
+                                    let frame = encode_message(
+                                        MSG_SYNC_STEP_2,
+                                        &content_doc_id(node_id),
+                                        &diff,
+                                    );
+                                    if let Err(e) = write
+                                        .send(WsMessage::Binary(frame.into()))
+                                        .await
+                                    {
+                                        anyhow::bail!(
+                                            "reply STEP_2 for {}: {e}",
+                                            doc_id
+                                        );
+                                    }
+                                }
+                                Err(e) => {
+                                    debug!("encode diff for {}: {}", doc_id, e);
+                                }
+                            }
                         }
                         other => {
                             debug!(
@@ -1073,6 +1100,18 @@ impl ContentStore {
         let doc = self.docs.get(&node_id).expect("inserted above");
         let txn = doc.transact();
         Ok(txn.state_vector().encode_v1())
+    }
+
+    /// Encode the local subdoc state as an update relative to a peer's
+    /// state vector. Used to reply to an incoming `MSG_SYNC_STEP_1` —
+    /// the returned bytes contain whatever updates the peer is missing.
+    fn encode_diff_v1(&mut self, node_id: NodeId, peer_sv_payload: &[u8]) -> Result<Vec<u8>> {
+        self.ensure_loaded(node_id)?;
+        let peer_sv = StateVector::decode_v1(peer_sv_payload)
+            .context("decode peer state vector")?;
+        let doc = self.docs.get(&node_id).expect("inserted above");
+        let txn = doc.transact();
+        Ok(txn.encode_state_as_update_v1(&peer_sv))
     }
 
     fn apply_update(&mut self, node_id: NodeId, payload: &[u8]) -> Result<()> {

--- a/syncline/src/server/db.rs
+++ b/syncline/src/server/db.rs
@@ -80,6 +80,39 @@ impl Db {
         Ok(row.0)
     }
 
+    /// Encode the current state vector for a doc as v1 bytes.
+    ///
+    /// Used by the server to advertise what it has so the client can
+    /// reply with the inverse diff (its updates the server is missing).
+    /// Without this the sync handshake is one-way: a client whose subdoc
+    /// has updates we never observed has no way to push them back after
+    /// reconnect.
+    pub async fn get_doc_state_vector(&self, doc_id: &str) -> Result<Vec<u8>> {
+        use yrs::Doc;
+        use yrs::ReadTxn;
+        use yrs::Transact;
+        use yrs::Update;
+        use yrs::updates::decoder::Decode;
+        use yrs::updates::encoder::Encode;
+
+        let all_updates = self.load_doc_updates(doc_id).await?;
+        tokio::task::spawn_blocking(move || {
+            let doc = Doc::new();
+            if !all_updates.is_empty() {
+                let mut txn = doc.transact_mut();
+                for update_data in all_updates {
+                    if let Ok(u) = Update::decode_v1(&update_data) {
+                        txn.apply_update(u);
+                    }
+                }
+            }
+            let txn = doc.transact();
+            Ok(txn.state_vector().encode_v1())
+        })
+        .await
+        .unwrap()
+    }
+
     pub async fn get_all_updates_since(
         &self,
         doc_id: &str,

--- a/syncline/src/server/server.rs
+++ b/syncline/src/server/server.rs
@@ -373,6 +373,8 @@ async fn handle_content_step1(
     let Ok(sv) = StateVector::decode_v1(payload) else {
         return;
     };
+
+    // 1) Reply with what we have past the client's SV (existing behaviour).
     match state.db.get_all_updates_since(doc_id, &sv).await {
         Ok(update) if !update.is_empty() => {
             let frame = encode_message(MSG_SYNC_STEP_2, doc_id, &update);
@@ -380,6 +382,21 @@ async fn handle_content_step1(
         }
         Ok(_) => {}
         Err(e) => tracing::error!("DB read for {}: {}", doc_id, e),
+    }
+
+    // 2) Send back our own state vector so the client can push the
+    //    inverse diff (whatever we are missing). Without this the Yrs
+    //    sync protocol is one-way: a client whose subdoc had content
+    //    we never observed (e.g. content authored before the server
+    //    had a chance to record it, then a connection reset wiped the
+    //    in-flight updates) would never re-broadcast that content,
+    //    leaving it stranded on the client side forever.
+    match state.db.get_doc_state_vector(doc_id).await {
+        Ok(server_sv) => {
+            let frame = encode_message(MSG_SYNC_STEP_1, doc_id, &server_sv);
+            let _ = tx_out.send(frame);
+        }
+        Err(e) => tracing::error!("compute server SV for {}: {}", doc_id, e),
     }
 }
 
@@ -538,6 +555,7 @@ mod tests {
     use tokio::net::TcpListener;
     use tokio_tungstenite::connect_async;
     use tokio_tungstenite::tungstenite::Message as TungsteniteMessage;
+    use yrs::updates::encoder::Encode;
     use yrs::{ReadTxn, Transact};
 
     async fn setup_test_server() -> (u16, AppState) {
@@ -780,5 +798,60 @@ mod tests {
         assert_eq!(t, MSG_BLOB_UPDATE);
         assert_eq!(d, hash_hex);
         assert_eq!(payload, bytes);
+    }
+
+    /// Pins the bidirectional content-sync handshake. When a client
+    /// sends `MSG_SYNC_STEP_1` for a content subdoc the server has
+    /// nothing for, the server must still reciprocate with its own
+    /// `MSG_SYNC_STEP_1` (carrying its state vector — empty or not)
+    /// so the client knows to push its updates back. Without this,
+    /// content authored by the client and never re-edited never
+    /// reaches the server.
+    #[tokio::test]
+    async fn server_reciprocates_step1_for_empty_content_doc() {
+        let (port, _state) = setup_test_server().await;
+        let url = format!("ws://127.0.0.1:{}/sync", port);
+        let (mut ws, _) = connect_async(url).await.unwrap();
+
+        // Handshake.
+        send_bin(
+            &mut ws,
+            encode_message(
+                MSG_VERSION,
+                MANIFEST_DOC_ID,
+                &encode_version_handshake(),
+            ),
+        )
+        .await;
+        let _ = recv_bin(&mut ws).await;
+
+        // Client subscribes to a content doc the server has never seen,
+        // sending an empty state vector.
+        let doc_id = "content:019dc69a-1234-7000-8000-000000000001";
+        let empty_sv = yrs::StateVector::default().encode_v1();
+        send_bin(
+            &mut ws,
+            encode_message(MSG_SYNC_STEP_1, doc_id, &empty_sv),
+        )
+        .await;
+
+        // Expect a STEP_1 back from the server (its SV) so we know it
+        // wants whatever we have. The server may also send STEP_2 first
+        // (with empty/non-empty content) — accept either ordering.
+        let mut saw_step1 = false;
+        for _ in 0..2 {
+            let resp = recv_bin(&mut ws).await;
+            let (t, d, _payload) = decode_message(&resp).unwrap();
+            assert_eq!(d, doc_id);
+            if t == MSG_SYNC_STEP_1 {
+                saw_step1 = true;
+                break;
+            }
+            assert_eq!(t, MSG_SYNC_STEP_2, "unexpected msg type {:#x}", t);
+        }
+        assert!(
+            saw_step1,
+            "server must reciprocate STEP_1 even when it has no content for the doc"
+        );
     }
 }


### PR DESCRIPTION
## Summary

A connection reset mid-cold-sync against a real ~1300-file vault left **514 of 1148 expected content subdocs absent from the server DB**, despite the CLI client having all the data in its `.syncline/content/<id>.bin` files. No amount of reconnecting fixed it because the protocol never asked the client to push.

Root cause: `handle_content_step1` only completes one leg of the Yrs sync handshake.

```rust
// before
async fn handle_content_step1(...) {
    ensure_subscribed(...).await;
    let Ok(sv) = StateVector::decode_v1(payload) else { return };
    match state.db.get_all_updates_since(doc_id, &sv).await {
        Ok(update) if !update.is_empty() => /* send STEP_2 */,
        Ok(_) => {}                         // ← no reply at all
        Err(e) => tracing::error!(...),
    }
}
```

If the server has nothing for the doc, no reply. The client never learns the server's state vector, so its `fold_disk_drift_into_content` stays a no-op (disk == CRDT after the previous flush), and content authored locally but never re-edited is stranded forever.

## Fix

- **Server:** after the existing STEP_2 reply, send back our own STEP_1 carrying the doc's state vector. Empty SVs are still meaningful — they tell the client "I have nothing, send me everything you have".
- **Server `Db::get_doc_state_vector`:** builds the doc from persisted updates and returns its encoded SV. Same `spawn_blocking` pattern as `get_all_updates_since`.
- **Client:** the `MSG_SYNC_STEP_1` branch for content frames was a debug log (`"unexpected STEP_1 for …"`). Replace with a real handler that decodes the peer's SV, encodes the local diff, and sends `MSG_SYNC_STEP_2` back.
- **Client `ContentStore::encode_diff_v1`:** helper that produces the bytes the peer is missing.

## Test

`server_reciprocates_step1_for_empty_content_doc` pins the contract: when a client subscribes to a content subdoc the server has never seen, the server must send back its own STEP_1, not silence.

All 214 existing tests still pass.

## Migration

No schema or wire-format change. Existing 1.x clients work against the patched server (they just won't push back, same as before). Existing 1.x servers work against patched clients (the new STEP_2 the client sends in reply to a server-initiated STEP_1 just never arrives, so the bug remains until the server is upgraded). Behaviour fully recovers once both sides are on the new build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)