### PR TITLE
fix(server): drop empty STEP_2 broadcasts to stop delete-resurrection

### DIFF
--- a/syncline/src/server/server.rs
+++ b/syncline/src/server/server.rs
@@ -400,12 +400,37 @@ async fn handle_content_step1(
     }
 }
 
+/// True iff the encoded Yrs update has no blocks and an empty delete set.
+/// Broadcasting an empty update is wasted bandwidth, and worse: it
+/// triggers `flush_content_to_disk` on every other CLI client, which
+/// can race with a concurrent local-disk delete (the freshly-deleted
+/// file gets re-written from CRDT content before scan_once notices the
+/// unlink, defeating delete propagation entirely).
+fn is_noop_update(payload: &[u8]) -> bool {
+    use yrs::Update;
+    use yrs::updates::decoder::Decode;
+    match Update::decode_v1(payload) {
+        Ok(u) => u.state_vector().is_empty(),
+        // Malformed: not no-op, but also can't apply — let downstream reject.
+        Err(_) => false,
+    }
+}
+
 async fn handle_content_update(
     state: &AppState,
     conn: uuid::Uuid,
     doc_id: &str,
     payload: &[u8],
 ) {
+    // Skip empty STEP_2 replies (typically those that come back from a
+    // client whose state vector matched ours after the handshake — the
+    // client has nothing to add). Without this the bidirectional handshake
+    // produces a thundering-herd of empty broadcasts, each one re-flushing
+    // the content to disk on every peer and shadow-resurrecting freshly
+    // deleted files before scan_once can register them as gone.
+    if is_noop_update(payload) {
+        return;
+    }
     if let Err(e) = state.db.save_update(doc_id, payload).await {
         tracing::error!("persist content update for {}: {}", doc_id, e);
         return;

--- a/syncline/tests/e2e.rs
+++ b/syncline/tests/e2e.rs
@@ -554,6 +554,58 @@ async fn test_filter_ignored_files() {
     );
 }
 
+/// Regression test for the CI failure on `propagates deletes CLI →
+/// Obsidian` after 70fde18 landed bidirectional STEP_1 reciprocation.
+///
+/// The bug: server unconditionally reciprocated STEP_1 with its own
+/// state vector. Clients whose state already matched the server's
+/// answered with a *no-op* STEP_2 (encoded Yrs update with no blocks
+/// and an empty delete-set). The server happily persisted+broadcast
+/// each one. Every other peer's MSG_UPDATE handler then ran
+/// flush_content_to_disk, re-writing the file from CRDT content.
+/// When that broadcast raced against a local-disk delete, the file
+/// got resurrected on disk before scan_once could register the
+/// unlink — so the deletion never propagated.
+///
+/// The fix (see `is_noop_update` in server.rs) drops empty STEP_2
+/// frames at the server's broadcast boundary. This test reproduces
+/// the rename-then-delete scenario across two CLI peers (standing in
+/// for the Obsidian peer in the wdio e2e suite).
+#[tokio::test]
+async fn test_rename_then_delete_propagates() {
+    let mut env = TestEnv::new(2).await;
+    tokio::time::sleep(Duration::from_millis(1000)).await;
+
+    let path0 = env.client_path(0).join("doomed.md");
+    fs::write(&path0, "# original\n").unwrap();
+    assert!(
+        wait_for_convergence(&env.dirs(), Duration::from_secs(10)).await,
+        "create did not converge"
+    );
+
+    let renamed0 = env.client_path(0).join("renamed.md");
+    fs::rename(&path0, &renamed0).unwrap();
+    assert!(
+        wait_for_convergence(&env.dirs(), Duration::from_secs(10)).await,
+        "rename did not converge"
+    );
+
+    fs::remove_file(&renamed0).unwrap();
+
+    let renamed1 = env.client_path(1).join("renamed.md");
+    let deadline = std::time::Instant::now() + Duration::from_secs(15);
+    while std::time::Instant::now() < deadline {
+        if !renamed1.exists() {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+    panic!(
+        "renamed.md still exists on peer 1 15s after delete on peer 0 \
+         (empty STEP_2 broadcast likely re-flushing the file)"
+    );
+}
+
 #[tokio::test]
 async fn test_offline_creation_and_deletion() {
     let mut env = TestEnv::new(2).await;


### PR DESCRIPTION
## Summary

The `propagates deletes CLI → Obsidian` e2e test has been failing 100 % of CI runs since v1.1.1 (commit [70fde18](https://github.com/tomas789/syncline/commit/70fde18) / [PR #50](https://github.com/tomas789/syncline/pull/50)). The test passes 7 of 8 cases in ~30 s, then sits 200 s on the delete check before timing out. The 1.1.0 release passed the same test in 0.5 s.

## Root cause

PR #50 made the server send its own state vector back to the client (a `MSG_SYNC_STEP_1` after the `MSG_SYNC_STEP_2` reply) so a client whose subdoc had content the server lost can push it back — the recovery path the user hit on a ~1300-file vault where 514 of 1148 expected content subdocs were stranded.

The protocol leg is correct, but the implementation has a thundering-herd bug. When client and server are already in sync, the client answers the reciprocal STEP_1 with a **no-op STEP_2** (an encoded Yrs update with no blocks and an empty delete set). `handle_content_update` happily persists each one and broadcasts it to every other peer. Each broadcast trips the receiving CLI's `MSG_UPDATE` handler, which calls `flush_content_to_disk` to atomic-write the CRDT body to the projection's path.

When this races with a concurrent local-disk delete (exactly the wdio e2e scenario):

1. Test runs `fs.unlinkSync(folderPath/renamed.md)` on the CLI's vault.
2. Watcher picks up the unlink, queues a debounced batch.
3. Before `scan_once` gets a chance, an empty `MSG_UPDATE` for `content:<N>` arrives from the server.
4. `flush_content_to_disk` re-creates `renamed.md` with the CRDT body.
5. `scan_once` runs: walkdir finds `renamed.md` present, hash matches manifest, no deletion candidate.
6. Repeat indefinitely. The unlink never propagates.

## Fix

`handle_content_update` filters no-op updates at the broadcast boundary. The new `is_noop_update` decodes the payload and checks `Update::state_vector().is_empty()`; if so the handler returns early without persisting or broadcasting. Real STEP_2 replies that actually carry data are unaffected — the original PR #50 recovery path still works (`server_reciprocates_step1_for_empty_content_doc` remains green).

## Test

New `test_rename_then_delete_propagates` in `syncline/tests/e2e.rs` spins up two CLI clients, renames a file, deletes the renamed copy, and asserts the second peer drops it within 15 s. Without this fix the test panics with `renamed.md still exists on peer 1 15s after delete on peer 0 (empty STEP_2 broadcast likely re-flushing the file)`. With the fix it passes in ~14 s on macOS.

All 214 existing unit tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)