### PR TITLE
fix: enable TLS in released binaries (#54)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4983,7 +4983,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "url",
- "webpki-roots",
+ "webpki-roots 0.25.4",
 ]
 
 [[package]]
@@ -5242,6 +5242,7 @@ dependencies = [
  "js-sys",
  "notify",
  "notify-debouncer-mini",
+ "rustls 0.23.36",
  "serde",
  "serde_json",
  "sha2",
@@ -5932,8 +5933,12 @@ checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
 dependencies = [
  "futures-util",
  "log",
+ "rustls 0.23.36",
+ "rustls-pki-types",
  "tokio",
+ "tokio-rustls",
  "tungstenite 0.28.0",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -6270,6 +6275,8 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.2",
+ "rustls 0.23.36",
+ "rustls-pki-types",
  "sha1",
  "thiserror 2.0.18",
  "utf-8",
@@ -6800,6 +6807,24 @@ name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.6",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "webview2-com"

--- a/syncline/Cargo.toml
+++ b/syncline/Cargo.toml
@@ -29,7 +29,8 @@ console_error_panic_hook = "0.1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { version = "1", features = ["full"] }
-tokio-tungstenite = "0.28"
+tokio-tungstenite = { version = "0.28", features = ["rustls-tls-webpki-roots"] }
+rustls = { version = "0.23", default-features = false, features = ["ring"] }
 axum = { version = "0.7", features = ["ws"] }
 headers = "0.4"
 tower = "0.4"

--- a/syncline/src/client/network.rs
+++ b/syncline/src/client/network.rs
@@ -1,11 +1,21 @@
 use anyhow::Result;
 use futures_util::{SinkExt, StreamExt};
+use std::sync::Once;
 use tokio::sync::mpsc;
 use tokio_tungstenite::{connect_async, tungstenite::protocol::Message as WsMessage};
 use tracing::{error, info};
 use url::Url;
 
 use crate::client::protocol::Message;
+
+// rustls 0.23 has no default CryptoProvider — pick one explicitly so that
+// `wss://` connections work out of the box. Idempotent and cheap to call.
+fn ensure_rustls_provider() {
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+    });
+}
 
 pub struct SynclineClient {
     pub url: Url,
@@ -36,6 +46,7 @@ impl SynclineClient {
             task.abort();
         }
 
+        ensure_rustls_provider();
         let (ws_stream, _) = connect_async(self.url.as_str()).await?;
         info!("Successfully connected to server at {}", self.url);
 
@@ -217,5 +228,47 @@ mod tests {
     fn test_invalid_url() {
         let result = SynclineClient::new("invalid_url");
         assert!(result.is_err());
+    }
+
+    // Regression test for #54: released binaries failed against `wss://` URLs
+    // with "TLS support not compiled in" because tokio-tungstenite's TLS
+    // features were disabled. We accept a TCP connection on a local port
+    // (so resolution + TCP connect succeed) and then attempt the WSS
+    // upgrade. Without TLS compiled in, this fails with the "not compiled"
+    // error; with rustls enabled, it fails with a real TLS handshake error
+    // (because our dummy listener doesn't actually speak TLS).
+    #[tokio::test]
+    async fn test_wss_url_does_not_fail_with_tls_not_compiled() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        // Accept loop — just keep the TCP connection open long enough for
+        // the TLS handshake attempt to fail in the way we expect.
+        tokio::spawn(async move {
+            while let Ok((stream, _)) = listener.accept().await {
+                tokio::spawn(async move {
+                    tokio::time::sleep(Duration::from_secs(5)).await;
+                    drop(stream);
+                });
+            }
+        });
+
+        let url = format!("wss://localhost:{port}/sync");
+        let mut client = SynclineClient::new(&url).unwrap();
+        let (app_tx, _rx) = mpsc::channel(10);
+
+        let result = tokio::time::timeout(
+            Duration::from_secs(10),
+            client.connect(app_tx),
+        )
+        .await
+        .expect("connect_async should not hang");
+
+        let err = result.expect_err("wss to non-TLS endpoint must fail");
+        let msg = format!("{:#}", err);
+        assert!(
+            !msg.contains("TLS support not compiled in"),
+            "wss:// must not fail with 'TLS support not compiled in' — got: {msg}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Closes #54.

Released `syncline sync` binaries crashed when given a `wss://` URL:

```
ERROR session failed: ws connect
Caused by:
    0: URL error: TLS support not compiled in
    1: TLS support not compiled in
```

`tokio-tungstenite`'s TLS support is gated behind feature flags. The dependency was declared with no features, so `wss://` always failed.

## Fix

`syncline/Cargo.toml`:

```diff
-tokio-tungstenite = "0.28"
+tokio-tungstenite = { version = "0.28", features = ["rustls-tls-webpki-roots"] }
+rustls = { version = "0.23", default-features = false, features = ["ring"] }
```

**Backend choice:** rustls over native-tls. `rustls-tls-webpki-roots` bundles Mozilla's root CA list, so released binaries work identically across Linux / macOS / Windows without needing a system trust store or `libssl-dev`. native-tls would have made the release pipeline depend on host TLS libraries.

**Why the extra `rustls` direct dep:** rustls 0.23 has no default `CryptoProvider`. Without one selected, the first `wss://` connection panics with `"Could not automatically determine the process-level CryptoProvider from Rustls crate features"`. `tokio-tungstenite` pulls rustls with `default-features = false`, so we add `rustls` ourselves with the `ring` feature and call `rustls::crypto::ring::default_provider().install_default()` once via `std::sync::Once` at the top of `SynclineClient::connect`. Idempotent, cheap, and library-local (no `main.rs` plumbing that downstream consumers like the desktop app or tests would have to replicate).

## TDD trace

Test added: `client::network::tests::test_wss_url_does_not_fail_with_tls_not_compiled`. It binds a plain-TCP listener on `127.0.0.1:0`, then points the client at `wss://localhost:<port>/sync`. The TCP connect succeeds; the TLS handshake fails (the listener doesn't speak TLS). Assertion: the error must NOT contain `"TLS support not compiled in"`.

Pre-fix run:
```
panicked at syncline/src/client/network.rs:258:9:
wss:// must not fail with 'TLS support not compiled in' — got:
URL error: TLS support not compiled in: TLS support not compiled in
```

Post-fix run:
```
test client::network::tests::test_wss_url_does_not_fail_with_tls_not_compiled ... ok
```

Smoke-tested the release binary against `wss://127.0.0.1:1/sync` — error is now `Connection refused (os error 61)`, i.e. real TCP-level failure, no longer a TLS-not-compiled message.

## Test plan

- [x] `cargo test -p syncline --lib` — 48 passed (incl. new regression test)
- [x] `cargo test --test e2e` — 15 passed
- [x] `cargo build --release -p syncline` — clean
- [x] Smoke-test: release binary against `wss://` URL returns connection-refused, not "not compiled in"

🤖 Generated with [Claude Code](https://claude.com/claude-code)