### PR TITLE
fix(server): cap per-doc broadcast channel at 64 to prevent OOM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5225,7 +5225,7 @@ dependencies = [
 
 [[package]]
 name = "syncline"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
  "anyhow",
  "axum",

--- a/syncline/src/server/server.rs
+++ b/syncline/src/server/server.rs
@@ -48,6 +48,15 @@ use yrs::{StateVector, updates::decoder::Decode};
 
 type ChannelMap = Arc<RwLock<HashMap<String, broadcast::Sender<(Vec<u8>, uuid::Uuid)>>>>;
 
+// Per-doc broadcast channels are created lazily, one per subscribed doc.
+// `tokio::sync::broadcast::channel(N)` pre-allocates a ring buffer of N
+// slots up front, so this constant is a fixed memory cost multiplied by
+// every subscribed doc — on a 1000-doc vault, 65_536 → ~3 GB of empty
+// ring buffer alone, which OOMs the server during initial fan-out. The
+// buffer only needs to absorb burst lag for a single forwarding task per
+// subscriber, which catches up immediately, so a small cap is plenty.
+const PER_DOC_BROADCAST_CAP: usize = 64;
+
 #[derive(Clone)]
 struct AppState {
     db: Db,
@@ -441,7 +450,7 @@ async fn handle_content_update(
     let mut channels = state.channels.write().await;
     let tx = channels
         .entry(doc_id.to_string())
-        .or_insert_with(|| broadcast::channel(65_536).0);
+        .or_insert_with(|| broadcast::channel(PER_DOC_BROADCAST_CAP).0);
     let _ = tx.send((frame, conn));
 }
 
@@ -508,7 +517,7 @@ async fn ensure_subscribed(
     let rx = {
         let mut channels = state.channels.write().await;
         let tx = channels.entry(doc_id.clone()).or_insert_with(|| {
-            let (tx, _rx) = broadcast::channel(65_536);
+            let (tx, _rx) = broadcast::channel(PER_DOC_BROADCAST_CAP);
             tx
         });
         tx.subscribe()


### PR DESCRIPTION
## Summary
- `tokio::sync::broadcast::channel(N)` pre-allocates an N-slot ring buffer up front. Previous `65_536` cap → ~2.6 MB per doc → 1000+ docs OOMs the server (~3 GB of empty buffer alone).
- Drop to 64. The channels only buffer burst lag for fast forwarding tasks; reactive consumers don't need history.

## Production trigger
On `claw.krej.ci` with a 1143-file vault, server peaked at **4.6 GB** and never got past **870 / 1300** docs before WS connection-reset → client reconnect → cycle. Server-side memory is dominated by the per-doc ring buffers (1300 × 65 536 × ~40 B ≈ 3.2 GB).

## Test plan
- [x] `cargo build --bin syncline` — clean
- [ ] Tag v1.1.4 via release-please, deploy to claw.krej.ci, watch sync converge to ~1300 docs without OOM

🤖 Generated with [Claude Code](https://claude.com/claude-code)