### PR TITLE
feat(plugin): add Syncline sidebar shell

### DIFF
--- a/obsidian-plugin/main.ts
+++ b/obsidian-plugin/main.ts
@@ -1,11 +1,13 @@
 import {
   App,
+  ItemView,
   Plugin,
   PluginSettingTab,
   Setting,
   Notice,
   TFile,
   TAbstractFile,
+  WorkspaceLeaf,
   debounce,
 } from "obsidian";
 // @ts-ignore - rollup base64-inlines the .wasm binary at build time.
@@ -165,6 +167,129 @@ function isNotConnectedError(e: unknown): boolean {
 }
 
 // ---------------------------------------------------------------------------
+// Sidebar view (Phase 1 of #65 — mirrors the status bar's four states,
+// adds file count + relative "last sync" timestamp; nothing else yet)
+// ---------------------------------------------------------------------------
+
+const VIEW_TYPE_SYNCLINE = "syncline-sidebar";
+
+const STATUS_LABELS: Record<SyncStatus, string> = {
+  synced: "Synced",
+  syncing: "Syncing…",
+  error: "Error",
+  disconnected: "Disconnected",
+};
+
+/** Format a "N seconds/minutes/hours ago" timestamp for the sidebar. */
+function formatRelativeTime(epochMs: number | null, nowMs: number): string {
+  if (epochMs === null) return "never";
+  const deltaMs = Math.max(0, nowMs - epochMs);
+  const seconds = Math.floor(deltaMs / 1000);
+  if (seconds < 5) return "just now";
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+class SynclineSidebarView extends ItemView {
+  plugin: SynclinePlugin;
+  private statusDot!: HTMLElement;
+  private statusLabel!: HTMLElement;
+  private fileCountEl!: HTMLElement;
+  private lastSyncEl!: HTMLElement;
+  private tickInterval: number | null = null;
+
+  constructor(leaf: WorkspaceLeaf, plugin: SynclinePlugin) {
+    super(leaf);
+    this.plugin = plugin;
+  }
+
+  getViewType(): string {
+    return VIEW_TYPE_SYNCLINE;
+  }
+
+  getDisplayText(): string {
+    return "Syncline";
+  }
+
+  getIcon(): string {
+    return "sync";
+  }
+
+  async onOpen(): Promise<void> {
+    const root = this.contentEl;
+    root.empty();
+    root.addClass("syncline-sidebar");
+
+    const statusRow = root.createDiv({ cls: "syncline-sidebar-status" });
+    this.statusDot = statusRow.createDiv({
+      cls: `syncline-sidebar-dot ${this.plugin.syncStatus}`,
+    });
+    this.statusLabel = statusRow.createDiv({
+      cls: "syncline-sidebar-status-label",
+      text: STATUS_LABELS[this.plugin.syncStatus],
+    });
+
+    const meta = root.createDiv({ cls: "syncline-sidebar-meta" });
+    const filesRow = meta.createDiv({ cls: "syncline-sidebar-row" });
+    filesRow.createSpan({ cls: "syncline-sidebar-row-label", text: "Files" });
+    this.fileCountEl = filesRow.createSpan({
+      cls: "syncline-sidebar-row-value",
+      text: "—",
+    });
+
+    const lastSyncRow = meta.createDiv({ cls: "syncline-sidebar-row" });
+    lastSyncRow.createSpan({
+      cls: "syncline-sidebar-row-label",
+      text: "Last sync",
+    });
+    this.lastSyncEl = lastSyncRow.createSpan({
+      cls: "syncline-sidebar-row-value",
+      text: "never",
+    });
+
+    this.render();
+
+    // Repaint relative timestamp every few seconds while the view is open;
+    // status / file count are pushed via render() from the plugin instead.
+    this.tickInterval = window.setInterval(() => {
+      this.renderLastSync();
+    }, 5000);
+    this.registerInterval(this.tickInterval);
+  }
+
+  async onClose(): Promise<void> {
+    if (this.tickInterval !== null) {
+      window.clearInterval(this.tickInterval);
+      this.tickInterval = null;
+    }
+  }
+
+  /** Push current plugin state into the DOM. Called by the plugin on every
+   *  status change and after the manifest reconcile updates the file count. */
+  render(): void {
+    if (!this.statusDot) return;
+    const status = this.plugin.syncStatus;
+    this.statusDot.className = `syncline-sidebar-dot ${status}`;
+    this.statusLabel.setText(STATUS_LABELS[status]);
+    const count = this.plugin.lastProjection.size;
+    this.fileCountEl.setText(String(count));
+    this.renderLastSync();
+  }
+
+  private renderLastSync(): void {
+    if (!this.lastSyncEl) return;
+    this.lastSyncEl.setText(
+      formatRelativeTime(this.plugin.lastSyncedAt, Date.now()),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Plugin
 // ---------------------------------------------------------------------------
 
@@ -175,6 +300,9 @@ export default class SynclinePlugin extends Plugin {
   statusText!: HTMLElement;
   ribbonIconEl!: HTMLElement;
   syncStatus: SyncStatus = "disconnected";
+  /** Wall-clock ms of the most recent transition into `synced` from the
+   *  status-bar pipeline. Used by the sidebar's relative timestamp. */
+  lastSyncedAt: number | null = null;
 
   client: SynclineV1Client | null = null;
   /**
@@ -234,6 +362,21 @@ export default class SynclinePlugin extends Plugin {
       this.showStatusDetails(),
     );
     this.ribbonIconEl.addClass("syncline-ribbon", "disconnected");
+
+    // Sidebar (Phase 1 of #65). Opt-in: registered here, but only opened
+    // when the user runs the "Open sidebar" command — keeps right-leaf
+    // real estate untouched for existing users.
+    this.registerView(
+      VIEW_TYPE_SYNCLINE,
+      (leaf) => new SynclineSidebarView(leaf, this),
+    );
+    this.addCommand({
+      id: "open-sidebar",
+      name: "Open sidebar",
+      callback: () => {
+        void this.activateSidebar();
+      },
+    });
 
     this.registerEvent(this.app.vault.on("modify", this.onFileModify));
     this.registerEvent(this.app.vault.on("create", this.onFileCreate));
@@ -384,6 +527,9 @@ export default class SynclinePlugin extends Plugin {
 
   updateStatus(status: SyncStatus, text?: string) {
     this.syncStatus = status;
+    if (status === "synced") {
+      this.lastSyncedAt = Date.now();
+    }
     this.statusIcon.className = `status-icon ${status}`;
     const statusTexts: Record<SyncStatus, string> = {
       synced: "Syncline: synced",
@@ -398,6 +544,32 @@ export default class SynclinePlugin extends Plugin {
       this.ribbonIconEl.addClass(status);
       this.ribbonIconEl.setAttribute("aria-label", newText);
     }
+    this.refreshSidebar();
+  }
+
+  /** Push current state into any open sidebar leaves. Cheap no-op when
+   *  the user hasn't opened the sidebar via the command palette. */
+  private refreshSidebar(): void {
+    for (const leaf of this.app.workspace.getLeavesOfType(VIEW_TYPE_SYNCLINE)) {
+      const view = leaf.view;
+      if (view instanceof SynclineSidebarView) {
+        view.render();
+      }
+    }
+  }
+
+  /** Open or reveal the Syncline sidebar in the right leaf. */
+  async activateSidebar(): Promise<void> {
+    const { workspace } = this.app;
+    const existing = workspace.getLeavesOfType(VIEW_TYPE_SYNCLINE);
+    if (existing.length > 0) {
+      await workspace.revealLeaf(existing[0]);
+      return;
+    }
+    const leaf = workspace.getRightLeaf(false);
+    if (!leaf) return;
+    await leaf.setViewState({ type: VIEW_TYPE_SYNCLINE, active: true });
+    await workspace.revealLeaf(leaf);
   }
 
   showStatusDetails() {

--- a/obsidian-plugin/styles.css
+++ b/obsidian-plugin/styles.css
@@ -61,3 +61,67 @@
 .syncline-ribbon.disconnected {
   color: #9e9e9e;
 }
+
+/* Sidebar view (Phase 1 of #65). Reuses the same four state colors as
+   the status-bar dot above so users get a consistent visual vocabulary. */
+.syncline-sidebar {
+  padding: 12px;
+  font-size: var(--font-ui-small);
+}
+
+.syncline-sidebar-status {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.syncline-sidebar-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.syncline-sidebar-dot.synced {
+  background-color: #4caf50;
+}
+
+.syncline-sidebar-dot.syncing {
+  background-color: #ff9800;
+  animation: pulse 1s infinite;
+}
+
+.syncline-sidebar-dot.error {
+  background-color: #f44336;
+}
+
+.syncline-sidebar-dot.disconnected {
+  background-color: #9e9e9e;
+}
+
+.syncline-sidebar-status-label {
+  font-weight: 600;
+}
+
+.syncline-sidebar-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.syncline-sidebar-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+}
+
+.syncline-sidebar-row-label {
+  color: var(--text-muted);
+}
+
+.syncline-sidebar-row-value {
+  color: var(--text-normal);
+  font-variant-numeric: tabular-nums;
+}


### PR DESCRIPTION
## Summary

Phase 1 of #65 — adds an opt-in sidebar view that mirrors the four states the status-bar dot already shows (`synced` / `syncing` / `error` / `disconnected`), plus two pieces of context the status bar can't fit: synced file count and a relative \"last sync\" timestamp. No protocol changes, no new WASM bindings, no new states.

- Registers `VIEW_TYPE_SYNCLINE = \"syncline-sidebar\"` via `registerView` and adds a \"Syncline: Open sidebar\" command. View opens in the right leaf only when invoked — existing users keep their layout untouched.
- The sidebar reads from the same source of truth as the status bar (`syncStatus`, `lastProjection.size`); `updateStatus` now also pushes into any open sidebar leaves and stamps `lastSyncedAt = Date.now()` on each transition into `synced`. The 1s polling loop in `startStatusCheck` keeps the file count fresh; a 5s in-view interval refreshes the relative timestamp.
- New CSS classes (`.syncline-sidebar*`) reuse the same four state colors as the existing `.syncline-status-bar .status-icon.*` rules, so visual vocabulary is consistent.

<!-- screenshot here -->

Closes part of #65; phases 2–6 remain.

## Test plan

- [ ] `cd obsidian-plugin && npm run build` succeeds cleanly (verified locally — only pre-existing \"Broken sourcemap\" warning from the base64 wasm plugin).
- [ ] `npm run lint` passes.
- [ ] In a running Obsidian: command palette → \"Syncline: Open sidebar\" reveals the view in the right leaf.
- [ ] All four states render with the expected colors (green/amber/red/grey), matching the status-bar dot.
- [ ] File count matches the existing status-bar Notice (`showStatusDetails`).
- [ ] \"Last sync\" reads `never` until the first `synced` transition, then ticks `Ns ago` / `Nm ago`.
- [ ] Closing and reopening the view preserves correct state.
- [ ] Status bar and ribbon icon behavior is unchanged.

## Out of scope (deliberately)

Per the issue's phased plan, this PR does *not* introduce: pending queue progress UI (phase 2), vault summary / conflict-copy list (phase 3), activity feed (phase 4), `MSG_SERVER_STATS` opcode (phase 5), `degraded` / `read-only` states or `MSG_MANIFEST_VERIFY` plumbing (phase 6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)