### PR TITLE
fix(plugin): unify plugin id to "syncline" across the repo

### DIFF
--- a/.github/workflows/plugin-id-consistency.yml
+++ b/.github/workflows/plugin-id-consistency.yml
@@ -1,0 +1,63 @@
+name: plugin-id-consistency
+
+# Guards against the bug fixed by #55: a previous version of the repo carried
+# two manifest.json files with different `id` values, plus a hard-coded
+# "syncline-obsidian" literal in main.ts. That drift caused the released
+# plugin to lay down state under a sibling directory, looking like a second
+# plugin install.
+#
+# The repo now has a single source-of-truth manifest at
+# obsidian-plugin/manifest.json. This workflow fails the build if:
+#   1. A second top-level manifest.json reappears at the repo root.
+#   2. The plugin id ever stops being "syncline".
+#   3. A stray "syncline-obsidian" literal sneaks back into main.ts outside
+#      the documented legacy-migration block.
+
+on:
+  push:
+    branches: [main, release/v1]
+  pull_request:
+    branches: [main, release/v1]
+
+jobs:
+  check:
+    name: Plugin id consistency
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Fail if a second manifest.json reappears at repo root
+        run: |
+          if [ -f manifest.json ]; then
+            echo "::error::A manifest.json file exists at the repo root."
+            echo "::error::The single source of truth is obsidian-plugin/manifest.json."
+            echo "::error::Either delete the root file or update this workflow to compare both."
+            exit 1
+          fi
+
+      - name: Verify obsidian-plugin/manifest.json id is "syncline"
+        run: |
+          id=$(jq -r .id obsidian-plugin/manifest.json)
+          if [ "$id" != "syncline" ]; then
+            echo "::error::obsidian-plugin/manifest.json#id is \"$id\"; expected \"syncline\"."
+            echo "::error::See issue #55 for why this id is fixed."
+            exit 1
+          fi
+
+      - name: Grep main.ts for stray "syncline-obsidian" literals
+        # The legacy-migration getter `legacyStateRoot` is the only place that
+        # may legitimately mention the old id. If you legitimately need a new
+        # reference (e.g. extending the migration), bump the expected count.
+        run: |
+          count=$(grep -c "syncline-obsidian" obsidian-plugin/main.ts || true)
+          # Expected occurrences in the legacy-migration block:
+          #  1. comment in stateRoot getter
+          #  2. literal in legacyStateRoot getter
+          #  3. comment in migrateLegacyStateRoot doc-block
+          expected=3
+          if [ "$count" -ne "$expected" ]; then
+            echo "::error::main.ts contains $count occurrences of \"syncline-obsidian\"; expected $expected."
+            echo "::error::Either remove the new reference or update the expected count in this workflow."
+            grep -n "syncline-obsidian" obsidian-plugin/main.ts || true
+            exit 1
+          fi

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -90,7 +90,7 @@ jobs:
         if: matrix.build_plugin
         run: |
           cp obsidian-plugin/main.js artifacts/main.js
-          cp manifest.json artifacts/manifest.json
+          cp obsidian-plugin/manifest.json artifacts/manifest.json
           cp obsidian-plugin/styles.css artifacts/styles.css
 
       - name: Upload Release Assets

--- a/e2e/test/specs/basic.e2e.ts
+++ b/e2e/test/specs/basic.e2e.ts
@@ -124,14 +124,14 @@ describe('Syncline v1 E2E', () => {
 
         const obsidianPage = browser.getObsidianPage();
         try {
-            await obsidianPage.enablePlugin('syncline-obsidian');
+            await obsidianPage.enablePlugin('syncline');
             console.log('Syncline plugin enabled');
         } catch (e: any) {
             console.error('Could not enable plugin or already enabled:', e?.message);
         }
 
         await browser.executeObsidian(async ({ app }, url) => {
-            const plugin: any = (app as any).plugins.plugins['syncline-obsidian'];
+            const plugin: any = (app as any).plugins.plugins['syncline'];
             if (!plugin) throw new Error('Syncline plugin not found in app.plugins');
             plugin.settings.serverUrl = url;
             await plugin.saveSettings();
@@ -142,7 +142,7 @@ describe('Syncline v1 E2E', () => {
         // Wait for the plugin's WS client to report isConnected=true.
         await waitFor('plugin connected', async () => {
             return browser.executeObsidian(async ({ app }) => {
-                const plugin: any = (app as any).plugins.plugins['syncline-obsidian'];
+                const plugin: any = (app as any).plugins.plugins['syncline'];
                 return !!(plugin && plugin.client && plugin.client.isConnected());
             });
         }, 30000);

--- a/e2e/test/specs/issue56.e2e.ts
+++ b/e2e/test/specs/issue56.e2e.ts
@@ -60,9 +60,9 @@ describe('Syncline #56 — case-insensitive FS phantom manifest entries', () => 
         await waitFor('server listening', async () => /listening/i.test(serverOut), 30_000, 100);
 
         const obsidianPage = browser.getObsidianPage();
-        try { await obsidianPage.enablePlugin('syncline-obsidian'); } catch {}
+        try { await obsidianPage.enablePlugin('syncline'); } catch {}
         await browser.executeObsidian(async ({ app }, url) => {
-            const plugin: any = (app as any).plugins.plugins['syncline-obsidian'];
+            const plugin: any = (app as any).plugins.plugins['syncline'];
             if (!plugin) throw new Error('plugin not found');
             plugin.settings.serverUrl = url;
             await plugin.saveSettings();
@@ -70,7 +70,7 @@ describe('Syncline #56 — case-insensitive FS phantom manifest entries', () => 
             await plugin.connect();
         }, serverUrl);
         await waitFor('plugin connected', async () => browser.executeObsidian(async ({ app }) => {
-            const plugin: any = (app as any).plugins.plugins['syncline-obsidian'];
+            const plugin: any = (app as any).plugins.plugins['syncline'];
             return !!(plugin && plugin.client && plugin.client.isConnected());
         }), 30_000, 100);
     });
@@ -87,7 +87,7 @@ describe('Syncline #56 — case-insensitive FS phantom manifest entries', () => 
         // with the mixed-case name FIRST so that subsequent
         // case-insensitive lookups resolve to it.
         const result: any = await browser.executeObsidian(async ({ app }) => {
-            const plugin: any = (app as any).plugins.plugins['syncline-obsidian'];
+            const plugin: any = (app as any).plugins.plugins['syncline'];
             const adapter = (app as any).vault.adapter;
 
             // Clean any prior bench-foo dirs.

--- a/e2e/test/specs/issue57.e2e.ts
+++ b/e2e/test/specs/issue57.e2e.ts
@@ -110,9 +110,9 @@ describe('Syncline #57 — STEP_1 dropped before WS handshake', () => {
         }
 
         const obsidianPage = browser.getObsidianPage();
-        try { await obsidianPage.enablePlugin('syncline-obsidian'); } catch {}
+        try { await obsidianPage.enablePlugin('syncline'); } catch {}
         await browser.executeObsidian(async ({ app }, url) => {
-            const plugin: any = (app as any).plugins.plugins['syncline-obsidian'];
+            const plugin: any = (app as any).plugins.plugins['syncline'];
             if (!plugin) throw new Error('plugin not found');
             plugin.settings.serverUrl = url;
             await plugin.saveSettings();
@@ -120,7 +120,7 @@ describe('Syncline #57 — STEP_1 dropped before WS handshake', () => {
             await plugin.connect();
         }, serverUrl);
         await waitFor('plugin connected', async () => browser.executeObsidian(async ({ app }) => {
-            const plugin: any = (app as any).plugins.plugins['syncline-obsidian'];
+            const plugin: any = (app as any).plugins.plugins['syncline'];
             return !!(plugin && plugin.client && plugin.client.isConnected());
         }), 30_000, 200);
     });
@@ -155,11 +155,11 @@ describe('Syncline #57 — STEP_1 dropped before WS handshake', () => {
         // Keep manifest.bin so the next connect()'s reconcile sees the
         // full projection synchronously and races the WS handshake.
         await browser.executeObsidian(async ({ app }) => {
-            const plugin: any = (app as any).plugins.plugins['syncline-obsidian'];
+            const plugin: any = (app as any).plugins.plugins['syncline'];
             plugin.disconnect();
         });
 
-        const stateDir = join(vaultPath, '.obsidian', 'plugins', 'syncline-obsidian', 'v1');
+        const stateDir = join(vaultPath, '.obsidian', 'plugins', 'syncline', 'v1');
         if (fs.existsSync(join(stateDir, 'content'))) {
             for (const f of fs.readdirSync(join(stateDir, 'content'))) {
                 fs.unlinkSync(join(stateDir, 'content', f));
@@ -206,11 +206,11 @@ describe('Syncline #57 — STEP_1 dropped before WS handshake', () => {
 
         // Phase C: reconnect — race fires.
         await browser.executeObsidian(async ({ app }) => {
-            const plugin: any = (app as any).plugins.plugins['syncline-obsidian'];
+            const plugin: any = (app as any).plugins.plugins['syncline'];
             await plugin.connect();
         });
         await waitFor('plugin re-connected', async () => browser.executeObsidian(async ({ app }) => {
-            const plugin: any = (app as any).plugins.plugins['syncline-obsidian'];
+            const plugin: any = (app as any).plugins.plugins['syncline'];
             return !!(plugin && plugin.client && plugin.client.isConnected());
         }), 30_000, 100);
         console.log(`[#57] phase C: reconnected`);
@@ -237,7 +237,7 @@ describe('Syncline #57 — STEP_1 dropped before WS handshake', () => {
             lastNonEmpty = nonEmpty;
             if (stableTicks % 25 === 0) {
                 const st: any = await browser.executeObsidian(async ({ app }) => {
-                    const p: any = (app as any).plugins.plugins['syncline-obsidian'];
+                    const p: any = (app as any).plugins.plugins['syncline'];
                     return p ? {
                         proj: p.lastProjection?.size ?? 0,
                         subs: p.subscribedContent?.size ?? 0,

--- a/e2e/test/specs/issue58.e2e.ts
+++ b/e2e/test/specs/issue58.e2e.ts
@@ -113,9 +113,9 @@ describe('Syncline #58 — synthetic onFileCreate on vault load creates conflict
         }
 
         const obsidianPage = browser.getObsidianPage();
-        try { await obsidianPage.enablePlugin('syncline-obsidian'); } catch {}
+        try { await obsidianPage.enablePlugin('syncline'); } catch {}
         await browser.executeObsidian(async ({ app }, url) => {
-            const plugin: any = (app as any).plugins.plugins['syncline-obsidian'];
+            const plugin: any = (app as any).plugins.plugins['syncline'];
             if (!plugin) throw new Error('plugin not found');
             plugin.settings.serverUrl = url;
             await plugin.saveSettings();
@@ -123,7 +123,7 @@ describe('Syncline #58 — synthetic onFileCreate on vault load creates conflict
             await plugin.connect();
         }, serverUrl);
         await waitFor('plugin connected', async () => browser.executeObsidian(async ({ app }) => {
-            const plugin: any = (app as any).plugins.plugins['syncline-obsidian'];
+            const plugin: any = (app as any).plugins.plugins['syncline'];
             return !!(plugin && plugin.client && plugin.client.isConnected());
         }), 30_000, 200);
     });
@@ -150,7 +150,7 @@ describe('Syncline #58 — synthetic onFileCreate on vault load creates conflict
         }, 2 * 60_000, 200);
 
         const initialProjSize: number = await browser.executeObsidian(async ({ app }) => {
-            const p: any = (app as any).plugins.plugins['syncline-obsidian'];
+            const p: any = (app as any).plugins.plugins['syncline'];
             return p?.lastProjection?.size ?? 0;
         });
         console.log(`[#58] phase A: initial projection size = ${initialProjSize}, expected ${N_FILES}`);
@@ -159,10 +159,10 @@ describe('Syncline #58 — synthetic onFileCreate on vault load creates conflict
         // Phase B: disconnect, wipe manifest cache, keep vault files +
         // content cache (Obsidian still has the TFile tree).
         await browser.executeObsidian(async ({ app }) => {
-            const plugin: any = (app as any).plugins.plugins['syncline-obsidian'];
+            const plugin: any = (app as any).plugins.plugins['syncline'];
             plugin.disconnect();
         });
-        const stateDir = join(vaultPath, '.obsidian', 'plugins', 'syncline-obsidian', 'v1');
+        const stateDir = join(vaultPath, '.obsidian', 'plugins', 'syncline', 'v1');
         if (fs.existsSync(join(stateDir, 'manifest.bin'))) fs.unlinkSync(join(stateDir, 'manifest.bin'));
         if (fs.existsSync(join(stateDir, 'lamport.txt'))) fs.unlinkSync(join(stateDir, 'lamport.txt'));
         console.log(`[#58] phase B: manifest cache wiped (vault files retained)`);
@@ -175,7 +175,7 @@ describe('Syncline #58 — synthetic onFileCreate on vault load creates conflict
         // populated the live projection but the plugin's `lastProjection`
         // copy is still empty.
         await browser.executeObsidian(async ({ app }) => {
-            const plugin: any = (app as any).plugins.plugins['syncline-obsidian'];
+            const plugin: any = (app as any).plugins.plugins['syncline'];
             await plugin.connect();
         });
         // Wait for live manifest projection (queried straight off the
@@ -183,7 +183,7 @@ describe('Syncline #58 — synthetic onFileCreate on vault load creates conflict
         // `lastProjection` to update here — that would defeat the race.
         await waitFor('live projection populated', async () => {
             const liveSize: number = await browser.executeObsidian(async ({ app }) => {
-                const p: any = (app as any).plugins.plugins['syncline-obsidian'];
+                const p: any = (app as any).plugins.plugins['syncline'];
                 if (!p?.client) return 0;
                 try {
                     return JSON.parse(p.client.projectionJson()).length;
@@ -198,7 +198,7 @@ describe('Syncline #58 — synthetic onFileCreate on vault load creates conflict
         // same executeObsidian call as a `lastProjection.clear()` so
         // the race window is wide:
         const result: any = await browser.executeObsidian(async ({ app }) => {
-            const plugin: any = (app as any).plugins.plugins['syncline-obsidian'];
+            const plugin: any = (app as any).plugins.plugins['syncline'];
             // Force lastProjection back to empty to mimic the gap between
             // "server pushed manifest" and "plugin's first reconcile
             // populated lastProjection" during a real restart. Without
@@ -220,7 +220,7 @@ describe('Syncline #58 — synthetic onFileCreate on vault load creates conflict
         let stableTicks = 0;
         await waitFor('reconcile settles', async () => {
             const sz: number = await browser.executeObsidian(async ({ app }) => {
-                const p: any = (app as any).plugins.plugins['syncline-obsidian'];
+                const p: any = (app as any).plugins.plugins['syncline'];
                 return p?.lastProjection?.size ?? 0;
             });
             if (sz === lastProjSize) stableTicks++; else stableTicks = 0;
@@ -231,7 +231,7 @@ describe('Syncline #58 — synthetic onFileCreate on vault load creates conflict
 
         // Phase E: assert no conflict copies and projection size matches.
         const finalProjSize: number = await browser.executeObsidian(async ({ app }) => {
-            const p: any = (app as any).plugins.plugins['syncline-obsidian'];
+            const p: any = (app as any).plugins.plugins['syncline'];
             return p?.lastProjection?.size ?? 0;
         });
         const obs = listVault(vaultPath);

--- a/e2e/test/specs/issue63.e2e.ts
+++ b/e2e/test/specs/issue63.e2e.ts
@@ -105,10 +105,10 @@ describe('Syncline #63 — ingestNewFile race regression', () => {
         await waitFor('CLI handshake', async () => /v1 handshake OK/.test(cliOut), 30_000);
 
         const obsidianPage = browser.getObsidianPage();
-        try { await obsidianPage.enablePlugin('syncline-obsidian'); } catch {}
+        try { await obsidianPage.enablePlugin('syncline'); } catch {}
 
         await browser.executeObsidian(async ({ app }, url) => {
-            const plugin: any = (app as any).plugins.plugins['syncline-obsidian'];
+            const plugin: any = (app as any).plugins.plugins['syncline'];
             if (!plugin) throw new Error('plugin not found');
             plugin.settings.serverUrl = url;
             await plugin.saveSettings();
@@ -117,7 +117,7 @@ describe('Syncline #63 — ingestNewFile race regression', () => {
         }, serverUrl);
 
         await waitFor('plugin connected', async () => browser.executeObsidian(async ({ app }) => {
-            const plugin: any = (app as any).plugins.plugins['syncline-obsidian'];
+            const plugin: any = (app as any).plugins.plugins['syncline'];
             return !!(plugin && plugin.client && plugin.client.isConnected());
         }), 30_000);
     });

--- a/e2e/test/specs/phase1.e2e.ts
+++ b/e2e/test/specs/phase1.e2e.ts
@@ -223,13 +223,13 @@ describe('Syncline Phase 1 — restore-then-launch', () => {
 
         const obsidianPage = browser.getObsidianPage();
         try {
-            await obsidianPage.enablePlugin('syncline-obsidian');
+            await obsidianPage.enablePlugin('syncline');
         } catch (e: any) {
             console.log('plugin enable:', e?.message);
         }
 
         await browser.executeObsidian(async ({ app }, url) => {
-            const plugin: any = (app as any).plugins.plugins['syncline-obsidian'];
+            const plugin: any = (app as any).plugins.plugins['syncline'];
             if (!plugin) throw new Error('Syncline plugin not found in app.plugins');
             plugin.settings.serverUrl = url;
             await plugin.saveSettings();
@@ -248,7 +248,7 @@ describe('Syncline Phase 1 — restore-then-launch', () => {
         const expectedSize = listVault(sourceVault).size; // 1305
         await waitFor('plugin projection settles', async () => {
             const size: number = await browser.executeObsidian(async ({ app }) => {
-                const plugin: any = (app as any).plugins.plugins['syncline-obsidian'];
+                const plugin: any = (app as any).plugins.plugins['syncline'];
                 return plugin && plugin.lastProjection ? plugin.lastProjection.size : 0;
             });
             console.log(`plugin lastProjection.size = ${size} (expecting ~${expectedSize})`);
@@ -281,7 +281,7 @@ describe('Syncline Phase 1 — restore-then-launch', () => {
             lastBinary = binary;
 
             const pluginState: any = await browser.executeObsidian(async ({ app }) => {
-                const plugin: any = (app as any).plugins.plugins['syncline-obsidian'];
+                const plugin: any = (app as any).plugins.plugins['syncline'];
                 if (!plugin) return null;
                 return {
                     projection: plugin.lastProjection?.size ?? 0,

--- a/e2e/test/specs/phase2.e2e.ts
+++ b/e2e/test/specs/phase2.e2e.ts
@@ -100,10 +100,10 @@ describe('Syncline Phase 2 — CLI-side add', () => {
         await waitFor('CLI handshake', async () => /v1 handshake OK/.test(cliOut), 30_000);
 
         const obsidianPage = browser.getObsidianPage();
-        try { await obsidianPage.enablePlugin('syncline-obsidian'); } catch {}
+        try { await obsidianPage.enablePlugin('syncline'); } catch {}
 
         await browser.executeObsidian(async ({ app }, url) => {
-            const plugin: any = (app as any).plugins.plugins['syncline-obsidian'];
+            const plugin: any = (app as any).plugins.plugins['syncline'];
             if (!plugin) throw new Error('plugin not found');
             plugin.settings.serverUrl = url;
             await plugin.saveSettings();
@@ -112,7 +112,7 @@ describe('Syncline Phase 2 — CLI-side add', () => {
         }, serverUrl);
 
         await waitFor('plugin connected', async () => browser.executeObsidian(async ({ app }) => {
-            const plugin: any = (app as any).plugins.plugins['syncline-obsidian'];
+            const plugin: any = (app as any).plugins.plugins['syncline'];
             return !!(plugin && plugin.client && plugin.client.isConnected());
         }), 30_000);
     });
@@ -165,7 +165,7 @@ describe('Syncline Phase 2 — CLI-side add', () => {
             if (nonEmpty === lastNonEmpty && bin === lastBin) stableTicks++; else stableTicks = 0;
             lastNonEmpty = nonEmpty; lastBin = bin;
             const st: any = await browser.executeObsidian(async ({ app }) => {
-                const p: any = (app as any).plugins.plugins['syncline-obsidian'];
+                const p: any = (app as any).plugins.plugins['syncline'];
                 return p ? { proj: p.lastProjection?.size ?? 0, subs: p.subscribedContent?.size ?? 0, blobs: p.requestedBlobs?.size ?? 0, conn: p.client?.isConnected?.() ?? false } : null;
             });
             console.log(`[settle] nonEmpty=${nonEmpty}/${expectedNonEmpty} bin=${bin}/161 proj=${st?.proj} subs=${st?.subs} blobs=${st?.blobs} conn=${st?.conn} stable=${stableTicks}`);

--- a/e2e/test/specs/phase3.e2e.ts
+++ b/e2e/test/specs/phase3.e2e.ts
@@ -102,10 +102,10 @@ describe('Syncline Phase 3 — Obsidian-side add', () => {
         await waitFor('CLI handshake', async () => /v1 handshake OK/.test(cliOut), 30_000);
 
         const obsidianPage = browser.getObsidianPage();
-        try { await obsidianPage.enablePlugin('syncline-obsidian'); } catch {}
+        try { await obsidianPage.enablePlugin('syncline'); } catch {}
 
         await browser.executeObsidian(async ({ app }, url) => {
-            const plugin: any = (app as any).plugins.plugins['syncline-obsidian'];
+            const plugin: any = (app as any).plugins.plugins['syncline'];
             if (!plugin) throw new Error('plugin not found');
             plugin.settings.serverUrl = url;
             await plugin.saveSettings();
@@ -114,7 +114,7 @@ describe('Syncline Phase 3 — Obsidian-side add', () => {
         }, serverUrl);
 
         await waitFor('plugin connected', async () => browser.executeObsidian(async ({ app }) => {
-            const plugin: any = (app as any).plugins.plugins['syncline-obsidian'];
+            const plugin: any = (app as any).plugins.plugins['syncline'];
             return !!(plugin && plugin.client && plugin.client.isConnected());
         }), 30_000);
     });
@@ -173,7 +173,7 @@ describe('Syncline Phase 3 — Obsidian-side add', () => {
             if (nonEmpty === lastNonEmpty && bin === lastBin) stableTicks++; else stableTicks = 0;
             lastNonEmpty = nonEmpty; lastBin = bin;
             const st: any = await browser.executeObsidian(async ({ app }) => {
-                const p: any = (app as any).plugins.plugins['syncline-obsidian'];
+                const p: any = (app as any).plugins.plugins['syncline'];
                 return p ? { proj: p.lastProjection?.size ?? 0, subs: p.subscribedContent?.size ?? 0, blobs: p.requestedBlobs?.size ?? 0, conn: p.client?.isConnected?.() ?? false } : null;
             });
             console.log(`[settle] cli_nonEmpty=${nonEmpty}/${expectedNonEmpty} cli_bin=${bin}/161 proj=${st?.proj} subs=${st?.subs} blobs=${st?.blobs} conn=${st?.conn} stable=${stableTicks}`);

--- a/e2e/test/specs/phase4.e2e.ts
+++ b/e2e/test/specs/phase4.e2e.ts
@@ -194,9 +194,9 @@ describe('Syncline Phase 4 — claw.krej.ci-as-server', () => {
 
         // Now connect Obsidian and let it pull from the remote server.
         const obsidianPage = browser.getObsidianPage();
-        try { await obsidianPage.enablePlugin('syncline-obsidian'); } catch {}
+        try { await obsidianPage.enablePlugin('syncline'); } catch {}
         await browser.executeObsidian(async ({ app }, url) => {
-            const plugin: any = (app as any).plugins.plugins['syncline-obsidian'];
+            const plugin: any = (app as any).plugins.plugins['syncline'];
             if (!plugin) throw new Error('plugin not found');
             plugin.settings.serverUrl = url;
             await plugin.saveSettings();
@@ -204,7 +204,7 @@ describe('Syncline Phase 4 — claw.krej.ci-as-server', () => {
             await plugin.connect();
         }, serverUrl);
         await waitFor('plugin connected', async () => browser.executeObsidian(async ({ app }) => {
-            const plugin: any = (app as any).plugins.plugins['syncline-obsidian'];
+            const plugin: any = (app as any).plugins.plugins['syncline'];
             return !!(plugin && plugin.client && plugin.client.isConnected());
         }), 60_000);
         const vaultPath: string = await browser.executeObsidian(async ({ app }) => (app as any).vault.adapter.basePath as string);
@@ -219,7 +219,7 @@ describe('Syncline Phase 4 — claw.krej.ci-as-server', () => {
             if (nonEmpty === lastNonEmpty && bin === lastBin) stableTicks++; else stableTicks = 0;
             lastNonEmpty = nonEmpty; lastBin = bin;
             const st: any = await browser.executeObsidian(async ({ app }) => {
-                const p: any = (app as any).plugins.plugins['syncline-obsidian'];
+                const p: any = (app as any).plugins.plugins['syncline'];
                 return p ? { proj: p.lastProjection?.size ?? 0, subs: p.subscribedContent?.size ?? 0, blobs: p.requestedBlobs?.size ?? 0, conn: p.client?.isConnected?.() ?? false } : null;
             });
             console.log(`[settle] nonEmpty=${nonEmpty}/${expectedNonEmpty} bin=${bin}/161 proj=${st?.proj} subs=${st?.subs} blobs=${st?.blobs} conn=${st?.conn} stable=${stableTicks}`);

--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,0 @@
-{
-  "id": "syncline",
-  "name": "Syncline (live sync)",
-  "version": "1.1.5",
-  "minAppVersion": "1.0.0",
-  "description": "Real-time collaborative editing for your vault using CRDTs.",
-  "author": "Tomas Krejci",
-  "isDesktopOnly": false
-}

--- a/obsidian-plugin/README.md
+++ b/obsidian-plugin/README.md
@@ -13,7 +13,7 @@ A CRDT-based synchronization plugin for Obsidian that enables real-time collabor
 ## Installation
 
 1. Download the latest release from [github.com/tomas789/syncline/releases](https://github.com/tomas789/syncline/releases)
-2. Copy the following files to your Obsidian vault's `.obsidian/plugins/syncline-obsidian/` folder:
+2. Copy the following files to your Obsidian vault's `.obsidian/plugins/syncline/` folder:
    - `main.js`
    - `manifest.json`
    - `styles.css`
@@ -89,7 +89,7 @@ npm run build
    - Connect your Android device to your computer via USB
    - Enable "File Transfer" mode on Android
    - Navigate to your Obsidian vault folder on the device
-   - Create the folder `.obsidian/plugins/syncline-obsidian/`
+   - Create the folder `.obsidian/plugins/syncline/`
    - Copy the plugin files (`main.js`, `manifest.json`, `styles.css`)
    - Disconnect the device
 
@@ -116,7 +116,7 @@ npm run build
 2. **Install the plugin using iCloud Drive**:
    - On your computer, locate your Obsidian vault in iCloud Drive
    - Navigate to `.obsidian/plugins/`
-   - Create `syncline-obsidian/` folder
+   - Create `syncline/` folder
    - Copy the plugin files (`main.js`, `manifest.json`, `styles.css`)
    - Wait for iCloud to sync
 

--- a/obsidian-plugin/install.sh
+++ b/obsidian-plugin/install.sh
@@ -16,7 +16,10 @@ if [ ! -d "$VAULT_PATH" ]; then
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-PLUGIN_DIR="$VAULT_PATH/.obsidian/plugins/syncline-obsidian"
+# Plugin id is "syncline" (see obsidian-plugin/manifest.json). Keep this
+# directory name in lockstep with manifest.json#id; the consistency check in
+# .github/workflows/plugin-id-consistency.yml enforces the match.
+PLUGIN_DIR="$VAULT_PATH/.obsidian/plugins/syncline"
 
 echo "Installing Syncline Obsidian Plugin..."
 echo "  Vault: $VAULT_PATH"

--- a/obsidian-plugin/main.ts
+++ b/obsidian-plugin/main.ts
@@ -222,6 +222,7 @@ export default class SynclinePlugin extends Plugin {
   async onload() {
     console.debug("[Syncline] Loading plugin (v1)…");
     await this.loadSettings();
+    await this.migrateLegacyStateRoot();
     this.addSettingTab(new SynclineSettingTab(this.app, this));
 
     this.statusBarItem = this.addStatusBarItem();
@@ -272,6 +273,13 @@ export default class SynclinePlugin extends Plugin {
 
   /** Root folder for v1 CRDT snapshots — separate from any v0 leftovers. */
   private get stateRoot(): string {
+    // Use the plugin's own manifest id rather than a literal so this never
+    // drifts again. Pre-1.1.6 installs wrote state under "syncline-obsidian";
+    // migrateLegacyStateRoot() handles the relocation on first load.
+    return `${this.app.vault.configDir}/plugins/${this.manifest.id}/v1`;
+  }
+  /** Pre-1.1.6 state-root path. Only consulted by migrateLegacyStateRoot(). */
+  private get legacyStateRoot(): string {
     return `${this.app.vault.configDir}/plugins/syncline-obsidian/v1`;
   }
   private get manifestPath(): string {
@@ -292,6 +300,82 @@ export default class SynclinePlugin extends Plugin {
     const contentDir = `${this.stateRoot}/content`;
     if (!(await adapter.exists(contentDir))) {
       await adapter.mkdir(contentDir);
+    }
+  }
+
+  /**
+   * Pre-1.1.6 the plugin wrote its CRDT state-cache to
+   * `plugins/syncline-obsidian/v1/` while Obsidian itself laid the plugin
+   * down at `plugins/syncline/`. Two sibling dirs that look like two plugins.
+   *
+   * On first load after the rename:
+   *   - if only the legacy dir exists, move it into place;
+   *   - if only the new dir exists, no-op (already migrated or fresh install);
+   *   - if both exist, leave them alone and warn — merging arbitrary CRDT
+   *     state-blobs from two roots is unsafe; the user must pick one.
+   *
+   * This runs from onload before any state is read or written, so a cold
+   * start sees the migrated layout end-to-end.
+   */
+  private async migrateLegacyStateRoot(): Promise<void> {
+    const adapter = this.app.vault.adapter;
+    const legacy = this.legacyStateRoot;
+    const target = this.stateRoot;
+
+    // If the manifest id ever happens to equal the legacy literal (e.g. a
+    // future revert), legacy === target and there's nothing to migrate.
+    if (legacy === target) return;
+
+    let legacyExists: boolean;
+    let targetExists: boolean;
+    try {
+      legacyExists = await adapter.exists(legacy);
+      targetExists = await adapter.exists(target);
+    } catch (e) {
+      console.error("[Syncline] migrateLegacyStateRoot: stat failed:", e);
+      return;
+    }
+
+    if (!legacyExists) return;
+
+    if (targetExists) {
+      console.warn(
+        `[Syncline] Both ${legacy} and ${target} exist. Skipping migration to ` +
+          "avoid clobbering CRDT state. Manually delete the unwanted directory " +
+          "and reload the plugin.",
+      );
+      return;
+    }
+
+    // Make sure the parent dir exists (it normally does — this plugin is
+    // installed under it — but be defensive on fresh sandboxes).
+    const targetParent = `${this.app.vault.configDir}/plugins/${this.manifest.id}`;
+    try {
+      if (!(await adapter.exists(targetParent))) {
+        await adapter.mkdir(targetParent);
+      }
+    } catch (e) {
+      // mkdir on an existing path can race with the platform layer; tolerate.
+      if (!isAlreadyExistsError(e)) {
+        console.error(`[Syncline] migrateLegacyStateRoot: mkdir ${targetParent} failed:`, e);
+        return;
+      }
+    }
+
+    try {
+      // Obsidian's DataAdapter exposes rename() for both files and folders;
+      // it falls through to the platform fs.rename so a same-volume move is
+      // atomic. No shelling out, no bytewise copy.
+      await adapter.rename(legacy, target);
+      console.debug(
+        `[Syncline] Migrated legacy state-root ${legacy} → ${target}.`,
+      );
+    } catch (e) {
+      console.error(
+        `[Syncline] migrateLegacyStateRoot: rename ${legacy} → ${target} failed. ` +
+          "Plugin will run with an empty state-cache; the legacy directory is untouched.",
+        e,
+      );
     }
   }
 

--- a/obsidian-plugin/manifest.json
+++ b/obsidian-plugin/manifest.json
@@ -1,9 +1,9 @@
 {
-  "id": "syncline-obsidian",
-  "name": "Syncline",
+  "id": "syncline",
+  "name": "Syncline (live sync)",
   "version": "1.1.5",
-  "minAppVersion": "0.15.0",
-  "description": "Syncline sync plugin for Obsidian",
+  "minAppVersion": "1.0.0",
+  "description": "Real-time collaborative editing for your vault using CRDTs.",
   "author": "Tomas Krejci",
   "authorUrl": "https://github.com/tomas789/syncline",
   "fundingUrl": "",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -28,11 +28,6 @@
           "type": "json",
           "path": "obsidian-plugin/manifest.json",
           "jsonpath": "$.version"
-        },
-        {
-          "type": "json",
-          "path": "manifest.json",
-          "jsonpath": "$.version"
         }
       ]
     }


### PR DESCRIPTION
Closes #55.

## Summary

The repo carried two different plugin ids: the root `manifest.json` (shipped by release CI) said `"syncline"`, while `obsidian-plugin/manifest.json` and a hard-coded literal in `main.ts:275` said `"syncline-obsidian"`. Released installs ended up with the plugin code under `plugins/syncline/` and a sibling state-cache under `plugins/syncline-obsidian/v1/` — two dirs that look like two plugins, with stale CRDT state surviving any `rm -rf plugins/syncline`.

This PR implements items 1, 2, 3, 5 from the issue's "Proposed fix". Item 4 (obsidianmd/obsidian-releases registration) is left to the maintainer.

## (a) Manifest source-of-truth choice

Went with **Option A: single manifest, located at `obsidian-plugin/manifest.json`**. Deleted the repo-root `manifest.json`; `release-please.yml` now copies the plugin-dir manifest into release artifacts. Reasoning: rollup, the install script, and `npm` all treat `obsidian-plugin/` as the plugin's home; the root manifest was the odd one out and was the file release CI referenced by accident. Keeping the manifest co-located with the plugin source removes the drift surface entirely.

Field reconciliation took the union — `authorUrl` and `fundingUrl` from the plugin-dir manifest are preserved. `name` is set to `"Syncline (live sync)"` (the released-artifact value, what users currently see in Community plugins). `minAppVersion` is `"1.0.0"` (the released value). `description` matches the released artifact's prose.

## (b) Migration logic

`onload` now calls `migrateLegacyStateRoot()` before any state-cache read. The function uses `app.vault.adapter` (no shelling out, no bytewise copy):

| Legacy dir | Target dir | Action                                                                |
|------------|-----------|------------------------------------------------------------------------|
| absent     | -         | no-op (fresh install or already migrated)                              |
| present    | absent    | `adapter.rename(legacy, target)` — atomic same-volume move             |
| present    | present   | `console.warn` and bail — merging two independent CRDT blobs is unsafe |

The hard-coded `"syncline-obsidian"` in the live `stateRoot` getter is replaced with `this.manifest.id`. The legacy literal is isolated in a new `legacyStateRoot` getter that is **only** consulted by the migration path, so it cannot drift back into normal operation.

## (c) CI consistency check

New workflow `.github/workflows/plugin-id-consistency.yml` runs on every PR and fails if:

1. A second top-level `manifest.json` reappears at the repo root (the bug this PR fixes — guard against accidental restoration).
2. `obsidian-plugin/manifest.json#id` is anything other than `"syncline"` (`jq -r .id` check).
3. `main.ts` contains an unexpected count of `"syncline-obsidian"` occurrences. The legacy-migration block has exactly 3 documented references; any deviation fails the check with a pointer to update either the code or the expected count.

## Test plan

- [x] `cd obsidian-plugin && npm install && npm run build` succeeds locally
- [x] `cd obsidian-plugin && npm run lint` succeeds locally
- [x] All three CI consistency-check assertions pass locally (root manifest absent, `jq -r .id` returns `syncline`, `main.ts` has exactly 3 occurrences)
- [x] `grep -rn syncline-obsidian` returns only: the legacy-migration code in `main.ts`, npm package metadata in `package.json`/`package-lock.json` (independent of the Obsidian id), and one comment block — no live id references
- [x] Migration logic traced for all four startup states (legacy absent / legacy-only / target-only / both) by reading the diff
- [ ] Manual smoke test in a vault with a pre-1.1.6 install (legacy dir present) — verify `console.debug` logs the rename and the next session reads from the new path
- [ ] Manual smoke test in a fresh vault — verify no migration runs and the plugin loads cleanly

## Coordination note

Per the task brief, expect a small merge conflict in `obsidian-plugin/main.ts` against the in-flight `feat/syncline-sidebar-shell` (issue #65). The conflict is mechanical (different sections of `onload`); whichever PR merges second rebases.