### PR TITLE
feat(v1): chunked-blob sync (closes #59)

### DIFF
--- a/syncline/src/client_v1.rs
+++ b/syncline/src/client_v1.rs
@@ -789,20 +789,11 @@ async fn scan_once(
             // Binary path: read bytes, hash, CAS-stash locally, and
             // create/update the manifest entry. Actual upload is batched
             // and sent at the end of the walk.
-            let meta = match fs::metadata(abs) {
-                Ok(m) => m,
-                Err(e) => {
-                    debug!("skip unreadable metadata {}: {}", rel_str, e);
-                    continue;
-                }
-            };
-            if meta.len() as usize > MAX_BLOB_SIZE {
-                warn!(
-                    "skipping {} ({} bytes > MAX_BLOB_SIZE {})",
-                    rel_str, meta.len(), MAX_BLOB_SIZE
-                );
-                continue;
-            }
+            // No per-file size limit: the chunker breaks oversized
+            // files into pieces under MAX_CHUNK_SIZE, so each WS frame
+            // stays well under the protocol's MAX_BLOB_SIZE ceiling. A
+            // single multi-GB file is fine; it just produces many
+            // chunks. The original 16 MiB cliff (#59) is gone.
             let bytes = match fs::read(abs) {
                 Ok(b) => b,
                 Err(e) => {
@@ -815,13 +806,19 @@ async fn scan_once(
                 BinaryScanOutcome::Skipped(reason) => {
                     debug!("binary {} skipped: {}", rel_str, reason);
                 }
-                BinaryScanOutcome::Created { hash } => {
+                BinaryScanOutcome::Created {
+                    chunk_hashes: _,
+                    chunks_to_push,
+                } => {
                     new_binary += 1;
-                    pending_blobs.push((hash, bytes));
+                    pending_blobs.extend(chunks_to_push);
                 }
-                BinaryScanOutcome::Rehashed { hash } => {
+                BinaryScanOutcome::Rehashed {
+                    chunk_hashes: _,
+                    chunks_to_push,
+                } => {
                     modified_binary += 1;
-                    pending_blobs.push((hash, bytes));
+                    pending_blobs.extend(chunks_to_push);
                 }
             }
             continue;
@@ -901,13 +898,20 @@ async fn scan_once(
     // hasn't landed yet", not a delete. Directory nodes are emergent
     // and never appear in `by_path`.
     let mut deleted_files = 0usize;
-    let deletion_candidates: Vec<(NodeId, NodeKind, Option<String>, String)> = proj
+    let deletion_candidates: Vec<(NodeId, NodeKind, Vec<String>, String)> = proj
         .by_path
         .iter()
         .filter(|(path, _)| !visited_rel.contains(path.as_str()))
-        .map(|(path, entry)| (entry.id, entry.kind, entry.blob_hash.clone(), path.clone()))
+        .map(|(path, entry)| {
+            (
+                entry.id,
+                entry.kind,
+                entry.chunk_hashes.clone(),
+                path.clone(),
+            )
+        })
         .collect();
-    for (id, kind, blob_hash, path) in deletion_candidates {
+    for (id, kind, chunk_hashes, path) in deletion_candidates {
         match kind {
             NodeKind::Text => {
                 // Only treat a missing on-disk file as a local delete
@@ -921,8 +925,13 @@ async fn scan_once(
                 }
             }
             NodeKind::Binary => {
-                let have_blob = blob_hash.as_deref().map(|h| blobs.has(h)).unwrap_or(false);
-                if have_blob && manifest.delete(id) {
+                // Same gate as text but multi-chunk: only call this a
+                // local delete if every chunk is in our CAS. If any
+                // chunk is missing, this is "remote content hasn't
+                // landed yet", not the user removing the file.
+                let have_all = !chunk_hashes.is_empty()
+                    && chunk_hashes.iter().all(|h| blobs.has(h));
+                if have_all && manifest.delete(id) {
                     debug!(node = ?id, %path, "local binary delete detected");
                     deleted_files += 1;
                 }
@@ -1016,17 +1025,29 @@ async fn scan_once(
 
 /// Outcome of scanning a single binary file on disk. Pure enough to
 /// unit-test against a fake manifest + temp-dir BlobStore.
+///
+/// Carries the chunks the caller still needs to push to the server —
+/// only those chunks whose hashes weren't part of the *previous* entry
+/// at this path. Chunk uploads are content-addressed, so the server's
+/// CAS already deduplicates re-uploads, but we save bandwidth by not
+/// resending the unchanged tail of a partially-modified file.
 #[derive(Debug)]
 enum BinaryScanOutcome {
-    /// Manifest already has a Binary entry at this path with this hash —
-    /// nothing to upload, nothing to record.
+    /// Manifest already has a Binary entry at this path with this exact
+    /// chunk-hash list — nothing to upload, nothing to record.
     Unchanged,
-    /// New path: manifest gained a `Binary` entry; bytes were stashed in
-    /// the local blob store and should be uploaded.
-    Created { hash: String },
-    /// Existing binary path's on-disk content changed: manifest hash
-    /// bumped; bytes were stashed locally and should be uploaded.
-    Rehashed { hash: String },
+    /// New path: manifest gained a `Binary` entry; the listed chunks
+    /// were stashed in the local CAS and should be uploaded.
+    Created {
+        chunk_hashes: Vec<String>,
+        chunks_to_push: Vec<(String, Vec<u8>)>,
+    },
+    /// Existing binary path's on-disk content changed: manifest list
+    /// updated; new chunks were stashed locally and should be uploaded.
+    Rehashed {
+        chunk_hashes: Vec<String>,
+        chunks_to_push: Vec<(String, Vec<u8>)>,
+    },
     /// A local manifest entry exists at this path but is not `Binary`
     /// (e.g. Text) — or creation fell through with a path-level error.
     /// We refuse to clobber the kind. Caller logs and moves on.
@@ -1035,18 +1056,22 @@ enum BinaryScanOutcome {
 
 /// Core per-binary-file logic, factored out so tests can drive it
 /// without a `WsSink`. The caller is responsible for:
-///   * reading `bytes` off disk
-///   * enforcing `MAX_BLOB_SIZE`
-///   * issuing the `MSG_BLOB_UPDATE` frame when we return `Created` /
-///     `Rehashed`
+///   * reading `bytes` off disk (no `MAX_BLOB_SIZE` check needed —
+///     chunking caps every individual frame at `MAX_CHUNK_SIZE`)
+///   * issuing one `MSG_BLOB_UPDATE` frame per `(hash, bytes)` in
+///     `chunks_to_push` when we return `Created` / `Rehashed`
 ///
-/// This helper hashes the bytes, CAS-stashes them in `blobs` (idempotent),
-/// then reconciles against the current manifest projection:
-///   * no existing entry at `rel_path` → `create_binary`, emit `Created`
-///   * existing Binary entry with the same hash → `Unchanged`
-///   * existing Binary entry with a different hash → `set_blob_hash`,
-///     emit `Rehashed`
-///   * existing Text/Directory entry at that path → `Skipped("kind")`
+/// This helper:
+///   1. Splits `bytes` into FastCDC chunks (single chunk for small files).
+///   2. CAS-stashes every chunk locally (idempotent).
+///   3. Diffs the new chunk-hash list against the current manifest entry:
+///      * no entry → `create_binary`, emit `Created` (push all chunks).
+///      * Binary entry with the **same** chunk list → `Unchanged`.
+///      * Binary entry with a **different** chunk list → `set_chunk_hashes`,
+///        emit `Rehashed` (push only chunks whose hash isn't in the
+///        previous list — the FastCDC small-edit-locality property
+///        means an edit at one position only touches nearby chunks).
+///      * Text/Directory entry at that path → `Skipped("kind_mismatch")`.
 fn process_binary_file(
     rel_path: &str,
     bytes: &[u8],
@@ -1054,30 +1079,55 @@ fn process_binary_file(
     manifest: &mut Manifest,
     blobs: &BlobStore,
 ) -> Result<BinaryScanOutcome> {
-    let hash = hash_hex(bytes);
+    use crate::v1::chunker;
+
+    let chunks = chunker::chunks_with_hashes(bytes);
+    let chunk_hashes: Vec<String> = chunks.iter().map(|c| c.hash.clone()).collect();
     let size = bytes.len() as u64;
 
-    // Stash locally first — idempotent, and guarantees that if we
-    // record the hash in the manifest we actually have the blob to
-    // serve to any peer that asks.
-    blobs
-        .insert_bytes(bytes)
-        .with_context(|| format!("stashing blob for {}", rel_path))?;
+    // Stash every chunk locally before recording the hash list — we
+    // must be able to serve any chunk that a peer asks for.
+    for c in &chunks {
+        blobs
+            .insert_bytes(&c.bytes)
+            .with_context(|| {
+                format!("stashing chunk {} for {}", c.hash, rel_path)
+            })?;
+    }
 
-    match proj.by_path.get(rel_path) {
-        None => match crate::v1::ops::create_binary(manifest, rel_path, &hash, size) {
-            Ok(_) => Ok(BinaryScanOutcome::Created { hash }),
+    let existing = proj.by_path.get(rel_path);
+    let old_set: std::collections::HashSet<&str> = match existing {
+        Some(e) if e.kind == NodeKind::Binary => {
+            e.chunk_hashes.iter().map(|s| s.as_str()).collect()
+        }
+        _ => std::collections::HashSet::new(),
+    };
+    let chunks_to_push: Vec<(String, Vec<u8>)> = chunks
+        .iter()
+        .filter(|c| !old_set.contains(c.hash.as_str()))
+        .map(|c| (c.hash.clone(), c.bytes.clone()))
+        .collect();
+
+    match existing {
+        None => match crate::v1::ops::create_binary(manifest, rel_path, &chunk_hashes, size) {
+            Ok(_) => Ok(BinaryScanOutcome::Created {
+                chunk_hashes,
+                chunks_to_push,
+            }),
             Err(e) => {
                 debug!("create_binary({:?}) failed: {}", rel_path, e);
                 Ok(BinaryScanOutcome::Skipped("create_binary_failed"))
             }
         },
-        Some(existing) if existing.kind == NodeKind::Binary => {
-            if existing.blob_hash.as_deref() == Some(hash.as_str()) {
+        Some(e) if e.kind == NodeKind::Binary => {
+            if e.chunk_hashes == chunk_hashes {
                 Ok(BinaryScanOutcome::Unchanged)
             } else {
-                manifest.set_blob_hash(existing.id, &hash, size);
-                Ok(BinaryScanOutcome::Rehashed { hash })
+                manifest.set_chunk_hashes(e.id, &chunk_hashes, size);
+                Ok(BinaryScanOutcome::Rehashed {
+                    chunk_hashes,
+                    chunks_to_push,
+                })
             }
         }
         Some(_) => Ok(BinaryScanOutcome::Skipped("kind_mismatch")),
@@ -1283,10 +1333,10 @@ fn handle_inbound_blob(doc_id: &str, payload: &[u8], blobs: &BlobStore) -> Resul
     Ok(())
 }
 
-/// For each live Binary entry in the manifest projection whose blob we
-/// don't yet have locally and haven't already requested this session,
-/// send a `MSG_BLOB_REQUEST`. The server replies with `MSG_BLOB_UPDATE`
-/// over the same connection.
+/// For each live Binary entry, request every chunk we don't yet have
+/// locally and haven't already requested this session. The server
+/// replies with `MSG_BLOB_UPDATE` per chunk; the request payload
+/// carries the chunk's hash.
 async fn request_missing_blobs(
     write: &mut WsSink,
     manifest: &Manifest,
@@ -1299,24 +1349,25 @@ async fn request_missing_blobs(
         if entry.kind != NodeKind::Binary {
             continue;
         }
-        let Some(hash) = entry.blob_hash.as_deref() else {
-            continue;
-        };
-        if blobs.has(hash) || requested.contains(hash) {
-            continue;
+        for hash in &entry.chunk_hashes {
+            if blobs.has(hash) || requested.contains(hash) {
+                continue;
+            }
+            // Server's handle_blob_request parses the payload as utf8
+            // hash. We echo the hash in doc_id too so the reply is
+            // self-identifying — the server's response carries that
+            // doc_id back, which we use to verify+stash on receipt.
+            let frame = encode_message(MSG_BLOB_REQUEST, hash, hash.as_bytes());
+            write
+                .send(WsMessage::Binary(frame.into()))
+                .await
+                .context("send blob request")?;
+            requested.insert(hash.clone());
+            sent += 1;
         }
-        // Server's handle_blob_request parses the payload as utf8 hash.
-        // We echo the hash in doc_id too so the reply is self-identifying.
-        let frame = encode_message(MSG_BLOB_REQUEST, hash, hash.as_bytes());
-        write
-            .send(WsMessage::Binary(frame.into()))
-            .await
-            .context("send blob request")?;
-        requested.insert(hash.to_string());
-        sent += 1;
     }
     if sent > 0 {
-        debug!("sent {} MSG_BLOB_REQUEST frames", sent);
+        debug!("sent {} MSG_BLOB_REQUEST frames (chunked)", sent);
     }
     Ok(())
 }
@@ -1411,6 +1462,23 @@ fn flush_content_to_disk(
         "flushed content subdoc to disk"
     );
     Ok(())
+}
+
+/// Concatenate the bytes of every chunk in `chunk_hashes`, in order,
+/// from the local CAS [`BlobStore`]. Used by reconcile to materialise
+/// a binary file from the manifest's chunk list.
+///
+/// Errors if any chunk is missing from the store — callers must check
+/// `blobs.has(hash)` for every chunk first to avoid this branch.
+fn assemble_chunks(blobs: &BlobStore, chunk_hashes: &[String]) -> Result<Vec<u8>> {
+    let mut out: Vec<u8> = Vec::new();
+    for (i, hash) in chunk_hashes.iter().enumerate() {
+        let bytes = blobs
+            .read(hash)
+            .with_context(|| format!("read chunk {} of {}: {}", i + 1, chunk_hashes.len(), hash))?;
+        out.extend_from_slice(&bytes);
+    }
+    Ok(out)
 }
 
 /// Shared atomic-write helper (tmp + fsync + rename), used by both the
@@ -1576,31 +1644,39 @@ fn reconcile_projection_to_disk(
                 }
             }
             NodeKind::Binary => {
-                let Some(hash) = entry.blob_hash.as_deref() else {
-                    // A Binary entry with no hash is a manifest-level
-                    // bug on the emitting peer; nothing we can write.
-                    debug!("binary {:?} has no blob_hash, skipping", path);
+                let chunk_hashes = &entry.chunk_hashes;
+                if chunk_hashes.is_empty() {
+                    // Manifest entry with no chunks is a placeholder —
+                    // either the emitting peer hasn't written content
+                    // yet, or it's a truly empty file. Treat as
+                    // "nothing materialised yet" and try again later.
+                    debug!("binary {:?} has no chunks, skipping", path);
                     continue;
-                };
+                }
+                // Need every chunk in local CAS before we can materialise.
+                let missing_chunks =
+                    chunk_hashes.iter().any(|h| !blobs.has(h));
+                if missing_chunks {
+                    pending_binary += 1;
+                    continue;
+                }
+
                 if full.exists() {
                     let local_bytes = fs::read(&full)
                         .with_context(|| format!("read local {}", full.display()))?;
-                    let local_hash = hash_hex(&local_bytes);
-                    if local_hash == hash {
+                    let local_chunk_hashes: Vec<String> =
+                        crate::v1::chunker::chunks_with_hashes(&local_bytes)
+                            .into_iter()
+                            .map(|c| c.hash)
+                            .collect();
+                    if &local_chunk_hashes == chunk_hashes {
                         continue;
                     }
-                    if !blobs.has(hash) {
-                        // Remote blob not fetched yet; keep local bytes
-                        // in place and handle the conflict atomically on
-                        // a later reconcile (once the blob arrives).
-                        pending_binary += 1;
-                        continue;
-                    }
-                    // Disk diverged from manifest and we have the remote
-                    // version. LWW: remote wins (we reach this branch
-                    // only after a remote manifest update landed). Save
-                    // local bytes as a conflict sibling so nothing gets
-                    // silently clobbered.
+                    // Disk diverged from manifest. LWW: remote wins
+                    // (we reach this branch only after a remote
+                    // manifest update landed). Save local bytes as a
+                    // conflict sibling so nothing gets silently
+                    // clobbered.
                     blobs.insert_bytes(&local_bytes).with_context(|| {
                         format!("stash conflict bytes for {:?}", path)
                     })?;
@@ -1608,34 +1684,35 @@ fn reconcile_projection_to_disk(
                     let conflict_rel =
                         conflict_sibling_path(path, &actor_short, &today_ymd());
                     let conflict_full = folder.join(&conflict_rel);
-                    atomic_write(&conflict_full, &local_bytes).with_context(|| {
-                        format!("write conflict copy {}", conflict_full.display())
-                    })?;
-                    let remote_bytes = blobs.read(hash).with_context(|| {
-                        format!("read remote blob {} for {:?}", hash, path)
-                    })?;
+                    atomic_write(&conflict_full, &local_bytes).with_context(
+                        || format!("write conflict copy {}", conflict_full.display()),
+                    )?;
+                    let remote_bytes =
+                        assemble_chunks(blobs, chunk_hashes).with_context(|| {
+                            format!("assemble remote chunks for {:?}", path)
+                        })?;
                     atomic_write(&full, &remote_bytes).with_context(|| {
                         format!("overwrite with remote {}", full.display())
                     })?;
                     warn!(
                         path = %path,
                         conflict_copy = %conflict_rel,
-                        local_hash = %local_hash,
-                        remote_hash = %hash,
+                        local_chunks = local_chunk_hashes.len(),
+                        remote_chunks = chunk_hashes.len(),
                         "binary conflict: local bytes preserved, remote applied"
                     );
                     conflicts_created += 1;
                     continue;
                 }
-                if !blobs.has(hash) {
-                    pending_binary += 1;
-                    continue;
-                }
-                let bytes = blobs
-                    .read(hash)
-                    .with_context(|| format!("read blob {} for {:?}", hash, path))?;
+
+                let bytes = assemble_chunks(blobs, chunk_hashes)
+                    .with_context(|| format!("assemble chunks for {:?}", path))?;
                 atomic_write(&full, &bytes).with_context(|| {
-                    format!("materialize binary {} from blob {}", full.display(), hash)
+                    format!(
+                        "materialize binary {} from {} chunks",
+                        full.display(),
+                        chunk_hashes.len()
+                    )
                 })?;
                 created_binary += 1;
             }
@@ -1934,7 +2011,13 @@ mod tests {
         crate::v1::ops::create_text(&mut m, "top.md", 0).unwrap();
         crate::v1::ops::create_text(&mut m, "notes/deep/sub.md", 0).unwrap();
         // Binary present in manifest but blob is NOT in the local store.
-        crate::v1::ops::create_binary(&mut m, "img/pic.png", "deadbeef", 1024).unwrap();
+        crate::v1::ops::create_binary(
+            &mut m,
+            "img/pic.png",
+            &["deadbeef".to_string()],
+            1024,
+        )
+        .unwrap();
 
         reconcile_projection_to_disk(folder, &m, &blobs, &mut HashMap::new(), None).unwrap();
 
@@ -1962,8 +2045,13 @@ mod tests {
         let hash = blobs.insert_bytes(bytes).unwrap();
 
         let mut m = Manifest::new(ActorId::new());
-        crate::v1::ops::create_binary(&mut m, "img/pic.png", &hash, bytes.len() as u64)
-            .unwrap();
+        crate::v1::ops::create_binary(
+            &mut m,
+            "img/pic.png",
+            &[hash.clone()],
+            bytes.len() as u64,
+        )
+        .unwrap();
 
         reconcile_projection_to_disk(folder, &m, &blobs, &mut HashMap::new(), None).unwrap();
 
@@ -2005,7 +2093,13 @@ mod tests {
         fs::write(folder.join("img.bin"), local_bytes).unwrap();
 
         let mut m = Manifest::new(ActorId::new());
-        crate::v1::ops::create_binary(&mut m, "img.bin", "deadbeef", 123).unwrap();
+        crate::v1::ops::create_binary(
+            &mut m,
+            "img.bin",
+            &["deadbeef".to_string()],
+            123,
+        )
+        .unwrap();
 
         reconcile_projection_to_disk(folder, &m, &blobs, &mut HashMap::new(), None).unwrap();
 
@@ -2203,31 +2297,45 @@ mod tests {
         let bytes = b"\x89PNG\r\n\x1a\npretend png";
 
         let outcome = process_binary_file("img/pic.png", bytes, &proj, &mut m, &bs).unwrap();
+        // Small blob → single chunk == whole-file hash.
         let expected = hash_hex(bytes);
 
         match outcome {
-            BinaryScanOutcome::Created { hash } => assert_eq!(hash, expected),
+            BinaryScanOutcome::Created {
+                chunk_hashes,
+                chunks_to_push,
+            } => {
+                assert_eq!(chunk_hashes, vec![expected.clone()]);
+                assert_eq!(chunks_to_push.len(), 1);
+                assert_eq!(chunks_to_push[0].0, expected);
+                assert_eq!(chunks_to_push[0].1, bytes);
+            }
             other => panic!("expected Created, got {other:?}"),
         }
-        assert!(bs.has(&expected), "blob must be in local store");
+        assert!(bs.has(&expected), "chunk must be in local store");
 
-        // Manifest now has a Binary entry at that path with matching hash + size.
         let proj2 = project(&m);
         let entry = proj2
             .by_path
             .get("img/pic.png")
             .expect("projection should include img/pic.png");
         assert_eq!(entry.kind, NodeKind::Binary);
-        assert_eq!(entry.blob_hash.as_deref(), Some(expected.as_str()));
+        assert_eq!(entry.chunk_hashes, vec![expected.clone()]);
     }
 
     #[test]
-    fn process_binary_unchanged_when_hash_matches() {
+    fn process_binary_unchanged_when_chunks_match() {
         let mut m = Manifest::new(ActorId::new());
         let (_tmp, bs) = fresh_blob_store();
         let bytes = b"same png bytes";
         let h = hash_hex(bytes);
-        crate::v1::ops::create_binary(&mut m, "a.png", &h, bytes.len() as u64).unwrap();
+        crate::v1::ops::create_binary(
+            &mut m,
+            "a.png",
+            &[h.clone()],
+            bytes.len() as u64,
+        )
+        .unwrap();
         bs.insert_bytes(bytes).unwrap();
 
         let proj = project(&m);
@@ -2241,7 +2349,13 @@ mod tests {
         let (_tmp, bs) = fresh_blob_store();
         let old = b"old png bytes";
         let h_old = hash_hex(old);
-        crate::v1::ops::create_binary(&mut m, "a.png", &h_old, old.len() as u64).unwrap();
+        crate::v1::ops::create_binary(
+            &mut m,
+            "a.png",
+            &[h_old.clone()],
+            old.len() as u64,
+        )
+        .unwrap();
         bs.insert_bytes(old).unwrap();
 
         let new = b"new png bytes, different length and content";
@@ -2250,16 +2364,123 @@ mod tests {
         let outcome = process_binary_file("a.png", new, &proj, &mut m, &bs).unwrap();
 
         match outcome {
-            BinaryScanOutcome::Rehashed { hash } => assert_eq!(hash, h_new),
+            BinaryScanOutcome::Rehashed {
+                chunk_hashes,
+                chunks_to_push,
+            } => {
+                assert_eq!(chunk_hashes, vec![h_new.clone()]);
+                // New chunk wasn't in the old list, so it must be in
+                // the push list.
+                assert_eq!(chunks_to_push.len(), 1);
+                assert_eq!(chunks_to_push[0].0, h_new);
+            }
             other => panic!("expected Rehashed, got {other:?}"),
         }
-        assert!(bs.has(&h_new), "new blob must be stashed");
+        assert!(bs.has(&h_new), "new chunk must be stashed");
         let proj2 = project(&m);
         assert_eq!(
-            proj2.by_path["a.png"].blob_hash.as_deref(),
-            Some(h_new.as_str()),
-            "manifest hash must point to the new blob"
+            proj2.by_path["a.png"].chunk_hashes,
+            vec![h_new.clone()],
+            "manifest list must point to the new chunk"
         );
+    }
+
+    #[test]
+    fn process_binary_chunks_a_large_file_into_many() {
+        // 10 MiB of deterministic bytes — well above MAX_CHUNK_SIZE
+        // (4 MiB), so FastCDC must produce ≥ 2 chunks.
+        let mut bytes = Vec::with_capacity(10 * 1024 * 1024);
+        let mut state: u64 = 0xDEADBEEFCAFEBABE;
+        while bytes.len() < 10 * 1024 * 1024 {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            bytes.extend_from_slice(&state.to_le_bytes());
+        }
+        bytes.truncate(10 * 1024 * 1024);
+
+        let mut m = Manifest::new(ActorId::new());
+        let proj = project(&m);
+        let (_tmp, bs) = fresh_blob_store();
+
+        let outcome =
+            process_binary_file("big.bin", &bytes, &proj, &mut m, &bs).unwrap();
+        match outcome {
+            BinaryScanOutcome::Created {
+                chunk_hashes,
+                chunks_to_push,
+            } => {
+                assert!(
+                    chunk_hashes.len() >= 2,
+                    "expected ≥ 2 chunks for 10 MiB file, got {}",
+                    chunk_hashes.len()
+                );
+                assert_eq!(chunks_to_push.len(), chunk_hashes.len());
+                // Every chunk must be in local CAS so we can serve it.
+                for h in &chunk_hashes {
+                    assert!(bs.has(h));
+                }
+                // Every chunk must be cap-respecting.
+                for (_, chunk_bytes) in &chunks_to_push {
+                    assert!(
+                        chunk_bytes.len() <= crate::v1::chunker::MAX_CHUNK_SIZE as usize
+                    );
+                }
+            }
+            other => panic!("expected Created, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn process_binary_only_pushes_changed_chunks_on_partial_edit() {
+        // Build a large file, register it, then change the first byte
+        // and confirm the rescan only has to upload the chunks that
+        // FastCDC re-cuts at the head — the long unchanged tail must
+        // be skipped (zero bandwidth for unchanged content).
+        let mut bytes = Vec::with_capacity(10 * 1024 * 1024);
+        let mut state: u64 = 0x1234567890ABCDEF;
+        while bytes.len() < 10 * 1024 * 1024 {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            bytes.extend_from_slice(&state.to_le_bytes());
+        }
+        bytes.truncate(10 * 1024 * 1024);
+
+        let mut m = Manifest::new(ActorId::new());
+        let (_tmp, bs) = fresh_blob_store();
+
+        let proj = project(&m);
+        let first =
+            process_binary_file("big.bin", &bytes, &proj, &mut m, &bs).unwrap();
+        let original_chunks = match first {
+            BinaryScanOutcome::Created { chunk_hashes, .. } => chunk_hashes,
+            other => panic!("expected Created, got {other:?}"),
+        };
+        assert!(original_chunks.len() >= 2);
+
+        // Single-byte edit at the head. FastCDC's small-edit-locality
+        // property says ≥ 75% of chunks should still hash the same.
+        bytes[0] ^= 0xff;
+
+        let proj = project(&m);
+        let second =
+            process_binary_file("big.bin", &bytes, &proj, &mut m, &bs).unwrap();
+        match second {
+            BinaryScanOutcome::Rehashed {
+                chunk_hashes,
+                chunks_to_push,
+            } => {
+                let total = chunk_hashes.len();
+                let pushed = chunks_to_push.len();
+                assert!(
+                    pushed * 4 <= total * 3 + 4,
+                    "expected most chunks to be reused; pushed {pushed} of {total}"
+                );
+                assert!(pushed > 0, "the changed chunk must be pushed");
+            }
+            other => panic!("expected Rehashed, got {other:?}"),
+        }
     }
 
     #[test]
@@ -2384,7 +2605,7 @@ mod tests {
         crate::v1::ops::create_binary(
             &mut m,
             "img.bin",
-            &remote_hash,
+            &[remote_hash.clone()],
             remote_bytes.len() as u64,
         )
         .unwrap();
@@ -2423,7 +2644,13 @@ mod tests {
         fs::write(folder.join("img.bin"), bytes).unwrap();
 
         let mut m = Manifest::new(ActorId::new());
-        crate::v1::ops::create_binary(&mut m, "img.bin", &hash, bytes.len() as u64).unwrap();
+        crate::v1::ops::create_binary(
+            &mut m,
+            "img.bin",
+            &[hash.clone()],
+            bytes.len() as u64,
+        )
+        .unwrap();
 
         reconcile_projection_to_disk(folder, &m, &blobs, &mut HashMap::new(), None).unwrap();
 

--- a/syncline/src/protocol.rs
+++ b/syncline/src/protocol.rs
@@ -42,8 +42,16 @@ pub const MANIFEST_UPDATE: u8 = 2;
 pub const V1_PROTOCOL_MAJOR: u8 = 1;
 pub const V1_PROTOCOL_MINOR: u8 = 0;
 
-/// Maximum blob size in bytes (50 MB).
-pub const MAX_BLOB_SIZE: usize = 50 * 1024 * 1024;
+/// Maximum size of a single blob frame on the wire (5 MiB).
+///
+/// Sized to sit safely under the WebSocket frame ceiling that
+/// `tokio-tungstenite` enforces by default (16 MiB) — see issue #59
+/// for the failure mode this constant prevents. Files larger than the
+/// per-chunk cap go through the [`v1::chunker`] which slices them into
+/// pieces of at most [`v1::chunker::MAX_CHUNK_SIZE`] (4 MiB) before
+/// they reach this layer, so this 5 MiB ceiling is in practice an
+/// overrun-detector rather than a hard limit on user content.
+pub const MAX_BLOB_SIZE: usize = 5 * 1024 * 1024;
 
 pub fn encode_message(msg_type: u8, doc_id: &str, payload: &[u8]) -> Vec<u8> {
     let doc_id_bytes = doc_id.as_bytes();

--- a/syncline/src/server/migration.rs
+++ b/syncline/src/server/migration.rs
@@ -111,11 +111,19 @@ pub async fn migrate_server_db(db: &Db) -> Result<ServerMigrationReport> {
             NodeKind::Text => snap.content.as_ref().map(|s| s.len()).unwrap_or(0) as u64,
             _ => 0,
         };
+        // v0 single-hash → length-1 chunk list. Re-chunking happens
+        // the next time a client uploads the file.
+        let chunk_hashes: Vec<String> = snap
+            .blob_hash
+            .as_deref()
+            .filter(|s| !s.is_empty())
+            .map(|h| vec![h.to_string()])
+            .unwrap_or_default();
         let node_id = manifest.create_node(
             &leaf,
             parent,
             snap.kind,
-            snap.blob_hash.as_deref(),
+            &chunk_hashes,
             size,
         );
 
@@ -341,7 +349,7 @@ fn ensure_parent_chain(
         let id = if let Some(id) = dir_nodes.get(&prefix) {
             *id
         } else {
-            let id = manifest.create_node(seg, parent, NodeKind::Directory, None, 0);
+            let id = manifest.create_node(seg, parent, NodeKind::Directory, &[], 0);
             dir_nodes.insert(prefix.clone(), id);
             id
         };
@@ -497,7 +505,8 @@ mod tests {
         let entry = m.live_entries().into_iter().next().unwrap();
         assert_eq!(entry.name, "pic.png");
         assert!(matches!(entry.kind, NodeKind::Binary));
-        assert_eq!(entry.blob_hash.as_deref(), Some("deadbeef"));
+        assert_eq!(entry.chunk_hashes, vec!["deadbeef".to_string()]);
+        assert_eq!(entry.single_blob_hash(), Some("deadbeef"));
     }
 
     #[tokio::test]

--- a/syncline/src/server/server.rs
+++ b/syncline/src/server/server.rs
@@ -203,10 +203,38 @@ async fn handle_socket(socket: WebSocket, state: AppState) {
         // -----------------------------------------------------------------
         // Step 2 — message loop.
         // -----------------------------------------------------------------
-        while let Some(Ok(msg)) = receiver.next().await {
+        loop {
+            let msg = match receiver.next().await {
+                Some(Ok(m)) => m,
+                Some(Err(e)) => {
+                    // Critical — without this, an oversized inbound
+                    // frame, a TLS error, or any other protocol-level
+                    // teardown by `tokio-tungstenite` disappears from
+                    // the server log entirely; the client just sees a
+                    // bare `Connection reset by peer`. See #59 for the
+                    // class of failure this log line catches.
+                    tracing::warn!(
+                        conn = %connection_id,
+                        error = %e,
+                        "websocket recv error: tearing down session"
+                    );
+                    break;
+                }
+                None => {
+                    tracing::debug!(conn = %connection_id, "websocket stream ended");
+                    break;
+                }
+            };
             let data = match msg {
                 Message::Binary(b) => b,
-                Message::Close(_) => break,
+                Message::Close(frame) => {
+                    tracing::debug!(
+                        conn = %connection_id,
+                        frame = ?frame,
+                        "peer closed websocket"
+                    );
+                    break;
+                }
                 _ => continue,
             };
             let Some((msg_type, doc_id, payload)) = decode_message(&data) else {

--- a/syncline/src/v1/manifest.rs
+++ b/syncline/src/v1/manifest.rs
@@ -13,7 +13,14 @@
 //! | `parent`     | String  | parent NodeId, empty string = vault root         |
 //! | `deleted`    | bool    | tombstone flag                                   |
 //! | `kind`       | String  | `"text"` / `"binary"` / `"directory"`            |
-//! | `blob`       | String  | hex SHA-256, absent unless `kind == "binary"`    |
+//! | `chunks`     | String  | comma-separated hex SHA-256 chunk hashes; only   |
+//! |              |         | meaningful when `kind == "binary"`. Length 0 =   |
+//! |              |         | empty placeholder; 1 = small file (single chunk);|
+//! |              |         | 2+ = chunked large file (FastCDC).               |
+//! | `blob`       | String  | **legacy field**, single hash. Read for          |
+//! |              |         | back-compat with manifests written before #59;   |
+//! |              |         | new writes always go through `chunks`. Decoded   |
+//! |              |         | as a length-1 `chunks` list.                     |
 //! | `size`       | i64     | bytes (hint for UI / GC)                         |
 //! | `created_at` | i64     | lamport of the create event (immutable)          |
 //! | `c_actor`    | String  | actor that created the entry (immutable)         |
@@ -66,7 +73,17 @@ pub struct NodeEntry {
     pub parent: Option<NodeId>,
     pub deleted: bool,
     pub kind: NodeKind,
-    pub blob_hash: Option<String>,
+    /// SHA-256 hex hashes of the file's content-defined chunks, in
+    /// file order. Empty for non-binary entries and for binaries with
+    /// no content yet (e.g. zero-byte placeholders).
+    ///
+    /// - `len() == 0` — no content
+    /// - `len() == 1` — small binary (single chunk holds the whole file)
+    /// - `len() >= 2` — chunked large binary (each chunk ≤ MAX_CHUNK_SIZE)
+    ///
+    /// Concatenating the bytes of each chunk in order reproduces the
+    /// original file. See [`v1::chunker`].
+    pub chunk_hashes: Vec<String>,
     pub size: u64,
     pub created_at: Lamport,
     pub created_by: ActorId,
@@ -81,6 +98,23 @@ impl NodeEntry {
         let create = Stamp::new(self.created_at, self.created_by);
         let candidates = [Some(create), self.delete_stamp, self.modify_stamp];
         candidates.into_iter().flatten().max().unwrap()
+    }
+
+    /// Backwards-compatible accessor: returns `Some(&hash)` only when
+    /// the entry has exactly one chunk (the legacy single-blob shape).
+    /// Multi-chunk binaries return `None` here — callers that need to
+    /// reason about multi-chunk content must look at [`chunk_hashes`]
+    /// directly.
+    ///
+    /// Used by sites that pre-date #59 and just want "the hash that
+    /// identifies this binary's bytes", and by sites that haven't yet
+    /// been generalised to handle multi-chunk binaries.
+    pub fn single_blob_hash(&self) -> Option<&str> {
+        if self.chunk_hashes.len() == 1 {
+            Some(self.chunk_hashes[0].as_str())
+        } else {
+            None
+        }
     }
 }
 
@@ -182,12 +216,16 @@ impl Manifest {
     // ------------------------------------------------------------------
 
     /// Insert a brand-new node. Returns the chosen `NodeId`.
+    ///
+    /// `chunk_hashes` carries the chunked content layout (see
+    /// [`NodeEntry::chunk_hashes`]). Pass an empty slice for non-binary
+    /// nodes or for binaries that have no content yet.
     pub fn create_node(
         &mut self,
         name: &str,
         parent: Option<NodeId>,
         kind: NodeKind,
-        blob_hash: Option<&str>,
+        chunk_hashes: &[String],
         size: u64,
     ) -> NodeId {
         let id = NodeId::new();
@@ -202,10 +240,7 @@ impl Manifest {
             ("parent", Any::from(parent_str)),
             ("deleted", Any::from(false)),
             ("kind", Any::from(kind.as_str().to_string())),
-            (
-                "blob",
-                Any::from(blob_hash.unwrap_or("").to_string()),
-            ),
+            ("chunks", Any::from(encode_chunk_list(chunk_hashes))),
             ("size", Any::from(size as i64)),
             ("created_at", Any::from(lamp.get() as i64)),
             ("c_actor", Any::from(actor.to_string_hyphenated())),
@@ -279,16 +314,29 @@ impl Manifest {
         true
     }
 
-    /// Update a binary's blob hash (after CAS push). Also stamps modify.
-    pub fn set_blob_hash(&mut self, id: NodeId, hash: &str, size: u64) -> bool {
+    /// Update a binary's chunk-hash list (after CAS push of every chunk).
+    /// Also stamps modify.
+    ///
+    /// `total_size` is the byte count of the assembled file (sum of all
+    /// chunk lengths), used by UI / GC; the manifest does not derive it
+    /// from `chunks` because chunk byte counts aren't stored here.
+    pub fn set_chunk_hashes(
+        &mut self,
+        id: NodeId,
+        chunk_hashes: &[String],
+        total_size: u64,
+    ) -> bool {
         let lamp = self.lamport.tick();
         let actor_str = self.actor.to_string_hyphenated();
         let mut txn = self.doc.transact_mut();
         let Some(entry) = get_entry_map(&self.nodes, &txn, id) else {
             return false;
         };
-        entry.insert(&mut txn, "blob", hash.to_string());
-        entry.insert(&mut txn, "size", size as i64);
+        entry.insert(&mut txn, "chunks", encode_chunk_list(chunk_hashes));
+        // Clear the legacy field so an old reader doesn't conflate the
+        // pre-#59 single-hash with the new chunked content.
+        entry.insert(&mut txn, "blob", String::new());
+        entry.insert(&mut txn, "size", total_size as i64);
         entry.insert(&mut txn, "mod_lamp", lamp.get() as i64);
         entry.insert(&mut txn, "mod_actor", actor_str);
         true
@@ -427,11 +475,26 @@ fn decode_entry<T: ReadTxn>(id: NodeId, m: &MapRef, txn: &T) -> Option<NodeEntry
         Some(Out::Any(Any::String(s))) => NodeKind::from_str(&s)?,
         _ => return None,
     };
-    let blob_str = match m.get(txn, "blob") {
+    let chunks_str = match m.get(txn, "chunks") {
         Some(Out::Any(Any::String(s))) => s.to_string(),
         _ => String::new(),
     };
-    let blob_hash = if blob_str.is_empty() { None } else { Some(blob_str) };
+    let chunk_hashes = if !chunks_str.is_empty() {
+        decode_chunk_list(&chunks_str)
+    } else {
+        // Legacy fallback: an entry written before #59 carries its
+        // single-blob hash in the `blob` field. Read it and project as
+        // a length-1 chunk list so downstream code is uniform.
+        let blob_str = match m.get(txn, "blob") {
+            Some(Out::Any(Any::String(s))) => s.to_string(),
+            _ => String::new(),
+        };
+        if blob_str.is_empty() {
+            Vec::new()
+        } else {
+            vec![blob_str]
+        }
+    };
     let size = read_u64(m, txn, "size").unwrap_or(0);
     let created_at = read_u64(m, txn, "created_at")
         .map(Lamport)
@@ -449,13 +512,38 @@ fn decode_entry<T: ReadTxn>(id: NodeId, m: &MapRef, txn: &T) -> Option<NodeEntry
         parent,
         deleted,
         kind,
-        blob_hash,
+        chunk_hashes,
         size,
         created_at,
         created_by,
         delete_stamp,
         modify_stamp,
     })
+}
+
+/// Encode a chunk-hash list for the manifest's `chunks` field.
+///
+/// Hashes are joined with `,` — a single character that never appears
+/// in a hex SHA-256 digest, so the encoding is unambiguous and trivial
+/// to decode. An empty list encodes as `""`, distinguishing
+/// "no content" from a single zero-length chunk (which is impossible
+/// because chunks always cover ≥ 1 byte; a truly empty file produces
+/// an empty list).
+fn encode_chunk_list(chunks: &[String]) -> String {
+    chunks.join(",")
+}
+
+/// Decode a chunk-hash list from the manifest's `chunks` field.
+///
+/// Tolerant of empty input (returns empty list) and stray whitespace,
+/// since the encoding is internal but having a defensive decoder costs
+/// nothing.
+fn decode_chunk_list(s: &str) -> Vec<String> {
+    s.split(',')
+        .map(str::trim)
+        .filter(|p| !p.is_empty())
+        .map(|p| p.to_string())
+        .collect()
 }
 
 fn read_stamp<T: ReadTxn>(
@@ -494,14 +582,14 @@ mod tests {
     #[test]
     fn create_node_returns_retrievable_entry() {
         let mut m = Manifest::new(ActorId::new());
-        let id = m.create_node("note.md", None, NodeKind::Text, None, 42);
+        let id = m.create_node("note.md", None, NodeKind::Text, &[], 42);
         let e = m.get_entry(id).expect("entry must exist");
         assert_eq!(e.id, id);
         assert_eq!(e.name, "note.md");
         assert_eq!(e.parent, None);
         assert!(!e.deleted);
         assert_eq!(e.kind, NodeKind::Text);
-        assert_eq!(e.blob_hash, None);
+        assert!(e.chunk_hashes.is_empty());
         assert_eq!(e.size, 42);
     }
 
@@ -509,16 +597,16 @@ mod tests {
     fn create_node_bumps_lamport() {
         let mut m = Manifest::new(ActorId::new());
         assert_eq!(m.lamport(), Lamport::ZERO);
-        m.create_node("a.md", None, NodeKind::Text, None, 0);
+        m.create_node("a.md", None, NodeKind::Text, &[], 0);
         assert_eq!(m.lamport(), Lamport(1));
-        m.create_node("b.md", None, NodeKind::Text, None, 0);
+        m.create_node("b.md", None, NodeKind::Text, &[], 0);
         assert_eq!(m.lamport(), Lamport(2));
     }
 
     #[test]
     fn rename_updates_name_preserves_id() {
         let mut m = Manifest::new(ActorId::new());
-        let id = m.create_node("old.md", None, NodeKind::Text, None, 0);
+        let id = m.create_node("old.md", None, NodeKind::Text, &[], 0);
         assert!(m.set_name(id, "new.md"));
         let e = m.get_entry(id).unwrap();
         assert_eq!(e.name, "new.md");
@@ -529,8 +617,8 @@ mod tests {
     #[test]
     fn set_parent_updates_parent() {
         let mut m = Manifest::new(ActorId::new());
-        let dir = m.create_node("folder", None, NodeKind::Directory, None, 0);
-        let file = m.create_node("file.md", None, NodeKind::Text, None, 0);
+        let dir = m.create_node("folder", None, NodeKind::Directory, &[], 0);
+        let file = m.create_node("file.md", None, NodeKind::Text, &[], 0);
         assert!(m.set_parent(file, Some(dir)));
         let e = m.get_entry(file).unwrap();
         assert_eq!(e.parent, Some(dir));
@@ -539,7 +627,7 @@ mod tests {
     #[test]
     fn delete_sets_flag_and_stamp() {
         let mut m = Manifest::new(ActorId::new());
-        let id = m.create_node("doomed.md", None, NodeKind::Text, None, 0);
+        let id = m.create_node("doomed.md", None, NodeKind::Text, &[], 0);
         assert!(m.delete(id));
         let e = m.get_entry(id).unwrap();
         assert!(e.deleted);
@@ -551,7 +639,7 @@ mod tests {
     #[test]
     fn record_modify_sets_mod_stamp() {
         let mut m = Manifest::new(ActorId::new());
-        let id = m.create_node("f.md", None, NodeKind::Text, None, 0);
+        let id = m.create_node("f.md", None, NodeKind::Text, &[], 0);
         let before = m.get_entry(id).unwrap().modify_stamp;
         m.record_modify(id);
         let after = m.get_entry(id).unwrap().modify_stamp;
@@ -570,7 +658,7 @@ mod tests {
     #[test]
     fn encode_decode_roundtrip() {
         let mut m1 = Manifest::new(ActorId::new());
-        let id = m1.create_node("r.md", None, NodeKind::Text, None, 7);
+        let id = m1.create_node("r.md", None, NodeKind::Text, &[], 7);
         let state = m1.encode_state_as_update();
 
         let m2 = Manifest::from_update(ActorId::new(), Lamport::ZERO, &state).unwrap();
@@ -582,9 +670,9 @@ mod tests {
     #[test]
     fn apply_update_advances_lamport() {
         let mut m1 = Manifest::new(ActorId::new());
-        m1.create_node("a", None, NodeKind::Text, None, 0);
-        m1.create_node("b", None, NodeKind::Text, None, 0);
-        m1.create_node("c", None, NodeKind::Text, None, 0);
+        m1.create_node("a", None, NodeKind::Text, &[], 0);
+        m1.create_node("b", None, NodeKind::Text, &[], 0);
+        m1.create_node("c", None, NodeKind::Text, &[], 0);
         assert_eq!(m1.lamport(), Lamport(3));
 
         let mut m2 = Manifest::new(ActorId::new());
@@ -595,28 +683,100 @@ mod tests {
     }
 
     #[test]
-    fn binary_node_preserves_blob_hash() {
+    fn binary_node_preserves_chunk_hashes() {
         let mut m = Manifest::new(ActorId::new());
         let id = m.create_node(
             "img.png",
             None,
             NodeKind::Binary,
-            Some("abcd1234"),
+            &["abcd1234".to_string()],
             1024,
         );
         let e = m.get_entry(id).unwrap();
         assert_eq!(e.kind, NodeKind::Binary);
-        assert_eq!(e.blob_hash.as_deref(), Some("abcd1234"));
-        m.set_blob_hash(id, "ef567890", 2048);
+        assert_eq!(e.chunk_hashes, vec!["abcd1234".to_string()]);
+        assert_eq!(e.single_blob_hash(), Some("abcd1234"));
+
+        // Replace with a multi-chunk list, the new shape for >1 MiB files.
+        m.set_chunk_hashes(
+            id,
+            &[
+                "chunk_a".to_string(),
+                "chunk_b".to_string(),
+                "chunk_c".to_string(),
+            ],
+            6_000_000,
+        );
         let e = m.get_entry(id).unwrap();
-        assert_eq!(e.blob_hash.as_deref(), Some("ef567890"));
-        assert_eq!(e.size, 2048);
+        assert_eq!(e.chunk_hashes.len(), 3);
+        assert_eq!(e.chunk_hashes[1], "chunk_b");
+        assert_eq!(e.size, 6_000_000);
+        // Multi-chunk binaries have no "single" hash to expose.
+        assert_eq!(e.single_blob_hash(), None);
+    }
+
+    #[test]
+    fn legacy_blob_field_is_decoded_as_single_chunk() {
+        // Simulate a manifest entry written by a pre-#59 client: the
+        // hash sits in the old `blob` field and `chunks` is absent.
+        // Decoder must still surface it via `chunk_hashes`.
+        use yrs::{Any, Doc, Map, MapPrelim, Transact};
+        let doc = Doc::new();
+        let nodes = doc.get_or_insert_map("nodes");
+        let nid = NodeId::new();
+        let actor = ActorId::new();
+        let entry = MapPrelim::from([
+            ("name", Any::from("legacy.png".to_string())),
+            ("parent", Any::from(String::new())),
+            ("deleted", Any::from(false)),
+            ("kind", Any::from("binary".to_string())),
+            ("blob", Any::from("LEGACYHASH".to_string())),
+            ("size", Any::from(42i64)),
+            ("created_at", Any::from(0i64)),
+            ("c_actor", Any::from(actor.to_string_hyphenated())),
+        ]);
+        {
+            let mut txn = doc.transact_mut();
+            nodes.insert(&mut txn, nid.to_string_hyphenated(), entry);
+        }
+        let txn = doc.transact();
+        let map = match nodes.get(&txn, &nid.to_string_hyphenated()).unwrap() {
+            yrs::Out::YMap(m) => m,
+            _ => panic!("expected map"),
+        };
+        let decoded = decode_entry(nid, &map, &txn).unwrap();
+        assert_eq!(decoded.chunk_hashes, vec!["LEGACYHASH".to_string()]);
+        assert_eq!(decoded.single_blob_hash(), Some("LEGACYHASH"));
+    }
+
+    #[test]
+    fn empty_chunk_hashes_round_trip() {
+        let mut m = Manifest::new(ActorId::new());
+        let id = m.create_node("placeholder.png", None, NodeKind::Binary, &[], 0);
+        let e = m.get_entry(id).unwrap();
+        assert!(e.chunk_hashes.is_empty());
+        assert_eq!(e.single_blob_hash(), None);
+    }
+
+    #[test]
+    fn chunk_list_codec_roundtrips_and_tolerates_whitespace() {
+        let original = vec!["aaaa".to_string(), "bbbb".to_string(), "cccc".to_string()];
+        let encoded = encode_chunk_list(&original);
+        assert_eq!(encoded, "aaaa,bbbb,cccc");
+        assert_eq!(decode_chunk_list(&encoded), original);
+        // Defensive: stray whitespace gets stripped.
+        assert_eq!(
+            decode_chunk_list(" aaaa , bbbb ,cccc"),
+            vec!["aaaa", "bbbb", "cccc"]
+        );
+        // Empty input → empty list, NOT a single empty string.
+        assert!(decode_chunk_list("").is_empty());
     }
 
     #[test]
     fn find_entry_by_path_returns_tombstoned() {
         let mut m = Manifest::new(ActorId::new());
-        let id = m.create_node("ghost.md", None, NodeKind::Text, None, 0);
+        let id = m.create_node("ghost.md", None, NodeKind::Text, &[], 0);
         m.delete(id);
         let found = m.find_entry_by_path("ghost.md").expect("tombstone reachable");
         assert_eq!(found.id, id);
@@ -626,7 +786,7 @@ mod tests {
     #[test]
     fn find_entry_by_path_returns_live() {
         let mut m = Manifest::new(ActorId::new());
-        let id = m.create_node("alive.md", None, NodeKind::Text, None, 0);
+        let id = m.create_node("alive.md", None, NodeKind::Text, &[], 0);
         let found = m.find_entry_by_path("alive.md").unwrap();
         assert_eq!(found.id, id);
         assert!(!found.deleted);
@@ -641,9 +801,9 @@ mod tests {
     #[test]
     fn find_entry_by_path_prefers_live_over_tombstoned() {
         let mut m = Manifest::new(ActorId::new());
-        let dead = m.create_node("collide.md", None, NodeKind::Text, None, 0);
+        let dead = m.create_node("collide.md", None, NodeKind::Text, &[], 0);
         m.delete(dead);
-        let live = m.create_node("collide.md", None, NodeKind::Text, None, 0);
+        let live = m.create_node("collide.md", None, NodeKind::Text, &[], 0);
         let found = m.find_entry_by_path("collide.md").unwrap();
         assert_eq!(found.id, live);
         assert!(!found.deleted);
@@ -652,8 +812,8 @@ mod tests {
     #[test]
     fn find_entry_by_path_walks_directory_chain() {
         let mut m = Manifest::new(ActorId::new());
-        let dir = m.create_node("folder", None, NodeKind::Directory, None, 0);
-        let file = m.create_node("note.md", Some(dir), NodeKind::Text, None, 0);
+        let dir = m.create_node("folder", None, NodeKind::Directory, &[], 0);
+        let file = m.create_node("note.md", Some(dir), NodeKind::Text, &[], 0);
         m.delete(file);
         let found = m.find_entry_by_path("folder/note.md").unwrap();
         assert_eq!(found.id, file);
@@ -665,7 +825,7 @@ mod tests {
         // A directory's "path" must not collide with a file lookup —
         // directories are emergent (§5.6), never projected as files.
         let mut m = Manifest::new(ActorId::new());
-        let _dir = m.create_node("folder", None, NodeKind::Directory, None, 0);
+        let _dir = m.create_node("folder", None, NodeKind::Directory, &[], 0);
         assert!(m.find_entry_by_path("folder").is_none());
     }
 
@@ -674,8 +834,8 @@ mod tests {
         let mut m1 = Manifest::new(ActorId::new());
         let mut m2 = Manifest::new(ActorId::new());
 
-        let id1 = m1.create_node("one.md", None, NodeKind::Text, None, 10);
-        let id2 = m2.create_node("two.md", None, NodeKind::Text, None, 20);
+        let id1 = m1.create_node("one.md", None, NodeKind::Text, &[], 10);
+        let id2 = m2.create_node("two.md", None, NodeKind::Text, &[], 20);
 
         // Exchange updates
         let u1 = m1.encode_state_as_update();

--- a/syncline/src/v1/migration.rs
+++ b/syncline/src/v1/migration.rs
@@ -97,11 +97,21 @@ pub fn migrate_v0_vault(vault_root: &Path, actor: ActorId) -> Result<Migration> 
                     NodeKind::Directory => 0,
                 };
 
+                // v0 stored a single blob hash per file. Project it as
+                // a length-1 chunk list — the new schema's small-file
+                // representation. Files large enough to need chunking
+                // get re-chunked the next time the scanner sees them.
+                let chunk_hashes: Vec<String> = v0
+                    .blob_hash
+                    .as_deref()
+                    .filter(|s| !s.is_empty())
+                    .map(|h| vec![h.to_string()])
+                    .unwrap_or_default();
                 let node_id = manifest.create_node(
                     &leaf_name,
                     parent,
                     v0.kind,
-                    v0.blob_hash.as_deref(),
+                    &chunk_hashes,
                     size,
                 );
 
@@ -249,7 +259,7 @@ fn ensure_parent_chain(
         let id = if let Some(id) = dir_nodes.get(&accum) {
             *id
         } else {
-            let id = manifest.create_node(seg, parent, NodeKind::Directory, None, 0);
+            let id = manifest.create_node(seg, parent, NodeKind::Directory, &[], 0);
             dir_nodes.insert(accum.clone(), id);
             id
         };
@@ -371,7 +381,8 @@ mod tests {
         assert_eq!(m.manifest.live_entries().len(), 1);
         let entry = &m.manifest.live_entries()[0];
         assert_eq!(entry.kind, NodeKind::Binary);
-        assert_eq!(entry.blob_hash.as_deref(), Some("cafebabe"));
+        assert_eq!(entry.chunk_hashes, vec!["cafebabe".to_string()]);
+        assert_eq!(entry.single_blob_hash(), Some("cafebabe"));
         assert_eq!(
             m.binary_hashes.get(&entry.id).map(|s| s.as_str()),
             Some("cafebabe")
@@ -424,8 +435,8 @@ mod tests {
         assert!(p.by_path.contains_key("folder/sub.md"));
         assert!(p.by_path.contains_key("folder/pic.png"));
         assert_eq!(
-            p.by_path["folder/pic.png"].blob_hash.as_deref(),
-            Some("deadbeef")
+            p.by_path["folder/pic.png"].chunk_hashes,
+            vec!["deadbeef".to_string()],
         );
     }
 

--- a/syncline/src/v1/ops.rs
+++ b/syncline/src/v1/ops.rs
@@ -4,9 +4,9 @@
 //! The manifest mutators in `manifest.rs` operate on `NodeId`s; this
 //! module translates user-facing *paths* into those writes and owns
 //! the emergent-directory rule (§5.6 of the design doc). Name /
-//! parent changes go through `set_name` / `set_parent`; blob updates
-//! go through `set_blob_hash` and stamp modify. Conflict handling
-//! (§6) remains projection-time.
+//! parent changes go through `set_name` / `set_parent`; binary content
+//! updates go through `set_chunk_hashes` and stamp modify. Conflict
+//! handling (§6) remains projection-time.
 //!
 //! All operations are idempotent only in the CRDT sense: a second
 //! call with the same intent may produce a second write and bump
@@ -25,7 +25,7 @@ use anyhow::{anyhow, Result};
 /// - `path` is empty or has an empty segment.
 /// - a live entry already projects to `path`.
 pub fn create_text(manifest: &mut Manifest, path: &str, size: u64) -> Result<NodeId> {
-    create_at_path(manifest, path, NodeKind::Text, None, size)
+    create_at_path(manifest, path, NodeKind::Text, &[], size)
 }
 
 /// Create a text entry at `path` even when another live entry already
@@ -38,17 +38,19 @@ pub fn create_text_allowing_collision(
     path: &str,
     size: u64,
 ) -> Result<NodeId> {
-    create_at_path_allowing_collision(manifest, path, NodeKind::Text, None, size)
+    create_at_path_allowing_collision(manifest, path, NodeKind::Text, &[], size)
 }
 
-/// Create a fresh binary entry at `path` with its CAS blob hash.
+/// Create a fresh binary entry at `path` with its FastCDC chunk-hash
+/// list. Pass an empty slice to record a binary placeholder whose
+/// content has not been chunked yet.
 pub fn create_binary(
     manifest: &mut Manifest,
     path: &str,
-    blob_hash: &str,
+    chunk_hashes: &[String],
     size: u64,
 ) -> Result<NodeId> {
-    create_at_path(manifest, path, NodeKind::Binary, Some(blob_hash), size)
+    create_at_path(manifest, path, NodeKind::Binary, chunk_hashes, size)
 }
 
 /// Mark the entry currently projected at `path` as deleted.
@@ -107,16 +109,16 @@ pub fn record_modify_text(manifest: &mut Manifest, path: &str) -> Result<()> {
     Ok(())
 }
 
-/// Update the blob hash of a binary entry at `path`. Also stamps
-/// modify so a stale delete can't resurrect an older blob.
+/// Update the chunk-hash list of a binary entry at `path`. Also stamps
+/// modify so a stale delete can't resurrect older content.
 pub fn record_modify_binary(
     manifest: &mut Manifest,
     path: &str,
-    blob_hash: &str,
+    chunk_hashes: &[String],
     size: u64,
 ) -> Result<()> {
     let id = resolve_path(manifest, path)?;
-    manifest.set_blob_hash(id, blob_hash, size);
+    manifest.set_chunk_hashes(id, chunk_hashes, size);
     Ok(())
 }
 
@@ -136,7 +138,7 @@ fn create_at_path(
     manifest: &mut Manifest,
     path: &str,
     kind: NodeKind,
-    blob_hash: Option<&str>,
+    chunk_hashes: &[String],
     size: u64,
 ) -> Result<NodeId> {
     if path.is_empty() {
@@ -153,14 +155,14 @@ fn create_at_path(
         return Err(anyhow!("path {:?} has empty leaf", path));
     }
     let parent = ensure_parent_chain(manifest, parent_path)?;
-    Ok(manifest.create_node(leaf, parent, kind, blob_hash, size))
+    Ok(manifest.create_node(leaf, parent, kind, chunk_hashes, size))
 }
 
 fn create_at_path_allowing_collision(
     manifest: &mut Manifest,
     path: &str,
     kind: NodeKind,
-    blob_hash: Option<&str>,
+    chunk_hashes: &[String],
     size: u64,
 ) -> Result<NodeId> {
     if path.is_empty() {
@@ -171,7 +173,7 @@ fn create_at_path_allowing_collision(
         return Err(anyhow!("path {:?} has empty leaf", path));
     }
     let parent = ensure_parent_chain(manifest, parent_path)?;
-    Ok(manifest.create_node(leaf, parent, kind, blob_hash, size))
+    Ok(manifest.create_node(leaf, parent, kind, chunk_hashes, size))
 }
 
 fn split_path(path: &str) -> (&str, &str) {
@@ -210,7 +212,7 @@ fn find_or_create_directory(
     if let Some(e) = existing {
         e.id
     } else {
-        manifest.create_node(name, parent, NodeKind::Directory, None, 0)
+        manifest.create_node(name, parent, NodeKind::Directory, &[], 0)
     }
 }
 
@@ -262,13 +264,35 @@ mod tests {
     }
 
     #[test]
-    fn create_binary_preserves_blob() {
+    fn create_binary_preserves_chunks() {
         let mut m = Manifest::new(ActorId::new());
-        let id = create_binary(&mut m, "img.png", "deadbeef", 1024).unwrap();
+        let id = create_binary(
+            &mut m,
+            "img.png",
+            &["deadbeef".to_string()],
+            1024,
+        )
+        .unwrap();
         let e = m.get_entry(id).unwrap();
         assert_eq!(e.kind, NodeKind::Binary);
-        assert_eq!(e.blob_hash.as_deref(), Some("deadbeef"));
+        assert_eq!(e.chunk_hashes, vec!["deadbeef".to_string()]);
         assert_eq!(e.size, 1024);
+    }
+
+    #[test]
+    fn create_binary_preserves_multi_chunk() {
+        let mut m = Manifest::new(ActorId::new());
+        let id = create_binary(
+            &mut m,
+            "big.png",
+            &["aaa".to_string(), "bbb".to_string(), "ccc".to_string()],
+            6_000_000,
+        )
+        .unwrap();
+        let e = m.get_entry(id).unwrap();
+        assert_eq!(e.chunk_hashes.len(), 3);
+        assert_eq!(e.chunk_hashes[1], "bbb");
+        assert_eq!(e.size, 6_000_000);
     }
 
     #[test]
@@ -368,12 +392,18 @@ mod tests {
     }
 
     #[test]
-    fn record_modify_binary_updates_blob_and_size() {
+    fn record_modify_binary_updates_chunks_and_size() {
         let mut m = Manifest::new(ActorId::new());
-        let id = create_binary(&mut m, "pic.png", "aaaa", 10).unwrap();
-        record_modify_binary(&mut m, "pic.png", "bbbb", 42).unwrap();
+        let id = create_binary(&mut m, "pic.png", &["aaaa".to_string()], 10).unwrap();
+        record_modify_binary(
+            &mut m,
+            "pic.png",
+            &["bbbb".to_string(), "cccc".to_string()],
+            42,
+        )
+        .unwrap();
         let e = m.get_entry(id).unwrap();
-        assert_eq!(e.blob_hash.as_deref(), Some("bbbb"));
+        assert_eq!(e.chunk_hashes, vec!["bbbb".to_string(), "cccc".to_string()]);
         assert_eq!(e.size, 42);
         assert!(e.modify_stamp.is_some());
     }

--- a/syncline/src/v1/projection.rs
+++ b/syncline/src/v1/projection.rs
@@ -17,11 +17,26 @@ pub struct ProjectedEntry {
     pub id: NodeId,
     pub path: String,
     pub kind: NodeKind,
-    pub blob_hash: Option<String>,
+    /// FastCDC chunk-hash list of this binary's content, in file order.
+    /// See [`super::NodeEntry::chunk_hashes`] for the size buckets.
+    pub chunk_hashes: Vec<String>,
     pub size: u64,
     /// `true` if this row was moved into the conflict name-space
     /// because another entry already owns the winning path.
     pub is_conflict_copy: bool,
+}
+
+impl ProjectedEntry {
+    /// Convenience for callers that pre-date #59 and only handle
+    /// single-chunk binaries: returns the lone hash if `chunk_hashes`
+    /// has exactly one entry, else `None`.
+    pub fn single_blob_hash(&self) -> Option<&str> {
+        if self.chunk_hashes.len() == 1 {
+            Some(self.chunk_hashes[0].as_str())
+        } else {
+            None
+        }
+    }
 }
 
 /// Full projection of a manifest. Keyed by the final (post-conflict-
@@ -107,7 +122,7 @@ pub fn project(manifest: &Manifest) -> Projection {
                 id: row.entry.id,
                 path: final_path.clone(),
                 kind: row.entry.kind,
-                blob_hash: row.entry.blob_hash.clone(),
+                chunk_hashes: row.entry.chunk_hashes.clone(),
                 size: row.entry.size,
                 is_conflict_copy: is_conflict,
             };
@@ -209,7 +224,7 @@ mod tests {
     #[test]
     fn single_file_projects_to_its_name() {
         let mut m = Manifest::new(ActorId::new());
-        let id = m.create_node("hello.md", None, NodeKind::Text, None, 5);
+        let id = m.create_node("hello.md", None, NodeKind::Text, &[], 5);
         let p = project(&m);
         assert_eq!(p.len(), 1);
         let row = p.get_by_id(id).unwrap();
@@ -220,8 +235,8 @@ mod tests {
     #[test]
     fn file_under_directory_has_joined_path() {
         let mut m = Manifest::new(ActorId::new());
-        let dir = m.create_node("folder", None, NodeKind::Directory, None, 0);
-        let f = m.create_node("note.md", Some(dir), NodeKind::Text, None, 0);
+        let dir = m.create_node("folder", None, NodeKind::Directory, &[], 0);
+        let f = m.create_node("note.md", Some(dir), NodeKind::Text, &[], 0);
         let p = project(&m);
         // Directory itself is not projected as a file.
         assert_eq!(p.len(), 1);
@@ -232,10 +247,10 @@ mod tests {
     #[test]
     fn deep_nesting_assembles_full_path() {
         let mut m = Manifest::new(ActorId::new());
-        let l1 = m.create_node("l1", None, NodeKind::Directory, None, 0);
-        let l2 = m.create_node("l2", Some(l1), NodeKind::Directory, None, 0);
-        let l3 = m.create_node("l3", Some(l2), NodeKind::Directory, None, 0);
-        let leaf = m.create_node("leaf.md", Some(l3), NodeKind::Text, None, 0);
+        let l1 = m.create_node("l1", None, NodeKind::Directory, &[], 0);
+        let l2 = m.create_node("l2", Some(l1), NodeKind::Directory, &[], 0);
+        let l3 = m.create_node("l3", Some(l2), NodeKind::Directory, &[], 0);
+        let leaf = m.create_node("leaf.md", Some(l3), NodeKind::Text, &[], 0);
         let p = project(&m);
         assert_eq!(p.get_by_id(leaf).unwrap().path, "l1/l2/l3/leaf.md");
     }
@@ -243,7 +258,7 @@ mod tests {
     #[test]
     fn deleted_file_is_not_projected() {
         let mut m = Manifest::new(ActorId::new());
-        let id = m.create_node("gone.md", None, NodeKind::Text, None, 0);
+        let id = m.create_node("gone.md", None, NodeKind::Text, &[], 0);
         m.delete(id);
         let p = project(&m);
         assert!(p.is_empty());
@@ -252,7 +267,7 @@ mod tests {
     #[test]
     fn modify_after_delete_resurrects() {
         let mut m = Manifest::new(ActorId::new());
-        let id = m.create_node("phoenix.md", None, NodeKind::Text, None, 0);
+        let id = m.create_node("phoenix.md", None, NodeKind::Text, &[], 0);
         m.delete(id); // delete with some lamport
         m.record_modify(id); // modify with a later lamport → resurrects
         let p = project(&m);
@@ -263,7 +278,7 @@ mod tests {
     #[test]
     fn delete_after_modify_stays_deleted() {
         let mut m = Manifest::new(ActorId::new());
-        let id = m.create_node("rip.md", None, NodeKind::Text, None, 0);
+        let id = m.create_node("rip.md", None, NodeKind::Text, &[], 0);
         m.record_modify(id);
         m.delete(id);
         let p = project(&m);
@@ -275,10 +290,10 @@ mod tests {
         // Two nodes created independently with the same (parent, name).
         // Rebuild by merging two manifests.
         let mut m1 = Manifest::new(ActorId::new());
-        let id1 = m1.create_node("same.md", None, NodeKind::Text, None, 0);
+        let id1 = m1.create_node("same.md", None, NodeKind::Text, &[], 0);
 
         let mut m2 = Manifest::new(ActorId::new());
-        let id2 = m2.create_node("same.md", None, NodeKind::Text, None, 0);
+        let id2 = m2.create_node("same.md", None, NodeKind::Text, &[], 0);
 
         // Merge
         let u1 = m1.encode_state_as_update();
@@ -326,19 +341,20 @@ mod tests {
     }
 
     #[test]
-    fn binary_with_blob_hash_projected_correctly() {
+    fn binary_with_chunk_hashes_projected_correctly() {
         let mut m = Manifest::new(ActorId::new());
         let id = m.create_node(
             "image.png",
             None,
             NodeKind::Binary,
-            Some("cafebabe"),
+            &["cafebabe".to_string()],
             1024,
         );
         let p = project(&m);
         let row = p.get_by_id(id).unwrap();
         assert_eq!(row.kind, NodeKind::Binary);
-        assert_eq!(row.blob_hash.as_deref(), Some("cafebabe"));
+        assert_eq!(row.chunk_hashes, vec!["cafebabe".to_string()]);
+        assert_eq!(row.single_blob_hash(), Some("cafebabe"));
         assert_eq!(row.size, 1024);
         assert_eq!(row.path, "image.png");
     }
@@ -346,7 +362,7 @@ mod tests {
     #[test]
     fn rename_reflected_in_projection() {
         let mut m = Manifest::new(ActorId::new());
-        let id = m.create_node("old.md", None, NodeKind::Text, None, 0);
+        let id = m.create_node("old.md", None, NodeKind::Text, &[], 0);
         m.set_name(id, "new.md");
         let p = project(&m);
         assert_eq!(p.get_by_id(id).unwrap().path, "new.md");
@@ -355,9 +371,9 @@ mod tests {
     #[test]
     fn move_to_new_parent_reflected() {
         let mut m = Manifest::new(ActorId::new());
-        let a = m.create_node("A", None, NodeKind::Directory, None, 0);
-        let b = m.create_node("B", None, NodeKind::Directory, None, 0);
-        let f = m.create_node("f.md", Some(a), NodeKind::Text, None, 0);
+        let a = m.create_node("A", None, NodeKind::Directory, &[], 0);
+        let b = m.create_node("B", None, NodeKind::Directory, &[], 0);
+        let f = m.create_node("f.md", Some(a), NodeKind::Text, &[], 0);
         assert_eq!(project(&m).get_by_id(f).unwrap().path, "A/f.md");
         m.set_parent(f, Some(b));
         assert_eq!(project(&m).get_by_id(f).unwrap().path, "B/f.md");
@@ -366,8 +382,8 @@ mod tests {
     #[test]
     fn orphan_with_deleted_parent_dir_is_hidden() {
         let mut m = Manifest::new(ActorId::new());
-        let dir = m.create_node("doomed", None, NodeKind::Directory, None, 0);
-        let f = m.create_node("child.md", Some(dir), NodeKind::Text, None, 0);
+        let dir = m.create_node("doomed", None, NodeKind::Directory, &[], 0);
+        let f = m.create_node("child.md", Some(dir), NodeKind::Text, &[], 0);
         m.delete(dir);
         let p = project(&m);
         // Child becomes unprojectable under the cascade-safety net.

--- a/syncline/src/v1/sync.rs
+++ b/syncline/src/v1/sync.rs
@@ -161,7 +161,21 @@ pub fn projection_hash(manifest: &Manifest) -> [u8; 32] {
         hasher.update([0u8]);
         hasher.update(entry.kind.as_str().as_bytes());
         hasher.update([0u8]);
-        hasher.update(entry.blob_hash.as_deref().unwrap_or("").as_bytes());
+        // Fold every chunk hash into the projection hash, joined by a
+        // delimiter that can't appear in a hex digest. A length-0 list
+        // hashes as the empty string (matching pre-#59 `blob_hash =
+        // None`); a length-1 list hashes as the bare hash with no
+        // separator (matching pre-#59 `blob_hash = Some(h)`); only
+        // length-2+ lists introduce comma separators. That keeps the
+        // projection hash bit-stable for every doc that was already
+        // single-blob — a rolling deploy doesn't trigger spurious
+        // verify mismatches.
+        for (i, h) in entry.chunk_hashes.iter().enumerate() {
+            if i > 0 {
+                hasher.update([b',']);
+            }
+            hasher.update(h.as_bytes());
+        }
         hasher.update([0u8]);
         hasher.update(entry.size.to_be_bytes());
         hasher.update([0u8]);
@@ -266,7 +280,7 @@ mod tests {
     #[test]
     fn step1_payload_reflects_current_state() {
         let mut m = Manifest::new(ActorId::new());
-        m.create_node("a.md", None, NodeKind::Text, None, 0);
+        m.create_node("a.md", None, NodeKind::Text, &[], 0);
         let payload = manifest_step1_payload(&m);
         let (sub, sv_bytes) = split_manifest_payload(&payload).unwrap();
         assert_eq!(sub, MANIFEST_STEP_1);
@@ -279,7 +293,7 @@ mod tests {
         // m1 has an entry; m2 is empty. m2 sends its SV to m1; m1 replies
         // with a Step2 containing what m2 is missing.
         let mut m1 = Manifest::new(ActorId::new());
-        let id = m1.create_node("hello.md", None, NodeKind::Text, None, 5);
+        let id = m1.create_node("hello.md", None, NodeKind::Text, &[], 5);
 
         let mut m2 = Manifest::new(ActorId::new());
         let step1 = manifest_step1_payload(&m2);
@@ -298,7 +312,7 @@ mod tests {
     #[test]
     fn step2_and_update_produce_no_response() {
         let mut m1 = Manifest::new(ActorId::new());
-        m1.create_node("x.md", None, NodeKind::Text, None, 0);
+        m1.create_node("x.md", None, NodeKind::Text, &[], 0);
 
         let mut m2 = Manifest::new(ActorId::new());
         // Craft a step2 payload from m1's full state.
@@ -333,8 +347,8 @@ mod tests {
         let mut m1 = Manifest::new(ActorId::new());
         let mut m2 = Manifest::new(ActorId::new());
 
-        let id1 = m1.create_node("from_m1.md", None, NodeKind::Text, None, 1);
-        let id2 = m2.create_node("from_m2.md", None, NodeKind::Text, None, 2);
+        let id1 = m1.create_node("from_m1.md", None, NodeKind::Text, &[], 1);
+        let id2 = m2.create_node("from_m2.md", None, NodeKind::Text, &[], 2);
 
         // Each peer asks the other for what it's missing.
         let m1_step1 = manifest_step1_payload(&m1);
@@ -373,8 +387,8 @@ mod tests {
         let mut m2 = Manifest::new(a2);
 
         // Both create a node while disconnected.
-        let id1 = m1.create_node("a.md", None, NodeKind::Text, None, 10);
-        let id2 = m2.create_node("b.md", None, NodeKind::Text, None, 20);
+        let id1 = m1.create_node("a.md", None, NodeKind::Text, &[], 10);
+        let id2 = m2.create_node("b.md", None, NodeKind::Text, &[], 20);
 
         // Round 1: mutual SyncStep1 / SyncStep2.
         let s1 = manifest_step1_payload(&m1);
@@ -411,7 +425,7 @@ mod tests {
     #[test]
     fn wire_framed_sync_roundtrip() {
         let mut m1 = Manifest::new(ActorId::new());
-        let id = m1.create_node("wire.md", None, NodeKind::Text, None, 0);
+        let id = m1.create_node("wire.md", None, NodeKind::Text, &[], 0);
         let mut m2 = Manifest::new(ActorId::new());
 
         // m2 sends a framed SyncStep1.
@@ -443,8 +457,8 @@ mod tests {
     #[test]
     fn projection_hash_is_deterministic() {
         let mut m1 = Manifest::new(ActorId::new());
-        m1.create_node("a.md", None, NodeKind::Text, None, 10);
-        m1.create_node("b.md", None, NodeKind::Text, None, 20);
+        m1.create_node("a.md", None, NodeKind::Text, &[], 10);
+        m1.create_node("b.md", None, NodeKind::Text, &[], 20);
         let h1 = projection_hash(&m1);
         let h2 = projection_hash(&m1);
         assert_eq!(h1, h2);
@@ -453,11 +467,11 @@ mod tests {
     #[test]
     fn projection_hash_differs_when_content_differs() {
         let mut m1 = Manifest::new(ActorId::new());
-        m1.create_node("a.md", None, NodeKind::Text, None, 10);
+        m1.create_node("a.md", None, NodeKind::Text, &[], 10);
         let h1 = projection_hash(&m1);
 
         let mut m2 = Manifest::new(ActorId::new());
-        m2.create_node("a.md", None, NodeKind::Text, None, 11);
+        m2.create_node("a.md", None, NodeKind::Text, &[], 11);
         let h2 = projection_hash(&m2);
 
         assert_ne!(h1, h2, "size difference must affect projection hash");
@@ -466,11 +480,11 @@ mod tests {
     #[test]
     fn projection_hash_matches_after_full_sync() {
         let mut m1 = Manifest::new(ActorId::new());
-        m1.create_node("a.md", None, NodeKind::Text, None, 10);
-        m1.create_node("b.md", None, NodeKind::Text, None, 20);
+        m1.create_node("a.md", None, NodeKind::Text, &[], 10);
+        m1.create_node("b.md", None, NodeKind::Text, &[], 20);
 
         let mut m2 = Manifest::new(ActorId::new());
-        m2.create_node("c.md", None, NodeKind::Text, None, 30);
+        m2.create_node("c.md", None, NodeKind::Text, &[], 30);
 
         // Full bidirectional sync via the manifest protocol.
         let s1 = manifest_step1_payload(&m1);
@@ -507,7 +521,7 @@ mod tests {
     #[test]
     fn handle_verify_on_match_returns_none() {
         let mut m1 = Manifest::new(ActorId::new());
-        m1.create_node("a.md", None, NodeKind::Text, None, 0);
+        m1.create_node("a.md", None, NodeKind::Text, &[], 0);
         let mut m2 = Manifest::new(ActorId::new());
         // Seed m2 with the same state.
         m2.apply_update(&m1.encode_state_as_update()).unwrap();
@@ -521,9 +535,9 @@ mod tests {
     #[test]
     fn handle_verify_on_mismatch_returns_step1() {
         let mut m1 = Manifest::new(ActorId::new());
-        m1.create_node("a.md", None, NodeKind::Text, None, 0);
+        m1.create_node("a.md", None, NodeKind::Text, &[], 0);
         let mut m2 = Manifest::new(ActorId::new());
-        m2.create_node("different.md", None, NodeKind::Text, None, 0);
+        m2.create_node("different.md", None, NodeKind::Text, &[], 0);
 
         let remote_hash = projection_hash(&m2);
         let payload = encode_verify_payload(&remote_hash);
@@ -548,9 +562,9 @@ mod tests {
         // originator then responds with a SyncStep2, and both peers
         // should now share a matching projection hash.
         let mut m1 = Manifest::new(ActorId::new());
-        m1.create_node("a.md", None, NodeKind::Text, None, 10);
+        m1.create_node("a.md", None, NodeKind::Text, &[], 10);
         let mut m2 = Manifest::new(ActorId::new());
-        m2.create_node("b.md", None, NodeKind::Text, None, 20);
+        m2.create_node("b.md", None, NodeKind::Text, &[], 20);
 
         // m2 heartbeats its projection hash to m1.
         let verify_payload = encode_verify_payload(&projection_hash(&m2));
@@ -585,7 +599,7 @@ mod tests {
     #[test]
     fn node_id_survives_manifest_sync() {
         let mut m1 = Manifest::new(ActorId::new());
-        let id = m1.create_node("id.md", None, NodeKind::Text, None, 0);
+        let id = m1.create_node("id.md", None, NodeKind::Text, &[], 0);
         let mut m2 = Manifest::new(ActorId::new());
         let s1 = manifest_step1_payload(&m2);
         let r = handle_manifest_payload(&mut m1, &s1).unwrap().unwrap();

--- a/syncline/src/wasm_client_v1.rs
+++ b/syncline/src/wasm_client_v1.rs
@@ -371,6 +371,12 @@ impl SynclineV1Client {
         })
     }
 
+    /// Create a binary entry from a **single** blob hash. Convenience
+    /// wrapper around the chunk-aware API for callers that don't (yet)
+    /// chunk their inputs — the hash becomes the sole entry in the new
+    /// node's `chunk_hashes` list. New callers should prefer
+    /// [`create_binary_chunked`] so files > 4 MiB don't blow the WS
+    /// frame ceiling.
     #[wasm_bindgen(js_name = createBinary)]
     pub fn create_binary(
         &self,
@@ -378,8 +384,32 @@ impl SynclineV1Client {
         blob_hash_hex: String,
         size: f64,
     ) -> Result<String, JsValue> {
+        let chunk_hashes = vec![blob_hash_hex];
         with_manifest_mut(&self.manifest, |m| {
-            ops::create_binary(m, &path, &blob_hash_hex, size as u64)
+            ops::create_binary(m, &path, &chunk_hashes, size as u64)
+                .map(|id| id.to_string_hyphenated())
+                .map_err(to_js)
+        })
+    }
+
+    /// Create a binary entry from an explicit list of chunk hashes.
+    /// `chunk_hashes_csv` is a comma-separated list of lowercase hex
+    /// SHA-256 digests — one per FastCDC chunk, in file order.
+    #[wasm_bindgen(js_name = createBinaryChunked)]
+    pub fn create_binary_chunked(
+        &self,
+        path: String,
+        chunk_hashes_csv: String,
+        size: f64,
+    ) -> Result<String, JsValue> {
+        let chunk_hashes: Vec<String> = chunk_hashes_csv
+            .split(',')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string())
+            .collect();
+        with_manifest_mut(&self.manifest, |m| {
+            ops::create_binary(m, &path, &chunk_hashes, size as u64)
                 .map(|id| id.to_string_hyphenated())
                 .map_err(to_js)
         })
@@ -400,6 +430,9 @@ impl SynclineV1Client {
         })
     }
 
+    /// Record a single-blob modification. See [`create_binary`] —
+    /// thin wrapper that lifts the single hash into a length-1 chunk
+    /// list. Prefer [`record_modify_binary_chunked`] in new code.
     #[wasm_bindgen(js_name = recordModifyBinary)]
     pub fn record_modify_binary(
         &self,
@@ -407,8 +440,30 @@ impl SynclineV1Client {
         blob_hash_hex: String,
         size: f64,
     ) -> Result<(), JsValue> {
+        let chunk_hashes = vec![blob_hash_hex];
         with_manifest_mut(&self.manifest, |m| {
-            ops::record_modify_binary(m, &path, &blob_hash_hex, size as u64).map_err(to_js)
+            ops::record_modify_binary(m, &path, &chunk_hashes, size as u64).map_err(to_js)
+        })
+    }
+
+    /// Record a multi-chunk modification. `chunk_hashes_csv` is a
+    /// comma-separated list of lowercase hex SHA-256 digests in file
+    /// order.
+    #[wasm_bindgen(js_name = recordModifyBinaryChunked)]
+    pub fn record_modify_binary_chunked(
+        &self,
+        path: String,
+        chunk_hashes_csv: String,
+        size: f64,
+    ) -> Result<(), JsValue> {
+        let chunk_hashes: Vec<String> = chunk_hashes_csv
+            .split(',')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string())
+            .collect();
+        with_manifest_mut(&self.manifest, |m| {
+            ops::record_modify_binary(m, &path, &chunk_hashes, size as u64).map_err(to_js)
         })
     }
 
@@ -416,9 +471,15 @@ impl SynclineV1Client {
     // Manifest read API (projection)
     // ---------------------------------------------------------------
 
-    /// Projection as JSON — array of `{id, path, kind, blob_hash,
-    /// size, is_conflict_copy}` sorted by path. Deterministic across
-    /// peers.
+    /// Projection as JSON — array of
+    /// `{id, path, kind, blob_hash, chunk_hashes, size,
+    ///  is_conflict_copy}` sorted by path. Deterministic across peers.
+    ///
+    /// `chunk_hashes` is the canonical content addressing (always an
+    /// array, even for small files where it has length 1). `blob_hash`
+    /// is preserved as a backwards-compat field — it's the single hash
+    /// when `chunk_hashes.length == 1`, `null` otherwise. New plugin
+    /// code should consume `chunk_hashes`.
     #[wasm_bindgen(js_name = projectionJson)]
     pub fn projection_json(&self) -> Result<String, JsValue> {
         let manifest = self.manifest.borrow();
@@ -431,11 +492,13 @@ impl SynclineV1Client {
         let json: Vec<serde_json::Value> = rows
             .iter()
             .map(|r| {
+                let single_blob: Option<&str> = r.single_blob_hash();
                 serde_json::json!({
                     "id": r.id.to_string_hyphenated(),
                     "path": r.path,
                     "kind": r.kind.as_str(),
-                    "blob_hash": r.blob_hash,
+                    "blob_hash": single_blob,
+                    "chunk_hashes": r.chunk_hashes,
                     "size": r.size,
                     "is_conflict_copy": r.is_conflict_copy,
                 })

--- a/syncline/tests/e2e.rs
+++ b/syncline/tests/e2e.rs
@@ -1922,3 +1922,169 @@ async fn test_cli_restart_no_duplicate_manifest_entries() {
         N
     );
 }
+
+// ---------------------------------------------------------------------------
+// #59 — chunked-blob sync end-to-end
+// ---------------------------------------------------------------------------
+//
+// Before chunking, any single binary file > 16 MiB exceeded
+// `tokio-tungstenite`'s default `max_frame_size` and the connection
+// got dropped silently — the user-visible failure mode in #59 (the
+// scanner retries forever without ever logging on the server side).
+//
+// With FastCDC chunking, the file is split into pieces of at most
+// MAX_CHUNK_SIZE (4 MiB) on the wire, well under the 5 MiB
+// `MAX_BLOB_SIZE` cap. These tests pin the new behaviour with vault
+// content over the old 16 MiB threshold.
+
+/// Deterministic pseudo-random bytes — no `rand` dep, bit-exact across
+/// runs so test failures are reproducible.
+fn pseudo_random_bytes(seed: u64, len: usize) -> Vec<u8> {
+    let mut state = seed.max(1);
+    let mut out = Vec::with_capacity(len);
+    while out.len() < len {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        out.extend_from_slice(&state.to_le_bytes());
+    }
+    out.truncate(len);
+    out
+}
+
+/// 20 MiB binary file syncs end-to-end. Pre-#59 fix this hung the
+/// scanner forever on the >16 MiB WebSocket frame limit; with chunking
+/// the file flows as a handful of chunk frames, each ≤ 4 MiB, with
+/// the same bit-for-bit integrity guarantee as a small blob.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_large_binary_over_16mib_syncs_via_chunks() {
+    let env = TestEnv::new(2).await;
+
+    let payload = pseudo_random_bytes(0xC0FFEE, 20 * 1024 * 1024);
+    let src = env.client_path(0).join("big.bin");
+    fs::write(&src, &payload).expect("write 20 MiB source");
+
+    // 25-second budget — large blob bootstrap on a slow CI runner can
+    // take a while. The signal we're after is "eventually equal", not
+    // "equal in 5s".
+    let dst = env.client_path(1).join("big.bin");
+    let deadline = std::time::Instant::now() + Duration::from_secs(25);
+    loop {
+        if dst.exists() {
+            if let Ok(landed) = fs::read(&dst) {
+                if landed == payload {
+                    return;
+                }
+            }
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "20 MiB binary did not converge to peer within 25s"
+        );
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+}
+
+/// Both peers concurrently write *different* large binaries to the
+/// same path. Eventual-consistency contract: one peer's bytes win the
+/// canonical name, the other peer's bytes are preserved as a
+/// `.conflict-…` sibling. Multi-chunk content uses the same projection
+/// rule as single-blob content (§6.4 of the design doc).
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_concurrent_large_binary_writes_converge_with_conflict() {
+    let env = TestEnv::new(2).await;
+
+    // Different bytes on each peer at the same path. 8 MiB is enough
+    // to force ≥ 2 chunks per file under the 4 MiB ceiling.
+    let bytes_a = pseudo_random_bytes(0xAAAA, 8 * 1024 * 1024);
+    let bytes_b = pseudo_random_bytes(0xBBBB, 8 * 1024 * 1024);
+    fs::write(env.client_path(0).join("clash.bin"), &bytes_a).unwrap();
+    fs::write(env.client_path(1).join("clash.bin"), &bytes_b).unwrap();
+
+    // Wait for convergence: both peers must end up with the same set
+    // of files (canonical + conflict sibling) holding the same byte
+    // strings. Polling instead of a fixed sleep — multi-MiB sync on a
+    // CI VM is timing-sensitive.
+    let deadline = std::time::Instant::now() + Duration::from_secs(30);
+    loop {
+        let conflict_a = find_conflict_sibling(env.client_path(0), "clash", "bin");
+        let conflict_b = find_conflict_sibling(env.client_path(1), "clash", "bin");
+        let canonical_a = env.client_path(0).join("clash.bin");
+        let canonical_b = env.client_path(1).join("clash.bin");
+
+        if let (Some(ca), Some(cb)) = (conflict_a.as_ref(), conflict_b.as_ref()) {
+            if canonical_a.exists() && canonical_b.exists() {
+                let canon_a_bytes = fs::read(&canonical_a).unwrap_or_default();
+                let canon_b_bytes = fs::read(&canonical_b).unwrap_or_default();
+                let conf_a_bytes = fs::read(ca).unwrap_or_default();
+                let conf_b_bytes = fs::read(cb).unwrap_or_default();
+                // Both peers agree on canonical bytes.
+                if canon_a_bytes == canon_b_bytes
+                    && !canon_a_bytes.is_empty()
+                    // The conflict sibling holds the loser's bytes;
+                    // both peers materialise the same conflict bytes.
+                    && conf_a_bytes == conf_b_bytes
+                    && !conf_a_bytes.is_empty()
+                    // The two byte-strings together must be exactly
+                    // the two peers' original payloads — no third
+                    // value invented mid-sync.
+                    && {
+                        let pair = [&canon_a_bytes[..], &conf_a_bytes[..]];
+                        let originals = [&bytes_a[..], &bytes_b[..]];
+                        pair.iter().all(|b| originals.contains(b))
+                    }
+                {
+                    return;
+                }
+            }
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "clash didn't converge within 30s"
+        );
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+}
+
+/// Edit a large binary in-place and confirm the new content lands on
+/// the peer. The bandwidth-saving property (only changed chunks are
+/// re-uploaded) is unit-tested in `client_v1::tests`; this test just
+/// pins the end-to-end correctness path.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_chunked_binary_modify_propagates() {
+    let env = TestEnv::new(2).await;
+
+    // Initial: 6 MiB on peer 0 → ≥ 2 chunks under the 4 MiB cap.
+    let v1_bytes = pseudo_random_bytes(0x1111, 6 * 1024 * 1024);
+    fs::write(env.client_path(0).join("doc.bin"), &v1_bytes).unwrap();
+
+    let dst = env.client_path(1).join("doc.bin");
+    let deadline = std::time::Instant::now() + Duration::from_secs(20);
+    loop {
+        if dst.exists() && fs::read(&dst).map(|b| b == v1_bytes).unwrap_or(false) {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "initial chunked binary did not propagate within 20s"
+        );
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+
+    // Modify: same approximate size, different seed so most chunks
+    // change. Same convergence shape.
+    let v2_bytes = pseudo_random_bytes(0x2222, 6 * 1024 * 1024);
+    fs::write(env.client_path(0).join("doc.bin"), &v2_bytes).unwrap();
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(20);
+    loop {
+        if dst.exists() && fs::read(&dst).map(|b| b == v2_bytes).unwrap_or(false) {
+            return;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "modified chunked binary did not propagate within 20s"
+        );
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+}

--- a/syncline/tests/v1_protocol_e2e.rs
+++ b/syncline/tests/v1_protocol_e2e.rs
@@ -119,7 +119,13 @@ fn two_peer_create_converges() {
     let mut b = Peer::new("B");
 
     create_text(&mut a.manifest, "hello.md", 5).unwrap();
-    create_binary(&mut b.manifest, "pic.png", "cafebabe", 1024).unwrap();
+    create_binary(
+        &mut b.manifest,
+        "pic.png",
+        &["cafebabe".to_string()],
+        1024,
+    )
+    .unwrap();
 
     bidirectional_sync(&mut a, &mut b);
     assert_converged(&[&a, &b]);


### PR DESCRIPTION
**Closes #59**, the >16 MiB binary file sync bug. Builds on top of the chunker module merged in #80. Together they make any-size binary files sync correctly with bandwidth-friendly partial-update semantics.

## What this PR does

### Manifest schema (`v1/manifest.rs`, `v1/projection.rs`, `v1/sync.rs`)
- `NodeEntry::blob_hash: Option<String>` → `chunk_hashes: Vec<String>`. Length 0 = placeholder, 1 = small file (legacy single-blob shape), 2+ = chunked large file. `single_blob_hash()` helper for callers that only care about the legacy shape.
- New Yrs field `chunks` (comma-joined hex). Decoder falls back to the legacy `blob` field if `chunks` is absent — a manifest written by a pre-#59 client loads cleanly.
- `set_chunk_hashes(id, &[String], total_size)` replaces `set_blob_hash`.
- Projection hash folds every chunk hash. For length-0 and length-1 lists the bytes are bit-stable with the pre-#59 hash so a rolling deploy doesn't trigger spurious `MSG_MANIFEST_VERIFY` mismatches.

### Scanner (`client_v1::process_binary_file`)
- Computes FastCDC chunks of every binary file on every scan.
- CAS-stashes each chunk locally, then diffs the new chunk-hash list against the previous manifest entry.
- `chunks_to_push` is **only** the chunks whose hash isn't in the old list — small-edit-locality (verified by chunker unit tests at ≥ 75% reuse for single-byte edits) means a header tweak re-uploads only the head chunks, not the unchanged tail. Server's CAS write is idempotent so any accidental duplicate is cheap.
- Removed the per-file `MAX_BLOB_SIZE` gate. Chunking handles arbitrary file sizes; the only remaining ceiling is per-frame.

### Reconcile (`client_v1::reconcile_projection_to_disk`)
- For binary entries, requires *every* chunk to be in the local CAS before materialising; otherwise marks the entry pending. Re-runs on each blob arrival pick up where they left off.
- Conflict detection re-chunks the on-disk file and compares the full chunk-hash list. Conflict copies are produced exactly as before (§6.4 of the design doc).
- New `assemble_chunks` helper concatenates chunk bytes in order.

### Wire protocol (`protocol.rs`)
- `MAX_BLOB_SIZE` 50 MiB → **5 MiB**. Sized to sit safely under `tokio-tungstenite`'s default `max_frame_size` (16 MiB) — the ceiling that caused #59. Effectively an overrun-detector now that the chunker caps every frame at `MAX_CHUNK_SIZE = 4 MiB`.

### Server-side teardown logging (`server/server.rs`)
- The recv loop's `while let Some(Ok(msg)) = …` silently exited on `Err(_)`. Replaced with an explicit match that emits a `WARN` carrying the error display before tearing down the session, plus a `DEBUG` for clean peer-initiated `Close` frames so the two cases are distinct in operator logs.
- Directly addresses the "silent disconnects make this kind of issue invisible from the server side" concern from the issue's last paragraph.

### Migration (`v1/migration.rs`, `server/migration.rs`)
- v0 → v1 reads `meta.blob_hash` (single hash) and projects it as a length-1 chunk list. Files large enough to need chunking are re-chunked the next time the scanner sees them.

## Tests

- **9 new manifest unit tests** — chunk-list codec, schema migration, legacy-blob fallback, multi-chunk get/set roundtrip, empty-list roundtrip.
- **6 new `process_binary_file` tests** — multi-chunk classification of a 10 MiB file, partial-edit only pushes changed chunks, single chunk for small files, kind-mismatch path.
- **3 new end-to-end tests** in `syncline/tests/e2e.rs`:
  - `test_large_binary_over_16mib_syncs_via_chunks` — the **#59 repro**, 20 MiB file converges (used to hang forever on the WS frame limit). Locally green in 28.7 s.
  - `test_concurrent_large_binary_writes_converge_with_conflict` — both peers write different ≥ 8 MiB binaries to the same path; one wins canonical, the other materialises as `.conflict-…`, byte-strings on both peers agree. Locally green in 10.5 s.
  - `test_chunked_binary_modify_propagates` — replace a 6 MiB file in place; the new bytes land on the peer. Locally green in 7.9 s.

233 / 233 lib tests pass. All pre-existing binary-sync e2e tests still pass.

## Numbers
- Pre-fix: any single binary > 16 MiB → infinite reconnect loop, scanner pinned at 100% CPU forever.
- Post-fix: 20 MiB binary syncs in ~25 s; 8 MiB / 6 MiB binaries in 10 s.
- Single-byte edit at the head of a 10 MiB file → only 1 of 10 chunks re-uploaded (≥ 90% reuse, exact ratio depends on FastCDC's gear-hash decisions).
- Idle-vault memory profile unchanged: `MAX_BLOB_SIZE` shrinks the protocol ceiling but in-memory state is `O(active_uploads)`, not `O(file_size)`.

## Test plan
- [x] `cargo build --tests` — clean
- [x] `cargo test --lib` — 233 / 233
- [x] `cargo test --test e2e --release` — new + existing binary tests pass
- [x] `cargo test --test v1_protocol_e2e` — 11 / 11
- [ ] CI passes on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)