### PR TITLE
feat: sidebar phase 5 — MSG_SERVER_STATS protocol + Server section

### DIFF
--- a/obsidian-plugin/main.ts
+++ b/obsidian-plugin/main.ts
@@ -129,7 +129,26 @@ interface SynclineV1Client {
   manifestNodeCount(): number;
   /** #65 phase 6 — `"unknown" | "pending" | "match" | "mismatch"`. */
   lastVerifyResult(): string;
+  /** #65 phase 5 — fires (jsonString) per server-stats reply. */
+  onServerStats(cb: (json: string) => void): void;
+  /** #65 phase 5 — sends an empty MSG_SERVER_STATS request. The reply
+   *  arrives via `onServerStats`. No-op if disconnected. */
+  requestServerStats(): void;
   free(): void;
+}
+
+/** Shape of the JSON the server returns in a `MSG_SERVER_STATS` reply
+ *  (#65 phase 5). All numeric fields are unsigned, but TypeScript only
+ *  has `number`, so values above 2^53 are theoretically lossy — in
+ *  practice none of these ever come close. */
+interface ServerStats {
+  server_version: string;
+  uptime_secs: number;
+  connected_clients: number;
+  manifest_node_count: number;
+  manifest_total_bytes: number;
+  blob_count: number;
+  blob_total_bytes: number;
 }
 
 async function initWasm(): Promise<WasmModule> {
@@ -244,6 +263,21 @@ function shortHash(h: string | null | undefined): string {
   return h.length > 12 ? `${h.slice(0, 8)}…${h.slice(-4)}` : h;
 }
 
+/** "X days HH:MM" / "HH:MM:SS" / "MM:SS" depending on magnitude. */
+function formatUptime(secs: number): string {
+  if (secs < 0) return "—";
+  const d = Math.floor(secs / 86400);
+  const h = Math.floor((secs % 86400) / 3600);
+  const m = Math.floor((secs % 3600) / 60);
+  const s = Math.floor(secs % 60);
+  if (d > 0) return `${d}d ${pad2(h)}:${pad2(m)}`;
+  if (h > 0) return `${pad2(h)}:${pad2(m)}:${pad2(s)}`;
+  return `${pad2(m)}:${pad2(s)}`;
+}
+function pad2(n: number): string {
+  return String(n).padStart(2, "0");
+}
+
 /** Format a "N seconds/minutes/hours ago" timestamp for the sidebar. */
 function formatRelativeTime(epochMs: number | null, nowMs: number): string {
   if (epochMs === null) return "never";
@@ -277,6 +311,14 @@ class SynclineSidebarView extends ItemView {
   private conflictRow!: HTMLElement;
   private conflictListEl!: HTMLElement;
   private vaultSizeEl!: HTMLElement;
+  // Server section (phase 5). Only populated once the first
+  // `MSG_SERVER_STATS` reply arrives — older servers that don't
+  // recognise the opcode never reply and the rows stay at "—".
+  private serverVersionEl!: HTMLElement;
+  private serverUptimeEl!: HTMLElement;
+  private serverPeersEl!: HTMLElement;
+  private serverDbBytesEl!: HTMLElement;
+  private serverManifestEl!: HTMLElement;
   // Activity feed (phase 4).
   private activitySection!: HTMLElement;
   private activityList!: HTMLElement;
@@ -376,6 +418,18 @@ class SynclineSidebarView extends ItemView {
       cls: "syncline-sidebar-conflict-list",
     });
     this.vaultSizeEl = appendKVRow(vaultSection, "Vault size");
+
+    // ---- Server section (phase 5). Populated by MSG_SERVER_STATS
+    //      replies — see SynclinePlugin.startServerStatsPolling.
+    const serverSection = root.createDiv({ cls: "syncline-sidebar-section" });
+    serverSection
+      .createDiv({ cls: "syncline-sidebar-section-title" })
+      .setText("Server");
+    this.serverVersionEl = appendKVRow(serverSection, "Version");
+    this.serverUptimeEl = appendKVRow(serverSection, "Uptime");
+    this.serverPeersEl = appendKVRow(serverSection, "Connected clients");
+    this.serverManifestEl = appendKVRow(serverSection, "Server-side files");
+    this.serverDbBytesEl = appendKVRow(serverSection, "Server blob storage");
 
     // ---- Activity feed (phase 4) ----
     this.activitySection = root.createDiv({ cls: "syncline-sidebar-section" });
@@ -487,6 +541,26 @@ class SynclineSidebarView extends ItemView {
       this.conflictListEl.empty();
     }
     this.vaultSizeEl.setText(formatBytes(totalBytes));
+
+    // ---- Server section (phase 5) ----
+    const stats = this.plugin.serverStats;
+    if (stats) {
+      this.serverVersionEl.setText(stats.server_version);
+      this.serverUptimeEl.setText(formatUptime(stats.uptime_secs));
+      this.serverPeersEl.setText(String(stats.connected_clients));
+      this.serverManifestEl.setText(
+        `${stats.manifest_node_count} (${formatBytes(stats.manifest_total_bytes)})`,
+      );
+      this.serverDbBytesEl.setText(
+        `${stats.blob_count} blobs, ${formatBytes(stats.blob_total_bytes)}`,
+      );
+    } else {
+      this.serverVersionEl.setText("—");
+      this.serverUptimeEl.setText("—");
+      this.serverPeersEl.setText("—");
+      this.serverManifestEl.setText("—");
+      this.serverDbBytesEl.setText("—");
+    }
 
     // ---- Activity feed (phase 4) ----
     this.activityList.empty();
@@ -605,6 +679,17 @@ export default class SynclinePlugin extends Plugin {
    */
   pendingBlobCount: number = 0;
   pendingBlobBytes: number = 0;
+
+  /**
+   * #65 phase 5 — most recent `MSG_SERVER_STATS` reply. `null` until
+   * the first server response (which can be never, if running against
+   * an older server that doesn't recognise the opcode — in that case
+   * the sidebar's Server section keeps showing "—"). Refreshed on a
+   * 30 s timer; see `serverStatsTimer`.
+   */
+  serverStats: ServerStats | null = null;
+  /** Timer id for the 30 s server-stats poll. Cleared on disconnect. */
+  serverStatsTimer: number | null = null;
 
   /**
    * #65 phase 4 — most recent {@link ACTIVITY_FEED_LIMIT} sync events.
@@ -1096,6 +1181,16 @@ export default class SynclinePlugin extends Plugin {
           console.warn("[Syncline] malformed sync event payload", json, err);
         }
       });
+      // #65 phase 5: subscribe to server-stats replies; the request
+      // is fired below once the WS is up and then on a 30 s timer.
+      this.client.onServerStats((json) => {
+        try {
+          this.serverStats = JSON.parse(json) as ServerStats;
+          this.refreshSidebar();
+        } catch (err) {
+          console.warn("[Syncline] malformed server stats payload", json, err);
+        }
+      });
 
       this.client.connect();
 
@@ -1138,6 +1233,7 @@ export default class SynclinePlugin extends Plugin {
       await this.reconcileProjection();
 
       this.startStatusCheck();
+      this.startServerStatsPolling();
     } catch (error) {
       console.error("[Syncline] Connection error:", error);
       this.updateStatus("error");
@@ -1158,6 +1254,7 @@ export default class SynclinePlugin extends Plugin {
 
   disconnect() {
     this.stopStatusCheck();
+    this.stopServerStatsPolling();
     if (this.reconnectTimeout !== null) {
       window.clearTimeout(this.reconnectTimeout);
       this.reconnectTimeout = null;
@@ -1173,7 +1270,37 @@ export default class SynclinePlugin extends Plugin {
     this.subscribedContent.clear();
     this.requestedBlobs.clear();
     this.reconcilePending = false;
+    this.serverStats = null;
     this.updateStatus("disconnected");
+  }
+
+  /**
+   * Poll `MSG_SERVER_STATS` once immediately and then every 30 s
+   * (#65 §4). 30 s is a deliberate compromise: the user-visible
+   * fields (uptime, connected_clients) drift slowly and the request
+   * payload is empty, so the bandwidth cost is trivial. A first
+   * request fires now so the sidebar's Server section populates
+   * within a couple of seconds of connect.
+   */
+  startServerStatsPolling() {
+    this.stopServerStatsPolling();
+    const fire = () => {
+      if (!this.client?.isConnected()) return;
+      try {
+        this.client.requestServerStats();
+      } catch (err) {
+        console.debug("[Syncline] requestServerStats failed:", err);
+      }
+    };
+    fire();
+    this.serverStatsTimer = window.setInterval(fire, 30_000);
+  }
+
+  stopServerStatsPolling() {
+    if (this.serverStatsTimer !== null) {
+      window.clearInterval(this.serverStatsTimer);
+      this.serverStatsTimer = null;
+    }
   }
 
   startStatusCheck() {

--- a/syncline/src/protocol.rs
+++ b/syncline/src/protocol.rs
@@ -25,6 +25,12 @@ pub const MSG_MANIFEST_SYNC: u8 = 0x20;
 /// v1: convergence heartbeat — SHA-256 over the projected namespace
 /// (§4.4.1). Mismatch triggers a full manifest SyncStep1.
 pub const MSG_MANIFEST_VERIFY: u8 = 0x21;
+/// v1: server-stats request/response (#65 §4). Client sends an empty
+/// payload (with [`MANIFEST_DOC_ID`] as the outer doc_id); server
+/// replies with the same opcode carrying a JSON document. Backwards
+/// compatible: a server that doesn't recognise the opcode silently
+/// ignores the frame, and the client renders "—" in the UI.
+pub const MSG_SERVER_STATS: u8 = 0x22;
 /// v1: protocol version handshake. Must be the first frame on a v1
 /// session. Payload is `[u8 major][u8 minor]`.
 pub const MSG_VERSION: u8 = 0xF0;

--- a/syncline/src/server/db.rs
+++ b/syncline/src/server/db.rs
@@ -183,6 +183,19 @@ impl Db {
                 .await?;
         Ok(row.0 > 0)
     }
+
+    /// Single SQL aggregate over the blobs table — `(count, total_bytes)`.
+    /// Used by the `MSG_SERVER_STATS` reply (#65 §4). The blobs table
+    /// has a `size` column populated on insert, so we sum that rather
+    /// than `LENGTH(data)` — saves SQLite from scanning blob pages on
+    /// large vaults.
+    pub async fn blob_summary(&self) -> Result<(u64, u64)> {
+        let row: (i64, i64) =
+            sqlx::query_as("SELECT COUNT(*), COALESCE(SUM(size), 0) FROM blobs")
+                .fetch_one(&self.pool)
+                .await?;
+        Ok((row.0.max(0) as u64, row.1.max(0) as u64))
+    }
 }
 
 #[cfg(test)]

--- a/syncline/src/server/server.rs
+++ b/syncline/src/server/server.rs
@@ -21,8 +21,8 @@
 
 use crate::protocol::{
     MANIFEST_DOC_ID, MSG_BLOB_REQUEST, MSG_BLOB_UPDATE, MSG_MANIFEST_SYNC,
-    MSG_MANIFEST_VERIFY, MSG_SYNC_STEP_1, MSG_SYNC_STEP_2, MSG_UPDATE, MSG_VERSION,
-    V1_PROTOCOL_MAJOR, V1_PROTOCOL_MINOR, decode_message, encode_message,
+    MSG_MANIFEST_VERIFY, MSG_SERVER_STATS, MSG_SYNC_STEP_1, MSG_SYNC_STEP_2, MSG_UPDATE,
+    MSG_VERSION, V1_PROTOCOL_MAJOR, V1_PROTOCOL_MINOR, decode_message, encode_message,
 };
 use crate::server::db::Db;
 use crate::server::migration::migrate_server_db;
@@ -65,6 +65,11 @@ struct AppState {
     /// applying an incoming MANIFEST_STEP_2/UPDATE; held only briefly
     /// for STEP_1 responses (state-vector read + update encoding).
     manifest: Arc<AsyncMutex<Manifest>>,
+    /// Wall-clock instant when this server process started. Used by
+    /// the `MSG_SERVER_STATS` handler (#65 phase 5) to report uptime
+    /// — no cross-restart accumulation, just "how long has this
+    /// process been up", which is the user-visible signal.
+    started_at: std::time::Instant,
 }
 
 pub async fn run_server(db: Db, port: u16) -> anyhow::Result<()> {
@@ -96,6 +101,7 @@ pub async fn run_server(db: Db, port: u16) -> anyhow::Result<()> {
         db,
         channels: Arc::new(RwLock::new(HashMap::new())),
         manifest: Arc::new(AsyncMutex::new(manifest)),
+        started_at: std::time::Instant::now(),
     };
 
     let app = Router::new()
@@ -254,6 +260,9 @@ async fn handle_socket(socket: WebSocket, state: AppState) {
                 MSG_MANIFEST_VERIFY if doc_id == MANIFEST_DOC_ID => {
                     handle_manifest_verify(&state_for_recv, &tx_out, payload).await;
                 }
+                MSG_SERVER_STATS if doc_id == MANIFEST_DOC_ID => {
+                    handle_server_stats(&state_for_recv, &tx_out).await;
+                }
                 MSG_SYNC_STEP_1 if doc_id.starts_with("content:") => {
                     handle_content_step1(
                         &state_for_recv,
@@ -392,6 +401,65 @@ async fn handle_manifest_verify(
             tracing::warn!("verify payload rejected: {}", e);
         }
     }
+}
+
+/// Build and reply with a `MSG_SERVER_STATS` JSON payload (#65 §4).
+///
+/// Backwards-compatible with old clients: they send no request, the
+/// server sends no unsolicited reply — the request/response shape
+/// is strictly client-initiated. New clients send an empty payload
+/// and consume the JSON.
+async fn handle_server_stats(
+    state: &AppState,
+    tx_out: &mpsc::UnboundedSender<Vec<u8>>,
+) {
+    // `connected_clients` is the per-vault MANIFEST broadcast channel's
+    // receiver count — i.e. how many WS connections currently subscribe
+    // to manifest updates. That's exactly the count the user cares
+    // about ("how many other clients have my vault open").
+    let connected_clients = {
+        let channels = state.channels.read().await;
+        channels
+            .get(MANIFEST_DOC_ID)
+            .map(|tx| tx.receiver_count())
+            .unwrap_or(0) as u32
+    };
+    // Manifest node count — live entries. Cheap; the manifest is
+    // already in memory.
+    let (manifest_node_count, manifest_total_size) = {
+        let manifest = state.manifest.lock().await;
+        let live = manifest.live_entries();
+        let total: u64 = live.iter().map(|e| e.size).sum();
+        (live.len() as u32, total)
+    };
+    // Blob counts — single SQL aggregate. Cheap on any reasonable
+    // vault because the blobs table tracks `size` as a separate
+    // column.
+    let (blob_count, blob_total_bytes) = state
+        .db
+        .blob_summary()
+        .await
+        .unwrap_or((0, 0));
+
+    let uptime_secs = state.started_at.elapsed().as_secs();
+    let payload = serde_json::json!({
+        "server_version": env!("CARGO_PKG_VERSION"),
+        "uptime_secs": uptime_secs,
+        "connected_clients": connected_clients,
+        "manifest_node_count": manifest_node_count,
+        "manifest_total_bytes": manifest_total_size,
+        "blob_count": blob_count,
+        "blob_total_bytes": blob_total_bytes,
+    });
+    let body = match serde_json::to_vec(&payload) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!("server_stats serialise: {}", e);
+            return;
+        }
+    };
+    let frame = encode_message(MSG_SERVER_STATS, MANIFEST_DOC_ID, &body);
+    let _ = tx_out.send(frame);
 }
 
 // ---------------------------------------------------------------------------
@@ -627,6 +695,7 @@ mod tests {
             db,
             channels: Arc::new(RwLock::new(HashMap::new())),
             manifest: Arc::new(AsyncMutex::new(Manifest::new(ActorId::new()))),
+            started_at: std::time::Instant::now(),
         };
         let app = Router::new()
             .route("/sync", get(ws_handler))

--- a/syncline/src/wasm_client_v1.rs
+++ b/syncline/src/wasm_client_v1.rs
@@ -28,8 +28,8 @@ use yrs::{Doc, GetString, ReadTxn, StateVector, Subscription, Text, Transact, Up
 
 use crate::protocol::{
     decode_message, encode_message, MANIFEST_DOC_ID, MSG_BLOB_REQUEST, MSG_BLOB_UPDATE,
-    MSG_MANIFEST_SYNC, MSG_MANIFEST_VERIFY, MSG_SYNC_STEP_1, MSG_SYNC_STEP_2, MSG_UPDATE,
-    MSG_VERSION,
+    MSG_MANIFEST_SYNC, MSG_MANIFEST_VERIFY, MSG_SERVER_STATS, MSG_SYNC_STEP_1, MSG_SYNC_STEP_2,
+    MSG_UPDATE, MSG_VERSION,
 };
 use crate::v1::hash::hash_hex;
 use crate::v1::ids::{ActorId, Lamport, NodeId};
@@ -110,6 +110,10 @@ pub struct SynclineV1Client {
     /// `{ kind, path?, hash?, bytes?, error? }`. The plugin keeps a
     /// small ring buffer of these for the activity feed.
     on_sync_event: Rc<RefCell<Option<Function>>>,
+    /// Fires when a `MSG_SERVER_STATS` reply arrives. Argument is the
+    /// JSON string the server sent. Plugin's sidebar `JSON.parse`s it
+    /// into `{ server_version, uptime_secs, connected_clients, … }`.
+    on_server_stats: Rc<RefCell<Option<Function>>>,
 }
 
 #[wasm_bindgen]
@@ -145,6 +149,7 @@ impl SynclineV1Client {
             on_status: Rc::new(RefCell::new(None)),
             on_blob_queue_change: Rc::new(RefCell::new(None)),
             on_sync_event: Rc::new(RefCell::new(None)),
+            on_server_stats: Rc::new(RefCell::new(None)),
         })
     }
 
@@ -275,6 +280,32 @@ impl SynclineV1Client {
     #[wasm_bindgen(js_name = onSyncEvent)]
     pub fn set_on_sync_event(&self, cb: Function) {
         *self.on_sync_event.borrow_mut() = Some(cb);
+    }
+
+    /// Subscribe to server-stats replies (#65 §4). Argument is the
+    /// raw JSON string. Plugin polls via [`request_server_stats`]
+    /// (e.g. every 30 s) and updates the sidebar's "Server" section
+    /// from each reply.
+    #[wasm_bindgen(js_name = onServerStats)]
+    pub fn set_on_server_stats(&self, cb: Function) {
+        *self.on_server_stats.borrow_mut() = Some(cb);
+    }
+
+    /// Send an empty `MSG_SERVER_STATS` request; the reply arrives via
+    /// the `onServerStats` callback. No-op if not connected — the
+    /// caller can retry on the next timer tick.
+    #[wasm_bindgen(js_name = requestServerStats)]
+    pub fn request_server_stats(&self) -> Result<(), JsValue> {
+        if !*self.is_connected.borrow() {
+            return Err(JsValue::from_str("request_server_stats: not connected"));
+        }
+        let ws = self.ws.borrow();
+        let ws = ws
+            .as_ref()
+            .ok_or_else(|| JsValue::from_str("request_server_stats: no socket"))?;
+        let frame = encode_message(MSG_SERVER_STATS, MANIFEST_DOC_ID, &[]);
+        send_frame(ws, &frame);
+        Ok(())
     }
 
     // ---------------------------------------------------------------
@@ -873,6 +904,7 @@ impl SynclineV1Client {
             on_blob: self.on_blob.clone(),
             on_blob_queue_change: self.on_blob_queue_change.clone(),
             on_sync_event: self.on_sync_event.clone(),
+            on_server_stats: self.on_server_stats.clone(),
         }
     }
 }
@@ -893,6 +925,7 @@ struct Handles {
     on_blob: Rc<RefCell<Option<Function>>>,
     on_blob_queue_change: Rc<RefCell<Option<Function>>>,
     on_sync_event: Rc<RefCell<Option<Function>>>,
+    on_server_stats: Rc<RefCell<Option<Function>>>,
 }
 
 impl Handles {
@@ -1116,6 +1149,24 @@ fn dispatch_frame(h: &Handles, ws: &WebSocket, data: &[u8]) {
                 "hash": expected,
                 "bytes": payload.len(),
             }));
+        }
+        MSG_SERVER_STATS => {
+            // Pass the JSON straight through — the plugin owns
+            // rendering. Old servers that don't recognise this opcode
+            // simply never reply, and the plugin's "—" placeholders
+            // stay in the UI.
+            if let Some(cb) = h.on_server_stats.borrow().clone() {
+                let s = match std::str::from_utf8(payload) {
+                    Ok(s) => s.to_string(),
+                    Err(_) => {
+                        web_sys::console::warn_1(&JsValue::from_str(
+                            "[SynclineV1] MSG_SERVER_STATS payload was not utf-8",
+                        ));
+                        return;
+                    }
+                };
+                let _ = cb.call1(&JsValue::NULL, &JsValue::from_str(&s));
+            }
         }
         _ => {
             web_sys::console::warn_1(&JsValue::from_str(&format!(


### PR DESCRIPTION
The last phase of #65. **Stacks on top of PR #84**, so review-merge order matters: #84 first, then this. Adds a new wire opcode the client uses to read server-side facts the local manifest can't derive — server version, uptime, connected clients, blob storage, manifest totals — and renders them in a "Server" section in the sidebar.

## Wire protocol

New opcode `MSG_SERVER_STATS = 0x22`. Client sends an empty payload (with `MANIFEST_DOC_ID` as the outer doc_id); server replies with the same opcode carrying a JSON document:

```json
{
  "server_version": "1.2.0",
  "uptime_secs": 12345,
  "connected_clients": 3,
  "manifest_node_count": 1024,
  "manifest_total_bytes": 8123456,
  "blob_count": 873,
  "blob_total_bytes": 234567890
}
```

**Backwards compatible.** A server too old to know the opcode silently ignores the frame; the client never gets a reply; the sidebar's Server rows stay at "—". Old clients never send the opcode. No protocol-version bump.

## Server

- `AppState.started_at: Instant` recorded at boot for uptime.
- New `handle_server_stats` reads everything from existing in-memory state plus a single SQL aggregate over the `blobs` table (new `Db::blob_summary` helper using the `size` column — no need to scan BLOB pages).
- `connected_clients` is the manifest broadcast channel's `receiver_count()` — exactly "how many other clients have my vault open".

## Client

- New `requestServerStats()` and `onServerStats(cb)` WASM bindings.
- Dispatcher forwards the JSON payload as a raw string for the plugin to `JSON.parse`.

## Plugin

- New "Server" sidebar section with rows: version, uptime, connected clients, server-side files (count + bytes), blob storage (count + bytes).
- `SynclinePlugin.serverStats` caches the most recent reply, cleared on disconnect.
- 30 s polling timer (`startServerStatsPolling`) — fires once on connect and then every 30 s. Bandwidth cost is trivial; user-visible fields drift slowly enough.
- `formatUptime` helper for "1d 04:23" / "01:23:45" / "12:34" output.

## Test plan
- [x] `cargo test --lib` — 233 / 233
- [x] `cargo build --target wasm32-unknown-unknown --lib` clean
- [x] `cargo build --lib` clean
- [x] `npm run lint` clean
- [x] `npm run build` clean
- [ ] CI passes
- [ ] Manual UX verification post-merge

Closes #65 (this and #84 land all six phases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)