### PR TITLE
fix(plugin): retry blob requests + prune ghosts left over by manifest churn

### DIFF
--- a/obsidian-plugin/main.ts
+++ b/obsidian-plugin/main.ts
@@ -122,6 +122,10 @@ interface SynclineV1Client {
   contentSnapshot(nodeIdHex: string): Uint8Array | undefined;
   sendBlob(bytes: Uint8Array): string;
   requestBlob(blobHashHex: string): void;
+  /** Re-issue any `MSG_BLOB_REQUEST` whose last send is older than
+   *  `staleAfterMs`. Returns the count of resent requests. Idempotent
+   *  and safe to call frequently. */
+  retryStaleBlobRequests(staleAfterMs: number): number;
   /** #65 phase 2 sidebar getters. */
   pendingBlobCount(): number;
   pendingBlobBytes(): number;
@@ -691,6 +695,9 @@ export default class SynclinePlugin extends Plugin {
   /** Timer id for the 30 s server-stats poll. Cleared on disconnect. */
   serverStatsTimer: number | null = null;
 
+  /** Timer id for the blob-request retry sweep. Cleared on disconnect. */
+  blobRetryTimer: number | null = null;
+
   /**
    * #65 phase 4 — most recent {@link ACTIVITY_FEED_LIMIT} sync events.
    * Newest first. Populated by `onSyncEvent` callbacks from the WASM
@@ -1234,6 +1241,7 @@ export default class SynclinePlugin extends Plugin {
 
       this.startStatusCheck();
       this.startServerStatsPolling();
+      this.startBlobRetrySweep();
     } catch (error) {
       console.error("[Syncline] Connection error:", error);
       this.updateStatus("error");
@@ -1255,6 +1263,7 @@ export default class SynclinePlugin extends Plugin {
   disconnect() {
     this.stopStatusCheck();
     this.stopServerStatsPolling();
+    this.stopBlobRetrySweep();
     if (this.reconnectTimeout !== null) {
       window.clearTimeout(this.reconnectTimeout);
       this.reconnectTimeout = null;
@@ -1294,6 +1303,43 @@ export default class SynclinePlugin extends Plugin {
     };
     fire();
     this.serverStatsTimer = window.setInterval(fire, 30_000);
+  }
+
+  /**
+   * Periodically re-issue any in-flight `MSG_BLOB_REQUEST` whose reply
+   * never arrived. Without this, a request frame dropped during a
+   * brief WS hiccup pinned the sidebar's "in flight" counter forever
+   * because the WASM client's request set is dedupe-only — it would
+   * never re-ask. Reproduced manually on a 1.2.0 vault stuck at
+   * "2 blobs · 7.2 MiB remaining".
+   *
+   * Sweep cadence (5 s) and stale threshold (15 s) chosen so a
+   * legitimately-slow large blob (~ 5 MiB at modest bandwidth) gets
+   * room to land before we retry, and so that retry traffic from a
+   * truly-lost request is bounded at one extra request every 15 s.
+   */
+  private static readonly BLOB_RETRY_SWEEP_MS = 5_000;
+  private static readonly BLOB_RETRY_STALE_AFTER_MS = 15_000;
+
+  startBlobRetrySweep() {
+    this.stopBlobRetrySweep();
+    this.blobRetryTimer = window.setInterval(() => {
+      if (!this.client?.isConnected()) return;
+      try {
+        this.client.retryStaleBlobRequests(
+          SynclinePlugin.BLOB_RETRY_STALE_AFTER_MS,
+        );
+      } catch (err) {
+        console.debug("[Syncline] retryStaleBlobRequests failed:", err);
+      }
+    }, SynclinePlugin.BLOB_RETRY_SWEEP_MS);
+  }
+
+  stopBlobRetrySweep() {
+    if (this.blobRetryTimer !== null) {
+      window.clearInterval(this.blobRetryTimer);
+      this.blobRetryTimer = null;
+    }
   }
 
   stopServerStatsPolling() {

--- a/syncline/src/blob_retry.rs
+++ b/syncline/src/blob_retry.rs
@@ -1,0 +1,146 @@
+//! Pure logic for the WASM client's blob-request retry sweep.
+//!
+//! `wasm_client_v1::SynclineV1Client::request_blob` records every
+//! `MSG_BLOB_REQUEST` it sends as `(hash → wall-clock-ms-of-send)` so a
+//! periodic sweep can re-issue any request whose reply never arrived.
+//! That sweep is gated to `wasm32` (it touches `js_sys::Date`,
+//! `web_sys::WebSocket`), but the *predicate* it uses is platform-pure
+//! — and gets exercised on every CI run by the unit tests below.
+//!
+//! Without this retry the WASM client's session-dedupe set silently
+//! pinned the sidebar's "in flight" counter forever whenever a request
+//! frame got dropped under WS backpressure. Reproduced in the wild on
+//! a 1.2.0 vault stuck at "2 blobs · 7.2 MiB remaining" — see #65 phase
+//! 2 progress UI.
+
+use std::collections::HashMap;
+
+/// Pick out hashes whose last-send timestamp is older than
+/// `stale_after_ms` relative to `now`. The filter uses `>=`, so a
+/// `stale_after_ms` of 0 reports every entry (operator-driven
+/// force-resync).
+pub(crate) fn collect_stale_blob_requests(
+    requests: &HashMap<String, f64>,
+    now: f64,
+    stale_after_ms: f64,
+) -> Vec<String> {
+    requests
+        .iter()
+        .filter(|&(_, &sent_at)| now - sent_at >= stale_after_ms)
+        .map(|(h, _)| h.clone())
+        .collect()
+}
+
+/// Pick out hashes that are still in the pending set but no longer
+/// referenced by any live manifest entry — "ghost requests" left over
+/// from a manifest update that swapped one set of chunk hashes for
+/// another. Without pruning, the retry sweep would re-ask the server
+/// for these forever and the server would keep replying "blob not
+/// found".
+///
+/// `live_chunk_hashes` is the union of `chunk_hashes` across every
+/// live binary entry currently in the projection.
+pub(crate) fn collect_ghost_blob_requests(
+    requests: &HashMap<String, f64>,
+    live_chunk_hashes: &std::collections::HashSet<&str>,
+) -> Vec<String> {
+    requests
+        .keys()
+        .filter(|h| !live_chunk_hashes.contains(h.as_str()))
+        .cloned()
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn picks_only_old_requests() {
+        let mut req: HashMap<String, f64> = HashMap::new();
+        // Wall-clock-style ms timestamps: imagine `now` is 100_000.
+        req.insert("hash_recent".into(), 99_000.0); // 1 s old
+        req.insert("hash_stale".into(), 80_000.0); // 20 s old
+        req.insert("hash_borderline".into(), 85_000.0); // exactly 15 s old
+
+        let now = 100_000.0;
+        let mut stale = collect_stale_blob_requests(&req, now, 15_000.0);
+        stale.sort();
+        assert_eq!(stale, vec!["hash_borderline", "hash_stale"]);
+    }
+
+    #[test]
+    fn returns_empty_when_no_requests_pending() {
+        let req: HashMap<String, f64> = HashMap::new();
+        assert!(collect_stale_blob_requests(&req, 1_000.0, 500.0).is_empty());
+    }
+
+    #[test]
+    fn returns_empty_when_threshold_not_yet_reached() {
+        let mut req: HashMap<String, f64> = HashMap::new();
+        req.insert("h1".into(), 10_000.0);
+        req.insert("h2".into(), 10_500.0);
+        // 1 s elapsed, threshold 5 s → nothing is stale.
+        assert!(collect_stale_blob_requests(&req, 11_000.0, 5_000.0).is_empty());
+    }
+
+    #[test]
+    fn zero_threshold_force_resyncs_everything() {
+        let mut req: HashMap<String, f64> = HashMap::new();
+        req.insert("h1".into(), 5_000.0);
+        req.insert("h2".into(), 5_001.0);
+        let mut all = collect_stale_blob_requests(&req, 5_001.0, 0.0);
+        all.sort();
+        assert_eq!(all, vec!["h1", "h2"]);
+    }
+
+    #[test]
+    fn ghost_collector_drops_hashes_not_in_live_set() {
+        use std::collections::HashSet;
+        let mut req: HashMap<String, f64> = HashMap::new();
+        req.insert("alive_a".into(), 1_000.0);
+        req.insert("alive_b".into(), 1_000.0);
+        req.insert("ghost".into(), 1_000.0); // no live entry references it
+
+        let alive_set: HashSet<&str> = ["alive_a", "alive_b", "alive_c"]
+            .into_iter()
+            .collect();
+        let ghosts = collect_ghost_blob_requests(&req, &alive_set);
+        assert_eq!(ghosts, vec!["ghost".to_string()]);
+    }
+
+    #[test]
+    fn ghost_collector_returns_empty_when_all_hashes_live() {
+        use std::collections::HashSet;
+        let mut req: HashMap<String, f64> = HashMap::new();
+        req.insert("a".into(), 1.0);
+        req.insert("b".into(), 2.0);
+        let alive: HashSet<&str> = ["a", "b", "c"].into_iter().collect();
+        assert!(collect_ghost_blob_requests(&req, &alive).is_empty());
+    }
+
+    #[test]
+    fn ghost_collector_handles_empty_live_set() {
+        let req: HashMap<String, f64> = HashMap::from_iter([
+            ("h1".to_string(), 1.0),
+            ("h2".to_string(), 2.0),
+        ]);
+        let alive = std::collections::HashSet::new();
+        let mut g = collect_ghost_blob_requests(&req, &alive);
+        g.sort();
+        assert_eq!(g, vec!["h1", "h2"]);
+    }
+
+    #[test]
+    fn newly_inserted_entry_is_not_stale_at_same_tick_with_positive_threshold() {
+        // Defends against the bug where the retry sweep would
+        // re-send a request we just enqueued in the same JS tick —
+        // `request_blob` writes `Date::now()` then the sweep reads
+        // `Date::now()`; without the strict `>=` boundary semantic
+        // they could converge and a forever-loop ensues.
+        let mut req: HashMap<String, f64> = HashMap::new();
+        req.insert("just_sent".into(), 1_000.0);
+        let stale = collect_stale_blob_requests(&req, 1_000.0, 1.0);
+        assert!(stale.is_empty());
+    }
+}

--- a/syncline/src/lib.rs
+++ b/syncline/src/lib.rs
@@ -1,6 +1,10 @@
 pub mod ignore;
 pub mod protocol;
 pub mod v1;
+/// WASM-client retry-sweep predicate. Lives at the crate root so the
+/// pure logic compiles + tests on every target, even though the only
+/// caller is wasm-gated `wasm_client_v1`.
+pub(crate) mod blob_retry;
 
 #[cfg(target_arch = "wasm32")]
 pub mod wasm_client;

--- a/syncline/src/wasm_client_v1.rs
+++ b/syncline/src/wasm_client_v1.rs
@@ -15,7 +15,7 @@
 //! without colliding on a monolithic borrow — this is the same pattern
 //! as `wasm_client.rs`.
 
-use js_sys::{Function, Uint8Array};
+use js_sys::{Date, Function, Uint8Array};
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
@@ -81,7 +81,7 @@ pub struct SynclineV1Client {
     ws: Rc<RefCell<Option<WebSocket>>>,
     is_connected: Rc<RefCell<bool>>,
     closures: Rc<RefCell<Vec<Closure<dyn FnMut(JsValue)>>>>,
-    requested_blobs: Rc<RefCell<HashSet<String>>>,
+    requested_blobs: Rc<RefCell<HashMap<String, f64>>>,
     /// Content node ids whose STEP_1 was deferred because the WebSocket
     /// hadn't completed its handshake yet. Drained on `onopen`. Without
     /// this, `subscribeContent` calls during the connect() → onopen
@@ -140,7 +140,7 @@ impl SynclineV1Client {
             ws: Rc::new(RefCell::new(None)),
             is_connected: Rc::new(RefCell::new(false)),
             closures: Rc::new(RefCell::new(Vec::new())),
-            requested_blobs: Rc::new(RefCell::new(HashSet::new())),
+            requested_blobs: Rc::new(RefCell::new(HashMap::new())),
             pending_step1: Rc::new(RefCell::new(HashSet::new())),
             last_verify_result: Rc::new(RefCell::new("unknown")),
             on_manifest_changed: Rc::new(RefCell::new(None)),
@@ -335,7 +335,7 @@ impl SynclineV1Client {
         }
         let mut total: u64 = 0;
         for entry in m.live_entries() {
-            if entry.chunk_hashes.iter().any(|h| pending.contains(h)) {
+            if entry.chunk_hashes.iter().any(|h| pending.contains_key(h)) {
                 total = total.saturating_add(entry.size);
             }
         }
@@ -869,14 +869,30 @@ impl SynclineV1Client {
 
     /// Request a blob by its hex hash. Deduplicates within a session.
     /// Reply arrives via the `onBlob` callback.
+    ///
+    /// Records the wall-clock instant of the send in `requested_blobs`
+    /// so [`retry_stale_blob_requests`] can re-issue requests whose
+    /// reply never arrived. Without that retry path, a `MSG_BLOB_REQUEST`
+    /// dropped during a brief WS hiccup pinned the sidebar's "in
+    /// flight" counter forever (manually reproduced on a 1.2.0 vault
+    /// with two large binary chunks).
     #[wasm_bindgen(js_name = requestBlob)]
     pub fn request_blob(&self, blob_hash_hex: String) -> Result<(), JsValue> {
         if !*self.is_connected.borrow() {
             return Err(JsValue::from_str("request_blob: not connected"));
         }
-        if !self.requested_blobs.borrow_mut().insert(blob_hash_hex.clone()) {
+        // Already-pending: no-op. Retries are the dedicated job of
+        // `retry_stale_blob_requests`.
+        if self
+            .requested_blobs
+            .borrow()
+            .contains_key(&blob_hash_hex)
+        {
             return Ok(());
         }
+        self.requested_blobs
+            .borrow_mut()
+            .insert(blob_hash_hex.clone(), Date::now());
         let ws = self.ws.borrow();
         let ws = ws
             .as_ref()
@@ -886,6 +902,94 @@ impl SynclineV1Client {
         // Newly-pending blob — the queue grew, sidebar wants to know.
         self.handles().emit_blob_queue_change();
         Ok(())
+    }
+
+    /// Re-issue any `MSG_BLOB_REQUEST` whose last send is older than
+    /// `stale_after_ms`. Returns the number of requests resent. The
+    /// predicate that picks stale requests lives in
+    /// [`collect_stale_blob_requests`] so it's unit-testable without
+    /// a live WebSocket.
+    ///
+    /// This is the missing companion to [`request_blob`]'s session-
+    /// dedupe set. A request frame can be dropped under WS
+    /// backpressure or lost during a reconnect window. Without this
+    /// retry, the dedupe set keeps the hash forever and the sidebar's
+    /// "in flight" counter never zeroes out.
+    ///
+    /// Idempotent and safe to call frequently — entries that aren't
+    /// stale are left alone; if the WebSocket isn't connected the
+    /// call short-circuits with `0`. Plugin-side caller drives this
+    /// on a small interval (e.g. every 5 s with a 15 s threshold).
+    #[wasm_bindgen(js_name = retryStaleBlobRequests)]
+    pub fn retry_stale_blob_requests(&self, stale_after_ms: f64) -> u32 {
+        if !*self.is_connected.borrow() {
+            return 0;
+        }
+        let now = Date::now();
+
+        // Step 1: prune ghost requests — pending hashes that no live
+        // manifest entry references any more (e.g. the entry's
+        // chunk_hashes changed under a manifest update). Without this
+        // we'd re-ask the server forever for blobs it will never
+        // have.
+        if let Some(m) = self.manifest.borrow().as_ref() {
+            // `live_entries()` returns owned `NodeEntry`s, so we have
+            // to hold the entry list ourselves to keep its
+            // `chunk_hashes` strings alive while we build the ref-set.
+            let entries = m.live_entries();
+            let live: std::collections::HashSet<&str> = entries
+                .iter()
+                .flat_map(|e| e.chunk_hashes.iter().map(|s| s.as_str()))
+                .collect();
+            let ghosts = crate::blob_retry::collect_ghost_blob_requests(
+                &self.requested_blobs.borrow(),
+                &live,
+            );
+            if !ghosts.is_empty() {
+                let mut map = self.requested_blobs.borrow_mut();
+                for h in &ghosts {
+                    map.remove(h);
+                }
+                drop(map);
+                web_sys::console::warn_1(&JsValue::from_str(&format!(
+                    "[SynclineV1] pruned {} ghost MSG_BLOB_REQUEST(s) — \
+                     hashes are no longer in any manifest entry",
+                    ghosts.len()
+                )));
+                self.handles().emit_blob_queue_change();
+            }
+        }
+
+        // Step 2: re-send anything past the stale threshold.
+        let stale = crate::blob_retry::collect_stale_blob_requests(
+            &self.requested_blobs.borrow(),
+            now,
+            stale_after_ms,
+        );
+        if stale.is_empty() {
+            return 0;
+        }
+        let ws = self.ws.borrow();
+        let Some(ws) = ws.as_ref() else {
+            return 0;
+        };
+        // Bump every stale timestamp first so a follow-up call
+        // before the reply can settle won't double-send.
+        {
+            let mut map = self.requested_blobs.borrow_mut();
+            for h in &stale {
+                map.insert(h.clone(), now);
+            }
+        }
+        for hash in &stale {
+            let frame = encode_message(MSG_BLOB_REQUEST, hash, hash.as_bytes());
+            send_frame(ws, &frame);
+        }
+        web_sys::console::warn_1(&JsValue::from_str(&format!(
+            "[SynclineV1] re-sent {} stale MSG_BLOB_REQUEST frame(s)",
+            stale.len()
+        )));
+        stale.len() as u32
     }
 
     // ---------------------------------------------------------------
@@ -918,7 +1022,7 @@ struct Handles {
     manifest: Rc<RefCell<Option<Manifest>>>,
     manifest_is_receiving: Rc<RefCell<bool>>,
     content: Rc<RefCell<HashMap<NodeId, ContentDoc>>>,
-    requested_blobs: Rc<RefCell<HashSet<String>>>,
+    requested_blobs: Rc<RefCell<HashMap<String, f64>>>,
     last_verify_result: Rc<RefCell<&'static str>>,
     on_manifest_changed: Rc<RefCell<Option<Function>>>,
     on_content_changed: Rc<RefCell<Option<Function>>>,
@@ -946,7 +1050,7 @@ impl Handles {
                 Some(m) if !pending.is_empty() => m
                     .live_entries()
                     .into_iter()
-                    .filter(|e| e.chunk_hashes.iter().any(|h| pending.contains(h)))
+                    .filter(|e| e.chunk_hashes.iter().any(|h| pending.contains_key(h)))
                     .map(|e| e.size)
                     .sum(),
                 _ => 0,
@@ -1116,7 +1220,7 @@ fn dispatch_frame(h: &Handles, ws: &WebSocket, data: &[u8]) {
                 )));
                 return;
             }
-            let was_pending = h.requested_blobs.borrow_mut().remove(&expected);
+            let was_pending = h.requested_blobs.borrow_mut().remove(&expected).is_some();
             let cb = h.on_blob.borrow().clone();
             if let Some(cb) = cb {
                 let js_hash = JsValue::from_str(&expected);
@@ -1230,3 +1334,4 @@ where
         .ok_or_else(|| JsValue::from_str("manifest not initialised"))?;
     f(m)
 }
+


### PR DESCRIPTION
**Stacks on PR #84.** Review-merge order: #84 first, then this. GitHub auto-rebases this PR's base to `main` once #84 lands.

## Two failure modes the WASM client's pending-blob set didn't handle

### 1. Lost-frame stuck queue
A `MSG_BLOB_REQUEST` dropped under WS backpressure pinned the sidebar's "in flight" counter forever, because the dedupe-only `requested_blobs` HashSet would never re-ask. Reproduced manually on a 1.2.0 vault stuck at "2 blobs · 7.2 MiB remaining".

### 2. Ghost requests after a manifest swap
When the chunked-blob feature in #59 landed, every binary file's manifest entry rewrote `chunk_hashes` from `[full_file_sha256]` to a list of FastCDC chunk hashes. Any in-flight `requested_blobs` entry pointing at the *old* full-file hash became unreachable: no live manifest entry references it, the server replies "blob not found" forever, and the sidebar pending counter never zeroes out.

Confirmed in production via the same stuck-counter symptom — server log:
```
WARN blob not found for c5739e14cb3e3f1094c7ec8e9490d98b632648cd9ba114fee01ddfc15f1b678c
```
That hash is the SHA-256 of a 7.5 MiB PDF that the pre-chunking 1.1.x sync uploaded as one blob. Once the 1.2.0 sync re-chunked the file, the manifest entry pointed to the new chunk hashes, but the plugin's existing pending request for the old hash had no escape hatch.

## The fix

`requested_blobs: HashSet<String>` → `HashMap<String, f64>` (hash → wall-clock-ms-of-last-send). New `retryStaleBlobRequests(staleAfterMs)` WASM method drives a two-step sweep:

1. **Prune ghosts.** Build the union of `chunk_hashes` across every live manifest entry; remove any pending hash not in that set. Warn-log + emit a queue-change event so the sidebar updates.
2. **Re-send stale.** Bump every stale entry's timestamp to `now` first (so a follow-up sweep before the reply lands won't double-send), then re-issue `MSG_BLOB_REQUEST`.

Sweep cadence (5 s) and stale threshold (15 s): legitimately-slow large blobs get room to land before retry, truly-lost requests stall the user-visible counter for at most one tick.

## Tests

Pure predicates `collect_stale_blob_requests` / `collect_ghost_blob_requests` live in a new non-wasm-gated `blob_retry` module so they run under `cargo test --lib` on every CI run (the WASM client is `cfg(target_arch = \"wasm32\")`-gated and the repo has no `wasm-bindgen-test` infrastructure).

**8 unit tests** cover:

| | |
|---|---|
| stale picker — happy path | mix of recent / stale / borderline-15 s entries |
| stale picker — empty pending-set | |
| stale picker — threshold not yet reached | |
| stale picker — `staleAfterMs == 0` force-resync | |
| stale picker — same-tick boundary | request just enqueued must NOT come back stale on the immediate next sweep with a tiny threshold |
| ghost picker — drops hashes not in live set | |
| ghost picker — empty when all live | |
| ghost picker — empty live set means everything's a ghost | |

8/8 pass; total lib test count goes 233 → 241.

## Plugin

- `WasmModule.retryStaleBlobRequests(staleAfterMs: number): number`.
- `SynclinePlugin.startBlobRetrySweep` / `stopBlobRetrySweep` paired with the `serverStats` polling lifecycle in connect / disconnect.
- Sweep cadence (5 s) and threshold (15 s) are private static constants on `SynclinePlugin` so they're discoverable in one place.

## Test plan

- [x] `cargo build --target wasm32-unknown-unknown --lib` clean
- [x] `cargo build --lib` clean (full workspace)
- [x] `cargo test --lib` — 241 / 241
- [x] `npm run lint` clean
- [x] `npm run build` clean
- [ ] CI passes (won't run until #84 merges and base auto-rebases)
- [ ] Manual reproduction post-merge: kill WS mid-request → counter recovers within 15-20 s; force a manifest swap → ghost prune fires within 5 s

🤖 Generated with [Claude Code](https://claude.com/claude-code)