### PR TITLE
fix(plugin): stop dotfile activity-feed loop + surface text edits

### DIFF
--- a/obsidian-plugin/main.ts
+++ b/obsidian-plugin/main.ts
@@ -1768,33 +1768,66 @@ export default class SynclinePlugin extends Plugin {
    */
   private async ensureBinaryInSync(row: ProjectionRow): Promise<void> {
     if (!this.client || !row.blob_hash) return;
-    const file = this.app.vault.getAbstractFileByPath(row.path);
-    if (file instanceof TFile) {
+
+    // First try the indexed vault. Fast path that hits Obsidian's
+    // in-memory file table directly.
+    const indexed = this.app.vault.getAbstractFileByPath(row.path);
+    if (indexed instanceof TFile) {
       try {
-        const data = await this.app.vault.readBinary(file);
+        const data = await this.app.vault.readBinary(indexed);
         const localHash = await sha256Hex(data);
         if (localHash === row.blob_hash) return;
         this.tryRequestBlob(row.blob_hash);
       } catch (e) {
-        // Disk-side I/O on a stale TFile — nothing to do.
         if (isMissingFileError(e)) return;
         console.error(`[Syncline] ensureBinaryInSync ${row.path}:`, e);
       }
-    } else {
-      // File missing on disk — request unconditionally. tryRequestBlob
-      // dedupes per-hash, but for the missing-file branch that's wrong:
-      // a previous request for this hash only wrote to whichever rows
-      // happened to be in lastProjection when the blob landed. Rows
-      // arriving in later manifest batches need their own delivery.
-      // Server still has the bytes; re-request is cheap.
-      if (!this.client.isConnected()) return;
-      try {
-        this.client.requestBlob(row.blob_hash);
-        this.requestedBlobs.add(row.blob_hash);
-      } catch (e) {
-        if (isNotConnectedError(e)) return;
-        console.error(`[Syncline] requestBlob ${row.blob_hash}:`, e);
+      return;
+    }
+
+    // Indexed vault doesn't see this path — but Obsidian deliberately
+    // hides dotfiles (anything starting with `.`) from `getFiles()`
+    // and `getAbstractFileByPath`. They're still on disk, and the
+    // adapter layer can see them. Without this fallback, every
+    // reconcile pass for a dotfile (e.g. `.gitignore`, `.env`,
+    // `.obsidianignore`) hit the "file missing" branch below,
+    // re-requested the same blob, the bytes landed via
+    // `onBlobReceived` (which uses the adapter so the file ended up
+    // on disk anyway), and the next reconcile re-requested again —
+    // visible to the user as the same handful of dot-paths spamming
+    // the activity feed forever.
+    try {
+      const adapter = this.app.vault.adapter;
+      if (await adapter.exists(row.path)) {
+        const data = await adapter.readBinary(row.path);
+        const localHash = await sha256Hex(data);
+        if (localHash === row.blob_hash) return;
+        this.tryRequestBlob(row.blob_hash);
+        return;
       }
+    } catch (e) {
+      if (!isMissingFileError(e)) {
+        console.error(
+          `[Syncline] ensureBinaryInSync adapter ${row.path}:`,
+          e,
+        );
+      }
+      // Fall through to the request-unconditionally path below.
+    }
+
+    // Truly missing on disk (neither the indexed vault nor the
+    // adapter found anything). Request unconditionally — `tryRequestBlob`
+    // dedupes per-hash, but for the missing-file branch that's wrong:
+    // a previous request for this hash only wrote to whichever rows
+    // happened to be in lastProjection when the blob landed. Rows
+    // arriving in later manifest batches need their own delivery.
+    if (!this.client.isConnected()) return;
+    try {
+      this.client.requestBlob(row.blob_hash);
+      this.requestedBlobs.add(row.blob_hash);
+    } catch (e) {
+      if (isNotConnectedError(e)) return;
+      console.error(`[Syncline] requestBlob ${row.blob_hash}:`, e);
     }
   }
 

--- a/syncline/src/wasm_client_v1.rs
+++ b/syncline/src/wasm_client_v1.rs
@@ -786,37 +786,61 @@ impl SynclineV1Client {
         let Some(node_id) = NodeId::parse_str(&node_id_hex) else {
             return;
         };
-        let content = self.content.borrow();
-        let Some(cd) = content.get(&node_id) else {
-            return;
-        };
-        let text = cd.doc.get_or_insert_text("text");
-        let mut txn = cd.doc.transact_mut();
-        let current = text.get_string(&txn);
-        if current == new_content {
-            return;
-        }
-        if current.is_empty() {
-            text.insert(&mut txn, 0, &new_content);
-            return;
-        }
-        if new_content.is_empty() {
-            text.remove_range(&mut txn, 0, current.len() as u32);
-            return;
-        }
-        let diff = dissimilar::diff(&current, &new_content);
-        let mut cursor = 0u32;
-        for chunk in diff {
-            match chunk {
-                dissimilar::Chunk::Equal(v) => cursor += v.len() as u32,
-                dissimilar::Chunk::Delete(v) => {
-                    text.remove_range(&mut txn, cursor, v.len() as u32);
-                }
-                dissimilar::Chunk::Insert(v) => {
-                    text.insert(&mut txn, cursor, v);
-                    cursor += v.len() as u32;
+        // `changed` flips true if the function actually mutates the
+        // text. Used below to decide whether to emit a sync-event for
+        // the activity feed — a no-op call shouldn't pollute it.
+        let mut changed = false;
+        let new_byte_len = new_content.len();
+        {
+            let content = self.content.borrow();
+            let Some(cd) = content.get(&node_id) else {
+                return;
+            };
+            let text = cd.doc.get_or_insert_text("text");
+            let mut txn = cd.doc.transact_mut();
+            let current = text.get_string(&txn);
+            if current == new_content {
+                return;
+            }
+            changed = true;
+            if current.is_empty() {
+                text.insert(&mut txn, 0, &new_content);
+            } else if new_content.is_empty() {
+                text.remove_range(&mut txn, 0, current.len() as u32);
+            } else {
+                let diff = dissimilar::diff(&current, &new_content);
+                let mut cursor = 0u32;
+                for chunk in diff {
+                    match chunk {
+                        dissimilar::Chunk::Equal(v) => cursor += v.len() as u32,
+                        dissimilar::Chunk::Delete(v) => {
+                            text.remove_range(&mut txn, cursor, v.len() as u32);
+                        }
+                        dissimilar::Chunk::Insert(v) => {
+                            text.insert(&mut txn, cursor, v);
+                            cursor += v.len() as u32;
+                        }
+                    }
                 }
             }
+        }
+
+        // Surface local text edits in the activity feed. Without this
+        // emission, the user's own `.md` edits never showed up, while
+        // every random binary blob_down lit up the feed — exactly the
+        // complaint that motivated this fix.
+        if changed {
+            let path: Option<String> = self
+                .manifest
+                .borrow()
+                .as_ref()
+                .and_then(|m| project(m).by_id.get(&node_id).map(|e| e.path.clone()));
+            self.handles().emit_sync_event(serde_json::json!({
+                "kind": "node_modified",
+                "path": path,
+                "hash": Option::<String>::None,
+                "bytes": new_byte_len,
+            }));
         }
     }
 
@@ -1187,6 +1211,27 @@ fn dispatch_frame(h: &Handles, ws: &WebSocket, data: &[u8]) {
                     &JsValue::from_str(&node_id.to_string_hyphenated()),
                 );
             }
+            // Surface this to the activity feed (#65 phase 4).
+            // Without this emission, text-file edits never appeared
+            // in "Recent activity" — only the binary blob_down/up
+            // paths did, which was confusing because every random
+            // dotfile broadcast lit up the feed but the user's own
+            // .md edits stayed silent.
+            //
+            // Path lookup is best-effort — for an STEP_2 / UPDATE we
+            // received before the matching manifest entry landed,
+            // we'd have no path yet; fall back to the node id.
+            let path: Option<String> = h
+                .manifest
+                .borrow()
+                .as_ref()
+                .and_then(|m| project(m).by_id.get(&node_id).map(|e| e.path.clone()));
+            h.emit_sync_event(serde_json::json!({
+                "kind": "node_modified",
+                "path": path,
+                "hash": Option::<String>::None,
+                "bytes": payload.len(),
+            }));
         }
         MSG_SYNC_STEP_1 => {
             let Some(node_id) = parse_content_doc_id(doc_id) else {


### PR DESCRIPTION
Two related sidebar bugs reported on a 1.3.0 vault.

## Bug 1 — dotfile blob_down loop

The user's screenshot showed the same five dot-paths spamming "Recent activity" every minute while their actual `.md` edits stayed invisible:

```
↓ skills/home-assistant/.gitignore (5 B)        27s ago
↓ skills/home-assistant/.env.example (70 B)     27s ago
↓ skills/home-assistant/.env (224 B)            27s ago
↓ 10 🦋 Aria/.obsidianignore (13 B)             27s ago
↓ 10 🦋 Aria/.claude/settings.json (1.3 KiB)    27s ago
↓ skills/home-assistant/.gitignore (5 B)        28s ago     ← repeat
↓ ...                                                       ← every reconcile
```

Bytes on disk matched the manifest's `blob_hash` exactly — verified by `shasum`. So why was the plugin re-requesting?

**Root cause**: `ensureBinaryInSync` checks for the file via `vault.getAbstractFileByPath(row.path)`. **Obsidian deliberately hides dotfiles** (anything starting with `.`) from that lookup. The check returned `null`, the code fell into the file-missing branch, and that branch issues an unconditional `requestBlob` that bypasses the hash equality check the file-exists branch performs.

Server replied, `onBlobReceived` wrote the bytes via the adapter (which *does* handle dotfiles), the file landed on disk, but the next reconcile asked the indexed vault again, found nothing, re-requested. Forever.

**Fix**: when the indexed lookup misses, fall back to `vault.adapter.exists()` + `vault.adapter.readBinary()` and run the same hash equality check as the file-exists branch. Only the truly-missing case still requests unconditionally.

## Bug 2 — text edits silent in the activity feed

> "the regular files I changed are not there. Only this list."

The activity feed only fired on `blob_down` / `blob_up` events. Text-content updates — the user's own `.md` edits and remote text edits arriving from peers — never emitted a sync event, so the feed felt broken.

**Fix**: emit `node_modified` sync events from two paths in `wasm_client_v1`:

- `MSG_SYNC_STEP_2` / `MSG_UPDATE` dispatcher — fires when a remote text update lands.
- `update_content_text` — fires when the local user's edit applies a non-empty diff to the Yrs subdoc. Guarded so a no-op call (same bytes) doesn't pollute the feed.

Path resolved best-effort from the projection; if the entry hasn't landed yet, the event still fires with `path = null`.

## Test plan
- [x] `cargo build --target wasm32-unknown-unknown --lib` clean
- [x] `cargo build --lib` clean (full workspace)
- [x] `cargo test --lib` — 241 / 241 pass
- [x] `npm run lint` clean
- [x] `npm run build` clean
- [x] **Manually verified** by installing the patched build into the user's 1.3.0 vault: the 5 dotfiles no longer appear in the feed every minute; a `.md` edit produces a `~ path/to/file.md` row.
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)