### PR TITLE
feat(plugin): hook onExternalSettingsChange — closes #90

### DIFF
--- a/e2e/test/specs/issue90.e2e.ts
+++ b/e2e/test/specs/issue90.e2e.ts
@@ -1,0 +1,212 @@
+// Regression test for #90 — onExternalSettingsChange.
+//
+// Obsidian fires this hook when our `data.json` is rewritten by something
+// other than this plugin instance — typically a second sync tool, or the
+// user editing the file by hand. The plugin must:
+//   - Pick up `serverUrl` and `autoSync` changes without restart.
+//   - REFUSE to overwrite `actorId`. ActorId is this device's CRDT
+//     identity; if two devices ever share one, Yrs history is corrupted
+//     permanently. On mismatch, keep ours and rewrite `data.json` so the
+//     on-disk state matches reality.
+//   - Ignore the echo of our own `saveSettings()` writes (250 ms cookie).
+//
+// Test strategy: write `data.json` from the test process (Node fs),
+// then invoke `plugin.onExternalSettingsChange()` directly. This
+// bypasses Obsidian's own fs-watcher (which is unreliable in xvfb /
+// headless chrome) and tests the plugin's logic deterministically.
+
+import { spawn, ChildProcess } from 'child_process';
+import { join } from 'path';
+import * as fs from 'fs';
+import { expect, browser } from '@wdio/globals';
+
+describe('Syncline #90 — onExternalSettingsChange', () => {
+    const port = 3090;
+    const altPort = 3091;
+    const serverUrl = `ws://localhost:${port}/sync`;
+    const altServerUrl = `ws://localhost:${altPort}/sync`;
+    const repoRoot = join(__dirname, '../../../');
+    const e2eDir = join(__dirname, '../../');
+    const dbPath = join(e2eDir, 'issue90.db');
+    const altDbPath = join(e2eDir, 'issue90-alt.db');
+    const synclineBin = join(repoRoot, 'target/release/syncline');
+
+    let serverProc: ChildProcess;
+    let altServerProc: ChildProcess;
+
+    async function waitFor<T>(label: string, fn: () => Promise<T | null | undefined | false | ''>, timeoutMs = 30_000, stepMs = 100): Promise<T> {
+        const deadline = Date.now() + timeoutMs;
+        while (Date.now() < deadline) {
+            try { const v = await fn(); if (v) return v as T; } catch {}
+            await new Promise((r) => setTimeout(r, stepMs));
+        }
+        throw new Error(`waitFor("${label}") timed out after ${timeoutMs}ms`);
+    }
+
+    async function startServer(serverPort: number, db: string): Promise<ChildProcess> {
+        let out = '';
+        const proc = spawn(synclineBin, ['server', '--port', String(serverPort), '--db-path', db], { stdio: 'pipe' });
+        proc.stdout?.on('data', (d) => { out += d; });
+        proc.stderr?.on('data', (d) => { out += d; });
+        await waitFor(`server :${serverPort} listening`, async () => /listening/i.test(out), 30_000, 100);
+        return proc;
+    }
+
+    async function rewriteDataJson(dataPath: string, mutator: (cur: any) => void) {
+        const cur = JSON.parse(fs.readFileSync(dataPath, 'utf8'));
+        mutator(cur);
+        fs.writeFileSync(dataPath, JSON.stringify(cur));
+    }
+
+    before(async function () {
+        this.timeout(2 * 60_000);
+        if (!fs.existsSync(synclineBin)) throw new Error(`syncline binary missing at ${synclineBin}`);
+        for (const p of [dbPath, altDbPath]) {
+            if (fs.existsSync(p)) fs.unlinkSync(p);
+        }
+
+        // Two servers so the URL-swap phase reaches a real handshake on
+        // both ends — otherwise the post-swap connect() leaves the plugin
+        // in "connecting…" forever and subsequent phases race against
+        // background reconnect attempts.
+        serverProc = await startServer(port, dbPath);
+        altServerProc = await startServer(altPort, altDbPath);
+
+        const obsidianPage = browser.getObsidianPage();
+        try { await obsidianPage.enablePlugin('syncline'); } catch {}
+        await browser.executeObsidian(async ({ app }, url) => {
+            const plugin: any = (app as any).plugins.plugins['syncline'];
+            if (!plugin) throw new Error('plugin not found');
+            plugin.settings.serverUrl = url;
+            plugin.settings.autoSync = true;
+            await plugin.saveSettings();
+            plugin.disconnect();
+            await plugin.connect();
+        }, serverUrl);
+        await waitFor('plugin connected', async () => browser.executeObsidian(async ({ app }) => {
+            const plugin: any = (app as any).plugins.plugins['syncline'];
+            return !!(plugin && plugin.client && plugin.client.isConnected());
+        }), 30_000, 100);
+    });
+
+    after(() => {
+        if (serverProc && !serverProc.killed) serverProc.kill();
+        if (altServerProc && !altServerProc.killed) altServerProc.kill();
+    });
+
+    it('reacts to external data.json changes correctly', async function () {
+        this.timeout(2 * 60_000);
+
+        const vaultPath: string = await browser.executeObsidian(async ({ app }) => (app as any).vault.adapter.basePath as string);
+        const dataPath = join(vaultPath, '.obsidian', 'plugins', 'syncline', 'data.json');
+
+        if (!fs.existsSync(dataPath)) {
+            throw new Error(`data.json missing at ${dataPath}`);
+        }
+        const originalData = JSON.parse(fs.readFileSync(dataPath, 'utf8'));
+        const originalActorId: string = originalData.actorId;
+        if (!originalActorId) throw new Error('plugin has no actorId yet — connect before this test');
+
+        // --------------------------------------------------------------
+        // Phase A — serverUrl change picks up; client is reinstantiated.
+        // --------------------------------------------------------------
+        await rewriteDataJson(dataPath, (c) => { c.serverUrl = altServerUrl; });
+        const phaseA: any = await browser.executeObsidian(async ({ app }) => {
+            const plugin: any = (app as any).plugins.plugins['syncline'];
+            const oldClient = plugin.client;
+            await plugin.onExternalSettingsChange();
+            return {
+                settingsUrl: plugin.settings.serverUrl,
+                clientReinstantiated: plugin.client !== oldClient,
+                clientNotNull: !!plugin.client,
+            };
+        });
+        expect(phaseA.settingsUrl).toBe(altServerUrl);
+        expect(phaseA.clientReinstantiated).toBe(true);
+        expect(phaseA.clientNotNull).toBe(true);
+        await waitFor('plugin reconnected to alt', async () => browser.executeObsidian(async ({ app }) => {
+            const p: any = (app as any).plugins.plugins['syncline'];
+            return !!(p && p.client && p.client.isConnected());
+        }), 30_000, 100);
+        console.log(`[#90] phase A: serverUrl change reflected, client reinstantiated, reconnected to ${altServerUrl}`);
+
+        // Restore back to primary server for subsequent phases.
+        await rewriteDataJson(dataPath, (c) => { c.serverUrl = serverUrl; });
+        await browser.executeObsidian(async ({ app }) => {
+            const plugin: any = (app as any).plugins.plugins['syncline'];
+            await plugin.onExternalSettingsChange();
+        });
+        await waitFor('plugin reconnected to primary', async () => browser.executeObsidian(async ({ app }) => {
+            const p: any = (app as any).plugins.plugins['syncline'];
+            return !!(p && p.client && p.client.isConnected());
+        }), 30_000, 100);
+
+        // --------------------------------------------------------------
+        // Phase B — autoSync: false disconnects the client.
+        // --------------------------------------------------------------
+        await rewriteDataJson(dataPath, (c) => { c.autoSync = false; });
+        const phaseB: any = await browser.executeObsidian(async ({ app }) => {
+            const plugin: any = (app as any).plugins.plugins['syncline'];
+            await plugin.onExternalSettingsChange();
+            return {
+                clientNull: plugin.client === null,
+                autoSync: plugin.settings.autoSync,
+            };
+        });
+        expect(phaseB.autoSync).toBe(false);
+        expect(phaseB.clientNull).toBe(true);
+        console.log(`[#90] phase B: autoSync=false disconnected client`);
+
+        // Restore autoSync, reconnect.
+        await rewriteDataJson(dataPath, (c) => { c.autoSync = true; });
+        await browser.executeObsidian(async ({ app }) => {
+            const plugin: any = (app as any).plugins.plugins['syncline'];
+            await plugin.onExternalSettingsChange();
+        });
+        await waitFor('plugin reconnected (post-B)', async () => browser.executeObsidian(async ({ app }) => {
+            const p: any = (app as any).plugins.plugins['syncline'];
+            return !!(p && p.client && p.client.isConnected());
+        }), 30_000, 100);
+
+        // --------------------------------------------------------------
+        // Phase C — actorId mismatch is REJECTED; data.json is restored.
+        //   This is the highest-stakes assertion: silently accepting an
+        //   external actorId would corrupt Yrs history across devices.
+        // --------------------------------------------------------------
+        const fakeActorId = '00000000-0000-4000-8000-deadbeefcafe';
+        await rewriteDataJson(dataPath, (c) => { c.actorId = fakeActorId; });
+        const phaseC: any = await browser.executeObsidian(async ({ app }) => {
+            const plugin: any = (app as any).plugins.plugins['syncline'];
+            await plugin.onExternalSettingsChange();
+            return { inMemoryActor: plugin.settings.actorId };
+        });
+        const onDiskActor = JSON.parse(fs.readFileSync(dataPath, 'utf8')).actorId;
+        expect(phaseC.inMemoryActor).toBe(originalActorId);
+        expect(onDiskActor).toBe(originalActorId);
+        console.log(`[#90] phase C: actorId mismatch rejected; on-disk file restored`);
+
+        // --------------------------------------------------------------
+        // Phase D — self-write echo within the cookie window is ignored.
+        //   saveSettings() refreshes lastSelfSaveAt; an immediate
+        //   onExternalSettingsChange() call must early-return without
+        //   touching client state.
+        // --------------------------------------------------------------
+        const phaseD: any = await browser.executeObsidian(async ({ app }) => {
+            const plugin: any = (app as any).plugins.plugins['syncline'];
+            const beforeUrl = plugin.settings.serverUrl;
+            const beforeClient = plugin.client;
+            const beforeAutoSync = plugin.settings.autoSync;
+            await plugin.saveSettings();
+            await plugin.onExternalSettingsChange();
+            return {
+                urlSame: plugin.settings.serverUrl === beforeUrl,
+                clientSame: plugin.client === beforeClient,
+                autoSyncSame: plugin.settings.autoSync === beforeAutoSync,
+            };
+        });
+        expect(phaseD.urlSame).toBe(true);
+        expect(phaseD.clientSame).toBe(true);
+        expect(phaseD.autoSyncSame).toBe(true);
+        console.log(`[#90] phase D: self-write echo did not trigger reaction`);
+    });
+});

--- a/e2e/test/specs/issue90.e2e.ts
+++ b/e2e/test/specs/issue90.e2e.ts
@@ -10,10 +10,13 @@
 //     on-disk state matches reality.
 //   - Ignore the echo of our own `saveSettings()` writes (250 ms cookie).
 //
-// Test strategy: write `data.json` from the test process (Node fs),
-// then invoke `plugin.onExternalSettingsChange()` directly. This
-// bypasses Obsidian's own fs-watcher (which is unreliable in xvfb /
-// headless chrome) and tests the plugin's logic deterministically.
+// Test strategy: write `data.json` via Obsidian's vault adapter (NOT
+// `Plugin.saveData`, so it counts as "external" from the plugin's
+// perspective), then invoke `plugin.onExternalSettingsChange()`
+// directly. We bypass Obsidian's own fs-watcher (unreliable under
+// xvfb / headless chrome) and bypass Node-side `fs.writeFileSync`
+// (the renderer's vault adapter may not see external fs writes
+// coherently in CI). Tests the plugin's logic deterministically.
 
 import { spawn, ChildProcess } from 'child_process';
 import { join } from 'path';
@@ -52,10 +55,24 @@ describe('Syncline #90 — onExternalSettingsChange', () => {
         return proc;
     }
 
-    async function rewriteDataJson(dataPath: string, mutator: (cur: any) => void) {
-        const cur = JSON.parse(fs.readFileSync(dataPath, 'utf8'));
-        mutator(cur);
-        fs.writeFileSync(dataPath, JSON.stringify(cur));
+    /**
+     * Mutate data.json via Obsidian's vault adapter — equivalent to what
+     * another in-Obsidian plugin or another adapter-based sync tool
+     * would do. Counts as "external" from this plugin's perspective
+     * (does NOT go through `this.saveData`), but stays adapter-coherent
+     * so the next `loadData()` call sees the new bytes immediately.
+     *
+     * Returns nothing; it's run inside Obsidian via executeObsidian.
+     */
+    async function adapterRewriteDataJson(mutation: { kind: 'serverUrl' | 'autoSync' | 'actorId'; value: any }) {
+        await browser.executeObsidian(async ({ app }, m) => {
+            const adapter = (app as any).vault.adapter;
+            const cd = (app as any).vault.configDir;
+            const path = `${cd}/plugins/syncline/data.json`;
+            const cur = JSON.parse(await adapter.read(path));
+            cur[m.kind] = m.value;
+            await adapter.write(path, JSON.stringify(cur));
+        }, mutation);
     }
 
     before(async function () {
@@ -97,20 +114,21 @@ describe('Syncline #90 — onExternalSettingsChange', () => {
     it('reacts to external data.json changes correctly', async function () {
         this.timeout(2 * 60_000);
 
-        const vaultPath: string = await browser.executeObsidian(async ({ app }) => (app as any).vault.adapter.basePath as string);
-        const dataPath = join(vaultPath, '.obsidian', 'plugins', 'syncline', 'data.json');
-
-        if (!fs.existsSync(dataPath)) {
-            throw new Error(`data.json missing at ${dataPath}`);
-        }
-        const originalData = JSON.parse(fs.readFileSync(dataPath, 'utf8'));
-        const originalActorId: string = originalData.actorId;
+        const originalActorId: string = await browser.executeObsidian(async ({ app }) => {
+            const adapter = (app as any).vault.adapter;
+            const cd = (app as any).vault.configDir;
+            const path = `${cd}/plugins/syncline/data.json`;
+            const exists = await adapter.exists(path);
+            if (!exists) throw new Error(`data.json missing at ${path}`);
+            const cur = JSON.parse(await adapter.read(path));
+            return cur.actorId;
+        });
         if (!originalActorId) throw new Error('plugin has no actorId yet — connect before this test');
 
         // --------------------------------------------------------------
         // Phase A — serverUrl change picks up; client is reinstantiated.
         // --------------------------------------------------------------
-        await rewriteDataJson(dataPath, (c) => { c.serverUrl = altServerUrl; });
+        await adapterRewriteDataJson({ kind: 'serverUrl', value: altServerUrl });
         const phaseA: any = await browser.executeObsidian(async ({ app }) => {
             const plugin: any = (app as any).plugins.plugins['syncline'];
             const oldClient = plugin.client;
@@ -131,7 +149,7 @@ describe('Syncline #90 — onExternalSettingsChange', () => {
         console.log(`[#90] phase A: serverUrl change reflected, client reinstantiated, reconnected to ${altServerUrl}`);
 
         // Restore back to primary server for subsequent phases.
-        await rewriteDataJson(dataPath, (c) => { c.serverUrl = serverUrl; });
+        await adapterRewriteDataJson({ kind: 'serverUrl', value: serverUrl });
         await browser.executeObsidian(async ({ app }) => {
             const plugin: any = (app as any).plugins.plugins['syncline'];
             await plugin.onExternalSettingsChange();
@@ -144,7 +162,7 @@ describe('Syncline #90 — onExternalSettingsChange', () => {
         // --------------------------------------------------------------
         // Phase B — autoSync: false disconnects the client.
         // --------------------------------------------------------------
-        await rewriteDataJson(dataPath, (c) => { c.autoSync = false; });
+        await adapterRewriteDataJson({ kind: 'autoSync', value: false });
         const phaseB: any = await browser.executeObsidian(async ({ app }) => {
             const plugin: any = (app as any).plugins.plugins['syncline'];
             await plugin.onExternalSettingsChange();
@@ -158,7 +176,7 @@ describe('Syncline #90 — onExternalSettingsChange', () => {
         console.log(`[#90] phase B: autoSync=false disconnected client`);
 
         // Restore autoSync, reconnect.
-        await rewriteDataJson(dataPath, (c) => { c.autoSync = true; });
+        await adapterRewriteDataJson({ kind: 'autoSync', value: true });
         await browser.executeObsidian(async ({ app }) => {
             const plugin: any = (app as any).plugins.plugins['syncline'];
             await plugin.onExternalSettingsChange();
@@ -174,15 +192,21 @@ describe('Syncline #90 — onExternalSettingsChange', () => {
         //   external actorId would corrupt Yrs history across devices.
         // --------------------------------------------------------------
         const fakeActorId = '00000000-0000-4000-8000-deadbeefcafe';
-        await rewriteDataJson(dataPath, (c) => { c.actorId = fakeActorId; });
+        await adapterRewriteDataJson({ kind: 'actorId', value: fakeActorId });
         const phaseC: any = await browser.executeObsidian(async ({ app }) => {
             const plugin: any = (app as any).plugins.plugins['syncline'];
             await plugin.onExternalSettingsChange();
-            return { inMemoryActor: plugin.settings.actorId };
+            const adapter = (app as any).vault.adapter;
+            const cd = (app as any).vault.configDir;
+            const path = `${cd}/plugins/syncline/data.json`;
+            const onDisk = JSON.parse(await adapter.read(path));
+            return {
+                inMemoryActor: plugin.settings.actorId,
+                onDiskActor: onDisk.actorId,
+            };
         });
-        const onDiskActor = JSON.parse(fs.readFileSync(dataPath, 'utf8')).actorId;
         expect(phaseC.inMemoryActor).toBe(originalActorId);
-        expect(onDiskActor).toBe(originalActorId);
+        expect(phaseC.onDiskActor).toBe(originalActorId);
         console.log(`[#90] phase C: actorId mismatch rejected; on-disk file restored`);
 
         // --------------------------------------------------------------

--- a/e2e/test/specs/issue90.e2e.ts
+++ b/e2e/test/specs/issue90.e2e.ts
@@ -128,17 +128,31 @@ describe('Syncline #90 — onExternalSettingsChange', () => {
         // --------------------------------------------------------------
         // Phase A — serverUrl change picks up; client is reinstantiated.
         // --------------------------------------------------------------
+        // Reset the self-write cookie so the hook's cookie guard (which
+        // exists to filter out the echo of our own saveSettings()) does
+        // NOT early-return. The before() block calls saveSettings within
+        // its setup; on a fast machine the test reaches the hook well
+        // within the 250 ms cookie window. Production behavior is
+        // tested separately in Phase D.
         await adapterRewriteDataJson({ kind: 'serverUrl', value: altServerUrl });
         const phaseA: any = await browser.executeObsidian(async ({ app }) => {
             const plugin: any = (app as any).plugins.plugins['syncline'];
+            plugin.lastSelfSaveAt = 0;
+            // Diagnostic: confirm the on-disk write is visible to
+            // loadData() before we trigger the hook. If raw is null
+            // here, the failure is at the IO layer, not the hook logic.
+            const raw = await plugin.loadData();
             const oldClient = plugin.client;
             await plugin.onExternalSettingsChange();
             return {
+                rawSeenByLoadData: raw,
                 settingsUrl: plugin.settings.serverUrl,
                 clientReinstantiated: plugin.client !== oldClient,
                 clientNotNull: !!plugin.client,
             };
         });
+        console.log(`[#90] phase A diagnostic: loadData saw serverUrl=${phaseA.rawSeenByLoadData?.serverUrl}`);
+        expect(phaseA.rawSeenByLoadData?.serverUrl).toBe(altServerUrl);
         expect(phaseA.settingsUrl).toBe(altServerUrl);
         expect(phaseA.clientReinstantiated).toBe(true);
         expect(phaseA.clientNotNull).toBe(true);
@@ -152,6 +166,7 @@ describe('Syncline #90 — onExternalSettingsChange', () => {
         await adapterRewriteDataJson({ kind: 'serverUrl', value: serverUrl });
         await browser.executeObsidian(async ({ app }) => {
             const plugin: any = (app as any).plugins.plugins['syncline'];
+            plugin.lastSelfSaveAt = 0;
             await plugin.onExternalSettingsChange();
         });
         await waitFor('plugin reconnected to primary', async () => browser.executeObsidian(async ({ app }) => {
@@ -165,6 +180,7 @@ describe('Syncline #90 — onExternalSettingsChange', () => {
         await adapterRewriteDataJson({ kind: 'autoSync', value: false });
         const phaseB: any = await browser.executeObsidian(async ({ app }) => {
             const plugin: any = (app as any).plugins.plugins['syncline'];
+            plugin.lastSelfSaveAt = 0;
             await plugin.onExternalSettingsChange();
             return {
                 clientNull: plugin.client === null,
@@ -179,6 +195,7 @@ describe('Syncline #90 — onExternalSettingsChange', () => {
         await adapterRewriteDataJson({ kind: 'autoSync', value: true });
         await browser.executeObsidian(async ({ app }) => {
             const plugin: any = (app as any).plugins.plugins['syncline'];
+            plugin.lastSelfSaveAt = 0;
             await plugin.onExternalSettingsChange();
         });
         await waitFor('plugin reconnected (post-B)', async () => browser.executeObsidian(async ({ app }) => {
@@ -195,6 +212,7 @@ describe('Syncline #90 — onExternalSettingsChange', () => {
         await adapterRewriteDataJson({ kind: 'actorId', value: fakeActorId });
         const phaseC: any = await browser.executeObsidian(async ({ app }) => {
             const plugin: any = (app as any).plugins.plugins['syncline'];
+            plugin.lastSelfSaveAt = 0;
             await plugin.onExternalSettingsChange();
             const adapter = (app as any).vault.adapter;
             const cd = (app as any).vault.configDir;

--- a/obsidian-plugin/main.ts
+++ b/obsidian-plugin/main.ts
@@ -805,8 +805,79 @@ export default class SynclinePlugin extends Plugin {
     ) as SynclineSettings;
   }
 
+  /** Wall-clock of the last `saveSettings()` call. Used by
+   *  `onExternalSettingsChange` to ignore the echo of our own write
+   *  in case Obsidian's own filtering doesn't catch every case
+   *  (e.g. on a slow filesystem the change event lands later than
+   *  expected). 250 ms is the same window LiveSync uses. */
+  private lastSelfSaveAt = 0;
+  private static readonly EXTERNAL_SETTINGS_SELF_WRITE_WINDOW_MS = 250;
+
   async saveSettings() {
+    this.lastSelfSaveAt = Date.now();
     await this.saveData(this.settings);
+  }
+
+  /**
+   * Obsidian fires this when our `data.json` is rewritten by something
+   * other than this plugin instance — typically a separate sync tool
+   * propagating settings across devices, or the user editing the file
+   * by hand to recover from a bad state.
+   *
+   * Apply the safe subset (server URL, autoSync), but refuse to
+   * overwrite `actorId`. `actorId` is this device's CRDT identity:
+   * if two devices ever mint Yrs updates with the same actor, history
+   * is corrupted permanently. So if an external write tries to change
+   * it, keep ours and rewrite `data.json` to match — that way the on-
+   * disk state ends up consistent with what we'll actually use, and
+   * the next external sync round won't keep proposing a bad value.
+   */
+  async onExternalSettingsChange() {
+    if (
+      Date.now() - this.lastSelfSaveAt <
+      SynclinePlugin.EXTERNAL_SETTINGS_SELF_WRITE_WINDOW_MS
+    ) {
+      return;
+    }
+    const raw = (await this.loadData()) as Partial<SynclineSettings> | null;
+    if (!raw) return;
+
+    const previous = { ...this.settings };
+    const incoming: SynclineSettings = Object.assign(
+      {},
+      DEFAULT_SETTINGS,
+      raw,
+    ) as SynclineSettings;
+
+    let needsRewrite = false;
+    if (incoming.actorId !== previous.actorId) {
+      console.warn(
+        `[Syncline] external data.json change tried to set actorId=${incoming.actorId} (current=${previous.actorId}) — keeping current; rewriting data.json`,
+      );
+      incoming.actorId = previous.actorId;
+      needsRewrite = true;
+    }
+    this.settings = incoming;
+    if (needsRewrite) {
+      await this.saveSettings();
+    }
+
+    if (previous.serverUrl !== incoming.serverUrl) {
+      // URL changed: tear down and rebind. Honor autoSync for the
+      // reconnect — same policy as a settings-tab edit.
+      if (this.client) {
+        this.disconnect();
+      }
+      if (incoming.autoSync) {
+        await this.connect();
+      }
+    } else if (previous.autoSync !== incoming.autoSync) {
+      if (incoming.autoSync && !this.client) {
+        await this.connect();
+      } else if (!incoming.autoSync && this.client) {
+        this.disconnect();
+      }
+    }
   }
 
   // ---------------------------------------------------------------


### PR DESCRIPTION
Closes #90.

## Why

Obsidian fires `onExternalSettingsChange` when our `data.json` is rewritten by something other than this plugin instance — typically another sync tool propagating settings across devices, or the user hand-editing the file. Without the hook, in-memory `this.settings` silently drifts from disk and the next `saveSettings()` clobbers whatever changed externally.

## What

- New `async onExternalSettingsChange()` on `SynclinePlugin`.
- Reads `data.json` via `loadData()`, merges over `DEFAULT_SETTINGS`.
- Applies `serverUrl` / `autoSync` changes the same way the settings tab does (disconnect, then reconnect if `autoSync`).
- **Refuses to overwrite `actorId`** from an external write. ActorId is this device's CRDT identity; if two devices ever share one, Yrs history is corrupted permanently. On mismatch: keep ours, rewrite `data.json` so the on-disk state matches reality and the next sync round doesn't keep proposing the bad value.
- 250 ms self-write cookie (same window LiveSync uses) on top of `saveSettings()` to ignore the echo of our own write in case Obsidian's own filtering misses an edge case.

## Test plan

- [ ] Manually rewrite `data.json` from outside Obsidian (e.g. `echo '{"serverUrl":"ws://other:3030/sync","autoSync":true,"actorId":"<existing>"}' > data.json`); plugin picks up the new URL and reconnects without restart.
- [ ] Same as above with `autoSync: false`; plugin disconnects.
- [ ] Same as above with a *different* `actorId`; warning logged, on-disk `actorId` reverts to ours.
- [ ] Round-trip with another sync tool overwriting `data.json`: no settings-mismatch state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)