### PR TITLE
feat(plugin): self-write fs-event suppression cookie — closes #91

### DIFF
--- a/e2e/test/specs/issue91.e2e.ts
+++ b/e2e/test/specs/issue91.e2e.ts
@@ -1,0 +1,153 @@
+// Regression test for #91 — self-write fs-event suppression cookie.
+//
+// When Syncline writes a file (vault.modify, vault.adapter.writeBinary,
+// etc.), Obsidian's vault watcher fires an event for that path. The
+// plugin must drop that echo, otherwise it re-reads, re-hashes, and
+// can re-broadcast its own write. Before this PR the suppression was
+// per-event-kind sets cleaned up via setTimeout — racy on slow machines
+// and easy to leak. After this PR it's per-kind Maps with explicit
+// expiry timestamps, lazy-swept on read and periodically full-swept.
+//
+// The cookie machinery itself doesn't require a server or vault state —
+// it's purely state on the plugin object. This test pokes
+// plugin.markSelfWrite / isSelfWriteEcho / sweepExpiredSelfWriteCookies
+// directly via executeObsidian and asserts the contract.
+
+import { expect, browser } from '@wdio/globals';
+
+describe('Syncline #91 — self-write fs-event suppression cookie', () => {
+
+    before(async function () {
+        this.timeout(60_000);
+        const obsidianPage = browser.getObsidianPage();
+        try { await obsidianPage.enablePlugin('syncline'); } catch {}
+        // The plugin doesn't need to be connected for the cookie
+        // machinery; we exercise it as pure state on the plugin object.
+        // But it does need to be loaded.
+        await browser.waitUntil(async () => browser.executeObsidian(async ({ app }) => {
+            return !!(app as any).plugins.plugins['syncline'];
+        }), { timeout: 30_000, interval: 200 });
+    });
+
+    it('marks, expires, and sweeps self-write cookies', async function () {
+        this.timeout(60_000);
+
+        // --------------------------------------------------------------
+        // Phase A — basic round-trip: mark, then read back.
+        // --------------------------------------------------------------
+        const phaseA: any = await browser.executeObsidian(async ({ app }) => {
+            const plugin: any = (app as any).plugins.plugins['syncline'];
+            // Start clean.
+            for (const m of Object.values(plugin.selfWriteCookies)) (m as Map<string, number>).clear();
+            plugin.markSelfWrite('modify', 'foo.md');
+            return {
+                isEcho: plugin.isSelfWriteEcho('modify', 'foo.md'),
+                mapSize: plugin.selfWriteCookies.modify.size,
+            };
+        });
+        expect(phaseA.isEcho).toBe(true);
+        expect(phaseA.mapSize).toBe(1);
+        console.log('[#91] phase A: mark + read-back works');
+
+        // --------------------------------------------------------------
+        // Phase B — per-kind isolation: a `modify` cookie does NOT
+        // suppress a `rename` of the same path. This is the property
+        // the per-kind separation exists to preserve — losing it would
+        // drop user-initiated renames that follow a self-write.
+        // --------------------------------------------------------------
+        const phaseB: any = await browser.executeObsidian(async ({ app }) => {
+            const plugin: any = (app as any).plugins.plugins['syncline'];
+            for (const m of Object.values(plugin.selfWriteCookies)) (m as Map<string, number>).clear();
+            plugin.markSelfWrite('modify', 'bar.md');
+            return {
+                modifyEcho: plugin.isSelfWriteEcho('modify', 'bar.md'),
+                createEcho: plugin.isSelfWriteEcho('create', 'bar.md'),
+                deleteEcho: plugin.isSelfWriteEcho('delete', 'bar.md'),
+                renameEcho: plugin.isSelfWriteEcho('rename', 'bar.md'),
+                anyEcho: plugin.isAnySelfWriteEcho('bar.md'),
+            };
+        });
+        expect(phaseB.modifyEcho).toBe(true);
+        expect(phaseB.createEcho).toBe(false);
+        expect(phaseB.deleteEcho).toBe(false);
+        expect(phaseB.renameEcho).toBe(false);
+        expect(phaseB.anyEcho).toBe(true);
+        console.log('[#91] phase B: per-kind isolation holds');
+
+        // --------------------------------------------------------------
+        // Phase C — expiry: an entry whose expiry timestamp is in the
+        // past must read as not-echo AND be lazy-swept on read.
+        // --------------------------------------------------------------
+        const phaseC: any = await browser.executeObsidian(async ({ app }) => {
+            const plugin: any = (app as any).plugins.plugins['syncline'];
+            for (const m of Object.values(plugin.selfWriteCookies)) (m as Map<string, number>).clear();
+            // Backdate expiry by 1ms — simulates a cookie whose TTL has lapsed.
+            plugin.selfWriteCookies.modify.set('stale.md', Date.now() - 1);
+            const isEchoBefore = plugin.isSelfWriteEcho('modify', 'stale.md');
+            const sizeAfter = plugin.selfWriteCookies.modify.size;
+            return { isEchoBefore, sizeAfter };
+        });
+        expect(phaseC.isEchoBefore).toBe(false);
+        expect(phaseC.sizeAfter).toBe(0); // lazy-swept
+        console.log('[#91] phase C: expired cookies read as false and lazy-sweep');
+
+        // --------------------------------------------------------------
+        // Phase D — bounded growth: 1 000 expired entries, then a full
+        // sweep, then verify the maps are empty. The lazy sweep only
+        // fires on read; the periodic sweep is the safety net for
+        // paths whose echo event never lands.
+        // --------------------------------------------------------------
+        const phaseD: any = await browser.executeObsidian(async ({ app }) => {
+            const plugin: any = (app as any).plugins.plugins['syncline'];
+            for (const m of Object.values(plugin.selfWriteCookies)) (m as Map<string, number>).clear();
+            const past = Date.now() - 1;
+            for (let i = 0; i < 250; i++) {
+                plugin.selfWriteCookies.modify.set(`m${i}.md`, past);
+                plugin.selfWriteCookies.create.set(`c${i}.md`, past);
+                plugin.selfWriteCookies.delete.set(`d${i}.md`, past);
+                plugin.selfWriteCookies.rename.set(`r${i}.md`, past);
+            }
+            const before = (
+                plugin.selfWriteCookies.modify.size +
+                plugin.selfWriteCookies.create.size +
+                plugin.selfWriteCookies.delete.size +
+                plugin.selfWriteCookies.rename.size
+            );
+            plugin.sweepExpiredSelfWriteCookies();
+            const after = (
+                plugin.selfWriteCookies.modify.size +
+                plugin.selfWriteCookies.create.size +
+                plugin.selfWriteCookies.delete.size +
+                plugin.selfWriteCookies.rename.size
+            );
+            return { before, after };
+        });
+        expect(phaseD.before).toBe(1000);
+        expect(phaseD.after).toBe(0);
+        console.log('[#91] phase D: full sweep clears all expired entries');
+
+        // --------------------------------------------------------------
+        // Phase E — sweep preserves unexpired entries. Bounding memory
+        // mustn't drop active cookies whose corresponding fs event
+        // hasn't fired yet.
+        // --------------------------------------------------------------
+        const phaseE: any = await browser.executeObsidian(async ({ app }) => {
+            const plugin: any = (app as any).plugins.plugins['syncline'];
+            for (const m of Object.values(plugin.selfWriteCookies)) (m as Map<string, number>).clear();
+            const past = Date.now() - 1;
+            const future = Date.now() + 60_000;
+            plugin.selfWriteCookies.modify.set('expired.md', past);
+            plugin.selfWriteCookies.modify.set('active.md', future);
+            plugin.sweepExpiredSelfWriteCookies();
+            return {
+                hasExpired: plugin.selfWriteCookies.modify.has('expired.md'),
+                hasActive: plugin.selfWriteCookies.modify.has('active.md'),
+                activeEcho: plugin.isSelfWriteEcho('modify', 'active.md'),
+            };
+        });
+        expect(phaseE.hasExpired).toBe(false);
+        expect(phaseE.hasActive).toBe(true);
+        expect(phaseE.activeEcho).toBe(true);
+        console.log('[#91] phase E: sweep preserves unexpired entries');
+    });
+});

--- a/obsidian-plugin/main.ts
+++ b/obsidian-plugin/main.ts
@@ -179,6 +179,8 @@ async function initWasm(): Promise<WasmModule> {
  */
 const IGNORE_CHANGES_TIMEOUT_MS = 1000;
 
+type SelfWriteKind = "modify" | "create" | "delete" | "rename";
+
 /** Extensions that project as text nodes (Y.Text CRDT). Everything else is binary. */
 const TEXT_EXTENSIONS = new Set(["md", "txt"]);
 
@@ -658,16 +660,89 @@ export default class SynclinePlugin extends Plugin {
   client: SynclineV1Client | null = null;
   /**
    * Per-event-kind suppression of vault echoes that follow our own writes.
-   * Keyed by event type ("modify"|"create"|"delete"|"rename") then path.
-   * Suppressing a `modify` echo on `foo.md` must not suppress a later
-   * `rename` of the same path, so the kinds are tracked separately.
+   * Keyed by event type then path → expiry timestamp (Date.now() + TTL).
+   *
+   * Why per-kind: suppressing a `modify` echo on `foo.md` must not
+   * suppress a later user-initiated `rename` of the same path, so the
+   * kinds are tracked separately.
+   *
+   * Why expiry timestamps (not setTimeout): timestamp-based expiry is
+   * deterministic and lazy-sweeps on read. setTimeout cleanup races
+   * against plugin unload (timers can fire after `disconnect()` clears
+   * unrelated state) and against successive writes to the same path
+   * (the second timer overwrites the first's window).
+   *
+   * Use `markSelfWrite` and `isSelfWriteEcho` rather than touching the
+   * maps directly.
    */
-  ignoreEvents: { modify: Set<string>; create: Set<string>; delete: Set<string>; rename: Set<string> } = {
-    modify: new Set(),
-    create: new Set(),
-    delete: new Set(),
-    rename: new Set(),
+  selfWriteCookies: {
+    modify: Map<string, number>;
+    create: Map<string, number>;
+    delete: Map<string, number>;
+    rename: Map<string, number>;
+  } = {
+    modify: new Map(),
+    create: new Map(),
+    delete: new Map(),
+    rename: new Map(),
   };
+
+  /** Stamp `path` as a self-write under `kind` so the next fs event for
+   *  that pair is dropped as an echo of our own work. The window is
+   *  `IGNORE_CHANGES_TIMEOUT_MS` (1 s) — long enough to outrun the
+   *  onFileModify debounce + Obsidian's vault watcher latency, short
+   *  enough that a user action on the same path within the window is
+   *  rare. Call IMMEDIATELY before the corresponding vault.* /
+   *  vault.adapter.* write, while still on the same microtask. */
+  private markSelfWrite(kind: SelfWriteKind, path: string): void {
+    this.selfWriteCookies[kind].set(
+      path,
+      Date.now() + IGNORE_CHANGES_TIMEOUT_MS,
+    );
+  }
+
+  /** True iff `path` was stamped under `kind` and the cookie hasn't
+   *  expired yet. Lazy-sweeps the entry on expiry so a path that fires
+   *  no event after its window doesn't accumulate. */
+  private isSelfWriteEcho(kind: SelfWriteKind, path: string): boolean {
+    const exp = this.selfWriteCookies[kind].get(path);
+    if (exp === undefined) return false;
+    if (Date.now() >= exp) {
+      this.selfWriteCookies[kind].delete(path);
+      return false;
+    }
+    return true;
+  }
+
+  /** True iff `path` was stamped under any kind and is unexpired.
+   *  Used by the hidden-file scanner where we don't track which
+   *  CRUD verb landed it on disk. */
+  private isAnySelfWriteEcho(path: string): boolean {
+    return (
+      this.isSelfWriteEcho("modify", path) ||
+      this.isSelfWriteEcho("create", path) ||
+      this.isSelfWriteEcho("delete", path) ||
+      this.isSelfWriteEcho("rename", path)
+    );
+  }
+
+  /** Drop every cookie whose expiry is in the past. Bounds memory usage
+   *  for paths whose corresponding fs event never fired (no-op writes,
+   *  events suppressed elsewhere). Lazy sweep on read handles the
+   *  common case; this is the periodic safety net. */
+  private sweepExpiredSelfWriteCookies(): void {
+    const now = Date.now();
+    for (const m of [
+      this.selfWriteCookies.modify,
+      this.selfWriteCookies.create,
+      this.selfWriteCookies.delete,
+      this.selfWriteCookies.rename,
+    ]) {
+      for (const [path, exp] of m) {
+        if (now >= exp) m.delete(path);
+      }
+    }
+  }
 
   /** Last projection we reconciled against — keyed by path. */
   lastProjection: Map<string, ProjectionRow> = new Map();
@@ -1276,7 +1351,7 @@ export default class SynclinePlugin extends Plugin {
       this.client.free();
       this.client = null;
     }
-    for (const k of Object.values(this.ignoreEvents)) k.clear();
+    for (const m of Object.values(this.selfWriteCookies)) m.clear();
     this.lastProjection.clear();
     this.subscribedContent.clear();
     this.requestedBlobs.clear();
@@ -1548,6 +1623,11 @@ export default class SynclinePlugin extends Plugin {
           }
           for (const f of listing.files) {
             if (this.isHiddenIgnored(f)) continue;
+            // Skip files we just wrote ourselves. Without this, an
+            // inbound blob landing on a hidden path (via onBlobReceived)
+            // is immediately picked back up by the next scan tick and
+            // re-broadcast — exact loop the cookie exists to break.
+            if (this.isAnySelfWriteEcho(f)) continue;
             seen.push(f);
           }
         } catch (e) {
@@ -1616,6 +1696,11 @@ export default class SynclinePlugin extends Plugin {
     // of the WS handshake completing, not 30 s later.
     void this.scanHiddenFiles();
     this.hiddenScanTimer = window.setInterval(() => {
+      // Lazy sweeps in `isSelfWriteEcho` clean up entries on read,
+      // but cookies for paths whose echo never fires (e.g. the write
+      // was a no-op or the fs event was lost) accumulate. Periodic
+      // full sweep on the same cadence as the scanner bounds memory.
+      this.sweepExpiredSelfWriteCookies();
       void this.scanHiddenFiles();
     }, SynclinePlugin.HIDDEN_SCAN_INTERVAL_MS);
   }
@@ -1720,8 +1805,8 @@ export default class SynclinePlugin extends Plugin {
     // lookups otherwise). Then iterate per-row serially.
     //
     // Tried Promise.all over the per-row loop; it was *slower* on real
-    // vaults — desktop adapter contention + 1k concurrent setTimeouts
-    // for ignoreEvents cleanup added more wall time than it saved.
+    // vaults — desktop adapter contention + concurrent self-write
+    // cookie writes added more wall time than it saved.
     // The serial loop also yields between rows so STEP_2/blob frames
     // can land and be processed mid-walk, which is itself a win.
     const parentDirs = new Set<string>();
@@ -1749,14 +1834,12 @@ export default class SynclinePlugin extends Plugin {
       if (row.kind === "text") {
         if (!(existing instanceof TFile)) {
           try {
-            this.ignoreEvents.create.add(row.path);
+            this.markSelfWrite("create", row.path);
             await this.app.vault.create(row.path, "");
           } catch (e) {
             if (!isAlreadyExistsError(e)) {
               console.error(`[Syncline] create placeholder ${row.path}:`, e);
             }
-          } finally {
-            setTimeout(() => this.ignoreEvents.create.delete(row.path), IGNORE_CHANGES_TIMEOUT_MS);
           }
         }
         if (!this.subscribedContent.has(row.id)) {
@@ -1773,7 +1856,7 @@ export default class SynclinePlugin extends Plugin {
   private async removeLocalFile(path: string): Promise<void> {
     const file = this.app.vault.getAbstractFileByPath(path);
     if (!(file instanceof TFile)) return;
-    this.ignoreEvents.delete.add(path);
+    this.markSelfWrite("delete", path);
     try {
       await this.app.fileManager.trashFile(file);
     } catch (e) {
@@ -1781,8 +1864,6 @@ export default class SynclinePlugin extends Plugin {
       // CRDT-side removal already happened, so this is a no-op locally.
       if (isMissingFileError(e)) return;
       console.error(`[Syncline] trash ${path}:`, e);
-    } finally {
-      setTimeout(() => this.ignoreEvents.delete.delete(path), IGNORE_CHANGES_TIMEOUT_MS);
     }
   }
 
@@ -1791,8 +1872,8 @@ export default class SynclinePlugin extends Plugin {
     if (!(file instanceof TFile)) return;
     try {
       await this.ensureParentFolders(to);
-      this.ignoreEvents.rename.add(from);
-      this.ignoreEvents.rename.add(to);
+      this.markSelfWrite("rename", from);
+      this.markSelfWrite("rename", to);
       await this.app.fileManager.renameFile(file, to);
     } catch (e) {
       // Source no longer on disk (Obsidian's index hadn't caught up) —
@@ -1802,11 +1883,6 @@ export default class SynclinePlugin extends Plugin {
       // we'll converge on the next reconcile pass.
       if (isAlreadyExistsError(e)) return;
       console.error(`[Syncline] rename ${from} → ${to}:`, e);
-    } finally {
-      setTimeout(() => {
-        this.ignoreEvents.rename.delete(from);
-        this.ignoreEvents.rename.delete(to);
-      }, IGNORE_CHANGES_TIMEOUT_MS);
     }
   }
 
@@ -1895,23 +1971,21 @@ export default class SynclinePlugin extends Plugin {
           // deleted out from under us. Treat it as "needs to be (re-)
           // written" — fall through to write the CRDT content via the
           // adapter so the file is restored on disk.
-          this.ignoreEvents.modify.add(row.path);
+          this.markSelfWrite("modify", row.path);
           await this.ensureParentFolders(row.path);
           await this.app.vault.adapter.write(row.path, text);
           return;
         }
         if (current === text) return;
-        this.ignoreEvents.modify.add(row.path);
+        this.markSelfWrite("modify", row.path);
         await this.app.vault.modify(file, text);
       } catch (e) {
         console.error(`[Syncline] modify ${row.path}:`, e);
-      } finally {
-        setTimeout(() => this.ignoreEvents.modify.delete(row.path), IGNORE_CHANGES_TIMEOUT_MS);
       }
     } else {
       try {
         await this.ensureParentFolders(row.path);
-        this.ignoreEvents.create.add(row.path);
+        this.markSelfWrite("create", row.path);
         try {
           await this.app.vault.create(row.path, text);
         } catch (e) {
@@ -1924,8 +1998,6 @@ export default class SynclinePlugin extends Plugin {
         }
       } catch (e) {
         console.error(`[Syncline] create ${row.path}:`, e);
-      } finally {
-        setTimeout(() => this.ignoreEvents.create.delete(row.path), IGNORE_CHANGES_TIMEOUT_MS);
       }
     }
   }
@@ -2066,8 +2138,8 @@ export default class SynclinePlugin extends Plugin {
         bytes.byteOffset + bytes.byteLength,
       ) as ArrayBuffer;
       const file = this.app.vault.getAbstractFileByPath(row.path);
-      const kind: 'modify' | 'create' = file instanceof TFile ? 'modify' : 'create';
-      this.ignoreEvents[kind].add(row.path);
+      const kind: SelfWriteKind = file instanceof TFile ? "modify" : "create";
+      this.markSelfWrite(kind, row.path);
       try {
         if (file instanceof TFile) {
           await this.app.vault.modifyBinary(file, buffer);
@@ -2084,8 +2156,6 @@ export default class SynclinePlugin extends Plugin {
         }
       } catch (e) {
         console.error(`[Syncline] write blob → ${row.path}:`, e);
-      } finally {
-        setTimeout(() => this.ignoreEvents[kind].delete(row.path), IGNORE_CHANGES_TIMEOUT_MS);
       }
     }
   }
@@ -2096,7 +2166,7 @@ export default class SynclinePlugin extends Plugin {
 
   onFileModify = debounce(async (file: TAbstractFile) => {
     if (!(file instanceof TFile)) return;
-    if (this.ignoreEvents.modify.has(file.path)) return;
+    if (this.isSelfWriteEcho("modify", file.path)) return;
     if (!this.client) return;
 
     const row = this.lastProjection.get(file.path);
@@ -2109,7 +2179,7 @@ export default class SynclinePlugin extends Plugin {
     if (row.kind === "text") {
       try {
         const content = await this.app.vault.read(file);
-        if (this.ignoreEvents.modify.has(file.path)) return;
+        if (this.isSelfWriteEcho("modify", file.path)) return;
         const crdtContent = this.client.getContentText(row.id) ?? "";
         if (crdtContent === content) return;
         this.client.updateContentText(row.id, content);
@@ -2124,7 +2194,7 @@ export default class SynclinePlugin extends Plugin {
     } else if (row.kind === "binary") {
       try {
         const data = await this.app.vault.readBinary(file);
-        if (this.ignoreEvents.modify.has(file.path)) return;
+        if (this.isSelfWriteEcho("modify", file.path)) return;
         const hash = await sha256Hex(data);
         if (row.blob_hash === hash) return;
         this.client.sendBlob(new Uint8Array(data));
@@ -2138,7 +2208,7 @@ export default class SynclinePlugin extends Plugin {
 
   onFileCreate = (file: TAbstractFile) => {
     if (!(file instanceof TFile)) return;
-    if (this.ignoreEvents.create.has(file.path)) return;
+    if (this.isSelfWriteEcho("create", file.path)) return;
     void this.ingestNewFile(file);
   };
 
@@ -2202,7 +2272,7 @@ export default class SynclinePlugin extends Plugin {
 
   onFileDelete = (file: TAbstractFile) => {
     if (!(file instanceof TFile)) return;
-    if (this.ignoreEvents.delete.has(file.path)) return;
+    if (this.isSelfWriteEcho("delete", file.path)) return;
     if (!this.client) return;
     const row = this.lastProjection.get(file.path);
     if (!row) return;
@@ -2217,7 +2287,7 @@ export default class SynclinePlugin extends Plugin {
 
   onFileRename = (file: TAbstractFile, oldPath: string) => {
     if (!(file instanceof TFile)) return;
-    if (this.ignoreEvents.rename.has(oldPath) || this.ignoreEvents.rename.has(file.path)) return;
+    if (this.isSelfWriteEcho("rename", oldPath) || this.isSelfWriteEcho("rename", file.path)) return;
     if (!this.client) return;
     const row = this.lastProjection.get(oldPath);
     if (row) {


### PR DESCRIPTION
Closes #91.

## Why

When Syncline writes a file (`vault.modify`, `vault.adapter.writeBinary`, etc.), Obsidian's vault watcher fires an event for that path. The plugin must drop that echo, otherwise it re-reads, re-hashes, and can re-broadcast its own write.

Before this PR the suppression was per-event-kind `Set<string>` cleaned up via `setTimeout`. Two problems:
- `setTimeout` cleanup races against plugin unload (timers can fire after `disconnect()` clears unrelated state) and against successive writes to the same path (the second timer overwrites the first's window).
- The hidden-file scanner had no suppression at all — an inbound blob landing on a hidden path was immediately picked back up by the next scan tick and re-broadcast.

## What

- `selfWriteCookies` field replaces `ignoreEvents`. Same per-kind shape (`modify` / `create` / `delete` / `rename`), but values are expiry timestamps (`Date.now() + 1000ms`) instead of `Set<>` membership.
- Per-kind separation preserved so a `modify` cookie on `foo.md` doesn't drop a later user-initiated `rename` of the same path. (Issue #91 proposed a single map, but losing per-kind would silently drop user actions that happen within the suppression window after a self-write.)
- Three helpers:
  - `markSelfWrite(kind, path)` — call IMMEDIATELY before `vault.*` / `vault.adapter.*` writes.
  - `isSelfWriteEcho(kind, path)` — call at fs-event handler entry. Lazy-sweeps expired entries on read.
  - `sweepExpiredSelfWriteCookies()` — periodic full sweep, fires on the hidden-file scanner's 30 s timer. Bounds memory for cookies whose echo never lands.
- Hidden-file scanner now skips paths that are self-writes under any kind, closing the loop the cookie exists to break.
- All `setTimeout`-based cleanup removed — expiry is checked on read.

## Test

- New `e2e/test/specs/issue91.e2e.ts` pokes the helpers directly via `executeObsidian`:
  - Round-trip mark / read.
  - Per-kind isolation (`modify` cookie doesn't suppress other kinds).
  - Lazy sweep on expired read.
  - Full sweep over 1 000 entries.
  - Sweep preserves unexpired entries.
- Existing e2e tests verified locally to still pass — basic (7/7), issue56, issue57, issue58, issue63 — confirming the refactor doesn't regress real edit flows.

## Test plan

- [ ] CI green.
- [ ] Manual smoke: install on a vault, edit files in Obsidian, verify no spurious re-broadcasts in the activity feed after self-applied remote updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)