### PR TITLE
feat(plugin): relocate CRDT state cache to IndexedDB — closes #94

### DIFF
--- a/.github/workflows/plugin-id-consistency.yml
+++ b/.github/workflows/plugin-id-consistency.yml
@@ -51,10 +51,11 @@ jobs:
         run: |
           count=$(grep -c "syncline-obsidian" obsidian-plugin/main.ts || true)
           # Expected occurrences in the legacy-migration block:
-          #  1. comment in stateRoot getter
-          #  2. literal in legacyStateRoot getter
-          #  3. comment in migrateLegacyStateRoot doc-block
-          expected=3
+          #  1. literal in legacyStateRoot getter
+          #  2. comment in migrateLegacyStateRoot doc-block
+          # (#94 removed the stateRoot getter and its comment, dropping
+          #  the count from 3 to 2.)
+          expected=2
           if [ "$count" -ne "$expected" ]; then
             echo "::error::main.ts contains $count occurrences of \"syncline-obsidian\"; expected $expected."
             echo "::error::Either remove the new reference or update the expected count in this workflow."

--- a/e2e/test/specs/issue57.e2e.ts
+++ b/e2e/test/specs/issue57.e2e.ts
@@ -151,20 +151,33 @@ describe('Syncline #57 — STEP_1 dropped before WS handshake', () => {
         }, 2 * 60_000, 200);
         console.log(`[#57] phase A: initial convergence done`);
 
-        // Phase B: disconnect, then wipe vault md files + plugin v1/content/.
-        // Keep manifest.bin so the next connect()'s reconcile sees the
-        // full projection synchronously and races the WS handshake.
-        await browser.executeObsidian(async ({ app }) => {
+        // Phase B: disconnect, then wipe vault md files + plugin's
+        // per-node content snapshots from storage. Keep the manifest
+        // snapshot so the next connect()'s reconcile sees the full
+        // projection synchronously and races the WS handshake.
+        //
+        // (Pre-#94 this code wiped `${configDir}/plugins/syncline/v1/content/*.bin`
+        // directly via Node fs. After #94 the content snapshots live
+        // in IndexedDB inside the renderer; reach them through the
+        // plugin's storage abstraction.)
+        const wipeStorageResult: any = await browser.executeObsidian(async ({ app }) => {
             const plugin: any = (app as any).plugins.plugins['syncline'];
+            // Capture the manifest before disconnect so we can verify
+            // it's still in storage after the wipe.
+            const projection = plugin.client
+                ? JSON.parse(plugin.client.projectionJson())
+                : [];
+            const nodeIds: string[] = projection.map((r: any) => r.id);
             plugin.disconnect();
-        });
-
-        const stateDir = join(vaultPath, '.obsidian', 'plugins', 'syncline', 'v1');
-        if (fs.existsSync(join(stateDir, 'content'))) {
-            for (const f of fs.readdirSync(join(stateDir, 'content'))) {
-                fs.unlinkSync(join(stateDir, 'content', f));
+            for (const id of nodeIds) {
+                await plugin.storage.deleteContent(id);
             }
-        }
+            const manifestStillThere = await plugin.storage.getManifest();
+            return {
+                wiped: nodeIds.length,
+                manifestPresent: !!(manifestStillThere && manifestStillThere.length > 0),
+            };
+        });
         // Wipe vault .md / .txt files (keep dirs and dotfiles).
         function wipeFiles(dir: string) {
             for (const ent of fs.readdirSync(dir, { withFileTypes: true })) {
@@ -176,15 +189,15 @@ describe('Syncline #57 — STEP_1 dropped before WS handshake', () => {
         }
         wipeFiles(vaultPath);
 
-        // Sanity: manifest.bin still there, content/.bin gone, vault empty of .md.
-        if (!fs.existsSync(join(stateDir, 'manifest.bin'))) {
-            throw new Error('manifest.bin missing — wipe was too aggressive');
+        // Sanity: manifest snapshot still in storage, content snapshots gone, vault empty of .md.
+        if (!wipeStorageResult.manifestPresent) {
+            throw new Error('manifest snapshot missing from storage — wipe was too aggressive');
         }
         const remainingMds = [...listVault(vaultPath).keys()].filter((k) => k.endsWith('.md')).length;
         if (remainingMds !== 0) {
             throw new Error(`vault still has ${remainingMds} .md files — wipe failed`);
         }
-        console.log(`[#57] phase B: cache + vault wiped, manifest.bin retained`);
+        console.log(`[#57] phase B: ${wipeStorageResult.wiped} content snapshots + vault wiped, manifest retained`);
 
         // Drain Obsidian's vault watcher (Chokidar on Linux) before
         // we plug back in. Chokidar batches and aggregates filesystem

--- a/e2e/test/specs/issue58.e2e.ts
+++ b/e2e/test/specs/issue58.e2e.ts
@@ -167,15 +167,23 @@ describe('Syncline #58 — synthetic onFileCreate on vault load creates conflict
         console.log(`[#58] phase A: initial projection .md size = ${initialProjSize}, expected ${N_FILES}`);
         expect(initialProjSize).toBe(N_FILES);
 
-        // Phase B: disconnect, wipe manifest cache, keep vault files +
-        // content cache (Obsidian still has the TFile tree).
+        // Phase B: disconnect, wipe manifest cache from storage, keep
+        // vault files + content cache (Obsidian still has the TFile
+        // tree). Pre-#94 the manifest cache lived on disk; after #94
+        // it's in IndexedDB, so we reach it through the plugin's
+        // storage abstraction.
         await browser.executeObsidian(async ({ app }) => {
             const plugin: any = (app as any).plugins.plugins['syncline'];
             plugin.disconnect();
+            // Wipe the manifest snapshot + lamport from storage so
+            // the next connect()'s `loadManifestFromStorage` returns
+            // null and reconcile starts from empty `lastProjection`.
+            // Use setManifest with an empty bytes blob — getManifest
+            // treats zero-length as null, mirroring the pre-#94
+            // contract where `manifest.bin` not on disk meant null.
+            await plugin.storage.setManifest(new Uint8Array(0));
+            plugin.storage.setLamport(0);
         });
-        const stateDir = join(vaultPath, '.obsidian', 'plugins', 'syncline', 'v1');
-        if (fs.existsSync(join(stateDir, 'manifest.bin'))) fs.unlinkSync(join(stateDir, 'manifest.bin'));
-        if (fs.existsSync(join(stateDir, 'lamport.txt'))) fs.unlinkSync(join(stateDir, 'lamport.txt'));
         console.log(`[#58] phase B: manifest cache wiped (vault files retained)`);
 
         // Phase C: reconnect, wait for server's manifest STEP_2 to land

--- a/e2e/test/specs/issue94.e2e.ts
+++ b/e2e/test/specs/issue94.e2e.ts
@@ -1,0 +1,285 @@
+// Regression test for #94 — relocate plugin state to IndexedDB.
+//
+// Pre-#94 the plugin wrote its CRDT state cache to
+// `${configDir}/plugins/syncline/v1/{manifest.bin,lamport.txt,content/<id>.bin}`.
+// That made the state visible to the hidden-file scanner, which was
+// patched over with a self-exclusion ignore rule (Tier 1) and a
+// hash-equality write guard (Tier 1) and a self-write fs-event
+// cookie (#91). All three were band-aids.
+//
+// #94 moves the state into IndexedDB (manifest + content) and
+// localStorage (lamport, vault id) — invisible to the vault adapter
+// and therefore physically un-watchable by the scanner. Settings
+// stay in `data.json` (still expected behavior for an Obsidian
+// plugin).
+//
+// Asserts:
+//   A. Storage roundtrip: setManifest/getManifest, putContent/
+//      getContent/deleteContent, setLamport/getLamport.
+//   B. Fresh install: no on-disk state files are created during
+//      normal operation; the v1/ directory does not appear under
+//      the plugin folder.
+//   C. Migration: pre-existing on-disk state files are read into
+//      IndexedDB on plugin load and removed from disk. Idempotent
+//      (a second migration pass with no on-disk files is a no-op).
+//   D. Defense-in-depth: ingestOrSyncHiddenFile, given a path inside
+//      the plugin's own folder, refuses to upload and logs an error.
+//      (The ignore-pattern logic should keep us out of the folder
+//      entirely; this is the backup if that ever regresses.)
+
+import { spawn, ChildProcess } from 'child_process';
+import { join } from 'path';
+import * as fs from 'fs';
+import { expect, browser } from '@wdio/globals';
+
+describe('Syncline #94 — state in IndexedDB', () => {
+    const port = 3094;
+    const serverUrl = `ws://localhost:${port}/sync`;
+    const repoRoot = join(__dirname, '../../../');
+    const e2eDir = join(__dirname, '../../');
+    const dbPath = join(e2eDir, 'issue94.db');
+    const synclineBin = join(repoRoot, 'target/release/syncline');
+
+    let serverProc: ChildProcess;
+
+    async function waitFor<T>(label: string, fn: () => Promise<T | null | undefined | false | ''>, timeoutMs = 30_000, stepMs = 100): Promise<T> {
+        const deadline = Date.now() + timeoutMs;
+        while (Date.now() < deadline) {
+            try { const v = await fn(); if (v) return v as T; } catch {}
+            await new Promise((r) => setTimeout(r, stepMs));
+        }
+        throw new Error(`waitFor("${label}") timed out after ${timeoutMs}ms`);
+    }
+
+    before(async function () {
+        this.timeout(2 * 60_000);
+        if (!fs.existsSync(synclineBin)) throw new Error(`syncline binary missing at ${synclineBin}`);
+        if (fs.existsSync(dbPath)) fs.unlinkSync(dbPath);
+
+        let serverOut = '';
+        serverProc = spawn(synclineBin, ['server', '--port', String(port), '--db-path', dbPath], { stdio: 'pipe' });
+        serverProc.stdout?.on('data', (d) => { serverOut += d; });
+        serverProc.stderr?.on('data', (d) => { serverOut += d; });
+        await waitFor('server listening', async () => /listening/i.test(serverOut), 30_000, 100);
+
+        const obsidianPage = browser.getObsidianPage();
+        try { await obsidianPage.enablePlugin('syncline'); } catch {}
+        await browser.executeObsidian(async ({ app }, url) => {
+            const plugin: any = (app as any).plugins.plugins['syncline'];
+            if (!plugin) throw new Error('plugin not found');
+            plugin.settings.serverUrl = url;
+            plugin.settings.autoSync = true;
+            await plugin.saveSettings();
+            plugin.disconnect();
+            await plugin.connect();
+        }, serverUrl);
+        await waitFor('plugin connected', async () => browser.executeObsidian(async ({ app }) => {
+            const plugin: any = (app as any).plugins.plugins['syncline'];
+            return !!(plugin && plugin.client && plugin.client.isConnected());
+        }), 30_000, 100);
+    });
+
+    after(() => {
+        if (serverProc && !serverProc.killed) serverProc.kill();
+    });
+
+    it('storage roundtrip + fresh install + migration + defense-in-depth', async function () {
+        this.timeout(2 * 60_000);
+
+        // --------------------------------------------------------------
+        // Phase A — storage roundtrip
+        // --------------------------------------------------------------
+        const phaseA: any = await browser.executeObsidian(async ({ app }) => {
+            const plugin: any = (app as any).plugins.plugins['syncline'];
+
+            // Manifest
+            const m1 = new Uint8Array([1, 2, 3, 4, 5]);
+            await plugin.storage.setManifest(m1);
+            const m1Back = await plugin.storage.getManifest();
+
+            // Content
+            await plugin.storage.putContent('test-node', new Uint8Array([9, 8, 7]));
+            const c1 = await plugin.storage.getContent('test-node');
+            await plugin.storage.deleteContent('test-node');
+            const c2 = await plugin.storage.getContent('test-node');
+
+            // Lamport
+            plugin.storage.setLamport(42);
+            const lamp = plugin.storage.getLamport();
+
+            return {
+                manifestEqual:
+                    !!m1Back &&
+                    m1Back.length === m1.length &&
+                    m1Back.every((b: number, i: number) => b === m1[i]),
+                contentRoundtripped:
+                    !!c1 && c1.length === 3 && c1[0] === 9 && c1[1] === 8 && c1[2] === 7,
+                contentDeleted: c2 === null,
+                lamport: lamp,
+            };
+        });
+        expect(phaseA.manifestEqual).toBe(true);
+        expect(phaseA.contentRoundtripped).toBe(true);
+        expect(phaseA.contentDeleted).toBe(true);
+        expect(phaseA.lamport).toBe(42);
+        console.log('[#94] phase A: storage roundtrip ok');
+
+        // --------------------------------------------------------------
+        // Phase B — fresh install: no on-disk state files
+        //   The plugin has been running. Confirm the on-disk v1/ root
+        //   was never created (or has been migrated away).
+        // --------------------------------------------------------------
+        const phaseB: any = await browser.executeObsidian(async ({ app }) => {
+            const plugin: any = (app as any).plugins.plugins['syncline'];
+            const adapter = (app as any).vault.adapter;
+            const cd = (app as any).vault.configDir;
+            const v1Root = `${cd}/plugins/${plugin.manifest.id}/v1`;
+            const manifestPath = `${v1Root}/manifest.bin`;
+            const lamportPath = `${v1Root}/lamport.txt`;
+            const contentDir = `${v1Root}/content`;
+            return {
+                v1Exists: await adapter.exists(v1Root),
+                manifestOnDisk: await adapter.exists(manifestPath),
+                lamportOnDisk: await adapter.exists(lamportPath),
+                contentDirOnDisk: await adapter.exists(contentDir),
+            };
+        });
+        expect(phaseB.v1Exists).toBe(false);
+        expect(phaseB.manifestOnDisk).toBe(false);
+        expect(phaseB.lamportOnDisk).toBe(false);
+        expect(phaseB.contentDirOnDisk).toBe(false);
+        console.log('[#94] phase B: no on-disk state files for a fresh install');
+
+        // --------------------------------------------------------------
+        // Phase C — migration: write fake on-disk state files, run the
+        //   migration directly, confirm files end up in IndexedDB and
+        //   on-disk artifacts are removed.
+        // --------------------------------------------------------------
+        const phaseC: any = await browser.executeObsidian(async ({ app }) => {
+            const plugin: any = (app as any).plugins.plugins['syncline'];
+            const adapter = (app as any).vault.adapter;
+            const cd = (app as any).vault.configDir;
+            const v1Root = `${cd}/plugins/${plugin.manifest.id}/v1`;
+            const manifestPath = `${v1Root}/manifest.bin`;
+            const lamportPath = `${v1Root}/lamport.txt`;
+            const contentDir = `${v1Root}/content`;
+            const contentFile = `${contentDir}/legacy-node.bin`;
+
+            // Save current storage state so we can restore at the end.
+            const savedManifest = await plugin.storage.getManifest();
+            const savedLamport = plugin.storage.getLamport();
+            // Wipe storage to give the migration a clean target.
+            await plugin.storage.setManifest(new Uint8Array(0));
+            plugin.storage.setLamport(0);
+
+            // Plant fake on-disk state.
+            await adapter.mkdir(v1Root);
+            await adapter.mkdir(contentDir);
+            const manifestBytes = new Uint8Array([10, 20, 30, 40, 50]);
+            await adapter.writeBinary(
+                manifestPath,
+                manifestBytes.buffer.slice(0) as ArrayBuffer,
+            );
+            await adapter.write(lamportPath, '7');
+            const contentBytes = new Uint8Array([100, 101, 102]);
+            await adapter.writeBinary(
+                contentFile,
+                contentBytes.buffer.slice(0) as ArrayBuffer,
+            );
+
+            // Run the migration directly.
+            await plugin.migrateOnDiskStateToIndexedDB();
+
+            const result = {
+                manifestInStorage: await plugin.storage.getManifest(),
+                lamportInStorage: plugin.storage.getLamport(),
+                legacyContentInStorage: await plugin.storage.getContent('legacy-node'),
+                manifestPathStillOnDisk: await adapter.exists(manifestPath),
+                lamportPathStillOnDisk: await adapter.exists(lamportPath),
+                contentFileStillOnDisk: await adapter.exists(contentFile),
+                v1RootStillOnDisk: await adapter.exists(v1Root),
+            };
+
+            // Idempotency check: a second migration should be a no-op.
+            await plugin.migrateOnDiskStateToIndexedDB();
+
+            // Restore prior storage state for subsequent phases /
+            // tests. Don't restore on-disk files — the migration
+            // already cleaned them up and that's the correct end
+            // state.
+            if (savedManifest && savedManifest.length > 0) {
+                await plugin.storage.setManifest(savedManifest);
+            }
+            plugin.storage.setLamport(savedLamport);
+            await plugin.storage.deleteContent('legacy-node');
+
+            return {
+                manifestMigrated:
+                    !!result.manifestInStorage &&
+                    result.manifestInStorage.length === 5 &&
+                    result.manifestInStorage[0] === 10 &&
+                    result.manifestInStorage[4] === 50,
+                lamportMigrated: result.lamportInStorage === 7,
+                contentMigrated:
+                    !!result.legacyContentInStorage &&
+                    result.legacyContentInStorage.length === 3 &&
+                    result.legacyContentInStorage[0] === 100,
+                manifestPathRemoved: !result.manifestPathStillOnDisk,
+                lamportPathRemoved: !result.lamportPathStillOnDisk,
+                contentFileRemoved: !result.contentFileStillOnDisk,
+                v1RootRemoved: !result.v1RootStillOnDisk,
+            };
+        });
+        expect(phaseC.manifestMigrated).toBe(true);
+        expect(phaseC.lamportMigrated).toBe(true);
+        expect(phaseC.contentMigrated).toBe(true);
+        expect(phaseC.manifestPathRemoved).toBe(true);
+        expect(phaseC.lamportPathRemoved).toBe(true);
+        expect(phaseC.contentFileRemoved).toBe(true);
+        expect(phaseC.v1RootRemoved).toBe(true);
+        console.log('[#94] phase C: on-disk state migrated to IndexedDB; on-disk artifacts removed');
+
+        // --------------------------------------------------------------
+        // Phase D — defense-in-depth: if a path under our own plugin
+        //   folder ever reaches `ingestOrSyncHiddenFile`, the call
+        //   refuses to upload and logs an error rather than looping.
+        //
+        //   Triggers normally don't reach this branch because the
+        //   ignore-pattern logic in `scanHiddenFiles` filters our own
+        //   folder out. We invoke directly to test the safety net.
+        // --------------------------------------------------------------
+        const phaseD: any = await browser.executeObsidian(async ({ app }) => {
+            const plugin: any = (app as any).plugins.plugins['syncline'];
+            const cd = (app as any).vault.configDir;
+            const ownPath = `${cd}/plugins/${plugin.manifest.id}/data.json`;
+
+            // Capture console.error output during the call.
+            const errors: string[] = [];
+            const origError = console.error;
+            console.error = (...args: unknown[]) => {
+                errors.push(args.map((a) => String(a)).join(' '));
+            };
+            try {
+                await plugin.ingestOrSyncHiddenFile(ownPath);
+            } finally {
+                console.error = origError;
+            }
+
+            const adapter = (app as any).vault.adapter;
+            const manifestEntries = JSON.parse(
+                plugin.client.projectionJson(),
+            );
+            return {
+                hadOwnPathError: errors.some((e) => e.includes('own plugin folder')),
+                ownPathInProjection: manifestEntries.some(
+                    (r: any) => r.path === ownPath,
+                ),
+                ownPathOnDisk: await adapter.exists(ownPath), // settings exist
+            };
+        });
+        expect(phaseD.hadOwnPathError).toBe(true);
+        expect(phaseD.ownPathInProjection).toBe(false); // never uploaded
+        expect(phaseD.ownPathOnDisk).toBe(true); // settings file untouched
+        console.log('[#94] phase D: ingest of own plugin path refused + error logged');
+    });
+});

--- a/obsidian-plugin/main.ts
+++ b/obsidian-plugin/main.ts
@@ -13,6 +13,11 @@ import {
 // @ts-ignore - rollup base64-inlines the .wasm binary at build time.
 import wasmBinary from "./wasm/syncline_bg.wasm";
 import * as wasmModule from "./wasm/syncline.js";
+import {
+  IndexedDBSynclineStorage,
+  SynclineStorage,
+  getOrMintVaultId,
+} from "./storage";
 
 // ---------------------------------------------------------------------------
 // Settings & persistence layout
@@ -878,6 +883,12 @@ export default class SynclinePlugin extends Plugin {
   reconnectTimeout: number | null = null;
   reconnectAttempts = 0;
 
+  /** IndexedDB-backed CRDT state cache. Replaces the on-disk
+   *  persistence under `${configDir}/plugins/syncline/v1/` so the
+   *  hidden-file scanner cannot observe (and therefore can't echo /
+   *  re-broadcast) the plugin's own state. Created in `onload`. */
+  storage!: SynclineStorage;
+
   // ---------------------------------------------------------------
   // Lifecycle
   // ---------------------------------------------------------------
@@ -885,7 +896,12 @@ export default class SynclinePlugin extends Plugin {
   async onload() {
     console.debug("[Syncline] Loading plugin (v1)…");
     await this.loadSettings();
+    this.storage = new IndexedDBSynclineStorage(
+      this.app,
+      getOrMintVaultId(this.app),
+    );
     await this.migrateLegacyStateRoot();
+    await this.migrateOnDiskStateToIndexedDB();
     this.addSettingTab(new SynclineSettingTab(this.app, this));
 
     this.statusBarItem = this.addStatusBarItem();
@@ -1081,36 +1097,19 @@ export default class SynclinePlugin extends Plugin {
   // On-disk persistence for CRDT state
   // ---------------------------------------------------------------
 
-  /** Root folder for v1 CRDT snapshots — separate from any v0 leftovers. */
-  private get stateRoot(): string {
-    // Use the plugin's own manifest id rather than a literal so this never
-    // drifts again. Pre-1.1.6 installs wrote state under "syncline-obsidian";
-    // migrateLegacyStateRoot() handles the relocation on first load.
-    return `${this.app.vault.configDir}/plugins/${this.manifest.id}/v1`;
-  }
-  /** Pre-1.1.6 state-root path. Only consulted by migrateLegacyStateRoot(). */
+  /** Pre-1.1.6 state-root path. Only consulted by
+   *  migrateLegacyStateRoot() during the on-disk era; #94 has since
+   *  moved everything off disk, so this is dead-letter except for
+   *  cleanup of leftover legacy directories. */
   private get legacyStateRoot(): string {
     return `${this.app.vault.configDir}/plugins/syncline-obsidian/v1`;
   }
-  private get manifestPath(): string {
-    return `${this.stateRoot}/manifest.bin`;
-  }
-  private get lamportPath(): string {
-    return `${this.stateRoot}/lamport.txt`;
-  }
-  private contentPath(nodeId: string): string {
-    return `${this.stateRoot}/content/${nodeId}.bin`;
-  }
-
-  private async ensureStateRoot(): Promise<void> {
-    const adapter = this.app.vault.adapter;
-    if (!(await adapter.exists(this.stateRoot))) {
-      await adapter.mkdir(this.stateRoot);
-    }
-    const contentDir = `${this.stateRoot}/content`;
-    if (!(await adapter.exists(contentDir))) {
-      await adapter.mkdir(contentDir);
-    }
+  /** Pre-#94 state-root: where the plugin used to keep its CRDT
+   *  snapshots before they moved to IndexedDB. Only consulted by
+   *  `migrateOnDiskStateToIndexedDB()` to find leftover files to
+   *  copy over and delete. */
+  private get preIndexedDBStateRoot(): string {
+    return `${this.app.vault.configDir}/plugins/${this.manifest.id}/v1`;
   }
 
   /**
@@ -1130,7 +1129,7 @@ export default class SynclinePlugin extends Plugin {
   private async migrateLegacyStateRoot(): Promise<void> {
     const adapter = this.app.vault.adapter;
     const legacy = this.legacyStateRoot;
-    const target = this.stateRoot;
+    const target = this.preIndexedDBStateRoot;
 
     // If the manifest id ever happens to equal the legacy literal (e.g. a
     // future revert), legacy === target and there's nothing to migrate.
@@ -1189,19 +1188,110 @@ export default class SynclinePlugin extends Plugin {
     }
   }
 
-  private async loadManifestFromDisk(): Promise<{ state: Uint8Array; lamport: number } | null> {
+  /**
+   * One-time migration from the on-disk state cache (pre-#94) to
+   * IndexedDB. Reads any leftover files under
+   * `${configDir}/plugins/<id>/v1/`, copies them into the storage
+   * abstraction, and removes the on-disk artifacts. Idempotent: a
+   * second run finds nothing to migrate and is a no-op.
+   *
+   * Runs in `onload` after `migrateLegacyStateRoot()` consolidates
+   * pre-1.1.6 paths, so we only need to handle the single
+   * `preIndexedDBStateRoot` location.
+   */
+  private async migrateOnDiskStateToIndexedDB(): Promise<void> {
     const adapter = this.app.vault.adapter;
-    if (!(await adapter.exists(this.manifestPath))) return null;
+    const root = this.preIndexedDBStateRoot;
+    let exists = false;
     try {
-      const state = new Uint8Array(await adapter.readBinary(this.manifestPath));
-      let lamport = 0;
-      if (await adapter.exists(this.lamportPath)) {
-        const txt = await adapter.read(this.lamportPath);
-        lamport = Number.parseInt(txt.trim(), 10) || 0;
-      }
-      return { state, lamport };
+      exists = await adapter.exists(root);
     } catch (e) {
-      console.error("[Syncline] Failed to load manifest from disk:", e);
+      console.error("[Syncline] migrateOnDisk: stat failed:", e);
+      return;
+    }
+    if (!exists) return;
+
+    let migratedAny = false;
+
+    // Manifest + lamport.
+    const manifestPath = `${root}/manifest.bin`;
+    const lamportPath = `${root}/lamport.txt`;
+    try {
+      if (await adapter.exists(manifestPath)) {
+        const bytes = new Uint8Array(await adapter.readBinary(manifestPath));
+        if (bytes.length > 0) {
+          await this.storage.setManifest(bytes);
+          migratedAny = true;
+        }
+        await adapter.remove(manifestPath);
+      }
+      if (await adapter.exists(lamportPath)) {
+        const txt = await adapter.read(lamportPath);
+        const n = Number.parseInt(txt.trim(), 10);
+        if (Number.isFinite(n)) {
+          this.storage.setLamport(n);
+          migratedAny = true;
+        }
+        await adapter.remove(lamportPath);
+      }
+    } catch (e) {
+      console.error("[Syncline] migrateOnDisk: manifest/lamport failed:", e);
+    }
+
+    // Content blobs.
+    const contentDir = `${root}/content`;
+    try {
+      if (await adapter.exists(contentDir)) {
+        const listing = await adapter.list(contentDir);
+        for (const file of listing.files) {
+          const name = file.split("/").pop() ?? "";
+          if (!name.endsWith(".bin")) continue;
+          const nodeId = name.slice(0, -4);
+          try {
+            const bytes = new Uint8Array(await adapter.readBinary(file));
+            await this.storage.putContent(nodeId, bytes);
+            await adapter.remove(file);
+            migratedAny = true;
+          } catch (e) {
+            console.error(`[Syncline] migrateOnDisk: content ${file}:`, e);
+          }
+        }
+        try {
+          await adapter.rmdir(contentDir, false);
+        } catch {
+          // Non-empty (residual files we couldn't migrate) or already
+          // gone — either way, leave as-is.
+        }
+      }
+    } catch (e) {
+      console.error("[Syncline] migrateOnDisk: content dir failed:", e);
+    }
+
+    // Empty state root → remove. If still has stragglers, leave it
+    // (the user / a future migration pass can deal with it).
+    try {
+      const post = await adapter.list(root);
+      if (post.files.length === 0 && post.folders.length === 0) {
+        await adapter.rmdir(root, false);
+      }
+    } catch {
+      // tolerated
+    }
+
+    if (migratedAny) {
+      console.debug(
+        "[Syncline] Migrated on-disk CRDT state cache → IndexedDB.",
+      );
+    }
+  }
+
+  private async loadManifestFromStorage(): Promise<{ state: Uint8Array; lamport: number } | null> {
+    try {
+      const state = await this.storage.getManifest();
+      if (!state || state.length === 0) return null;
+      return { state, lamport: this.storage.getLamport() };
+    } catch (e) {
+      console.error("[Syncline] Failed to load manifest from storage:", e);
       return null;
     }
   }
@@ -1209,17 +1299,21 @@ export default class SynclinePlugin extends Plugin {
   private async persistManifest(): Promise<void> {
     if (!this.client) return;
     try {
-      await this.ensureStateRoot();
       const snap = this.client.manifestSnapshot();
       // Zero-length means uninitialised — don't clobber.
       if (!snap || snap.length === 0) return;
-      const buffer = snap.buffer.slice(
-        snap.byteOffset,
-        snap.byteOffset + snap.byteLength,
-      ) as ArrayBuffer;
-      await this.app.vault.adapter.writeBinary(this.manifestPath, buffer);
-      const lamport = String(this.client.lamport());
-      await this.app.vault.adapter.write(this.lamportPath, lamport);
+      // Copy into a plain Uint8Array detached from the WASM heap.
+      // IndexedDB structured-clones the value before storing it, but
+      // the WASM-backed view becomes invalid the moment the WASM
+      // module reallocates its memory; copying first guarantees the
+      // bytes survive the next allocation.
+      const detached = new Uint8Array(snap.length);
+      detached.set(snap);
+      await this.storage.setManifest(detached);
+      // The wasm-bindgen binding for u64 surfaces as bigint at
+      // runtime even though the .d.ts declares `number`. Coerce
+      // explicitly so the storage layer always sees a JS number.
+      this.storage.setLamport(Number(this.client.lamport()));
     } catch (e) {
       console.error("[Syncline] Failed to persist manifest:", e);
     }
@@ -1228,15 +1322,9 @@ export default class SynclinePlugin extends Plugin {
   private persistManifestDebounced = debounce(() => void this.persistManifest(), 500, false);
 
   private async loadContentState(nodeId: string): Promise<Uint8Array | null> {
-    const adapter = this.app.vault.adapter;
-    const p = this.contentPath(nodeId);
-    if (!(await adapter.exists(p))) return null;
     try {
-      return new Uint8Array(await adapter.readBinary(p));
+      return await this.storage.getContent(nodeId);
     } catch (e) {
-      // exists() returned true but read raced with a concurrent
-      // removeContentState — treat as "no state" and move on.
-      if (isMissingFileError(e)) return null;
       console.error(`[Syncline] Failed to load content state ${nodeId}:`, e);
       return null;
     }
@@ -1245,30 +1333,21 @@ export default class SynclinePlugin extends Plugin {
   private async persistContentState(nodeId: string): Promise<void> {
     if (!this.client) return;
     try {
-      await this.ensureStateRoot();
       const snap = this.client.contentSnapshot(nodeId);
       if (!snap) return;
-      const buffer = snap.buffer.slice(
-        snap.byteOffset,
-        snap.byteOffset + snap.byteLength,
-      ) as ArrayBuffer;
-      await this.app.vault.adapter.writeBinary(this.contentPath(nodeId), buffer);
+      const detached = new Uint8Array(snap.length);
+      detached.set(snap);
+      await this.storage.putContent(nodeId, detached);
     } catch (e) {
       console.error(`[Syncline] Failed to persist content ${nodeId}:`, e);
     }
   }
 
   private async removeContentState(nodeId: string): Promise<void> {
-    const adapter = this.app.vault.adapter;
-    const p = this.contentPath(nodeId);
-    if (await adapter.exists(p)) {
-      try {
-        await adapter.remove(p);
-      } catch (e) {
-        // Concurrent remove already cleaned this up — that's fine.
-        if (isMissingFileError(e)) return;
-        console.error(`[Syncline] Failed to remove content state ${nodeId}:`, e);
-      }
+    try {
+      await this.storage.deleteContent(nodeId);
+    } catch (e) {
+      console.error(`[Syncline] Failed to remove content state ${nodeId}:`, e);
     }
   }
 
@@ -1409,8 +1488,7 @@ export default class SynclinePlugin extends Plugin {
         await this.saveSettings();
       }
 
-      await this.ensureStateRoot();
-      const persisted = await this.loadManifestFromDisk();
+      const persisted = await this.loadManifestFromStorage();
       if (persisted) {
         this.client.loadManifestState(persisted.state, persisted.lamport);
       } else {
@@ -1841,14 +1919,16 @@ export default class SynclinePlugin extends Plugin {
    *  from PR #40 — keep the two lists in lockstep or peers diverge
    *  on what does and doesn't sync.
    *
-   *  Self-exclusion of `${cd}/plugins/${manifest.id}/` is critical:
-   *  the plugin stores its CRDT manifest, lamport counter, and
-   *  content blobs under that directory. Letting the scanner upload
-   *  them would (a) feedback-loop: write → scanner → upload →
-   *  broadcast → write, and (b) corrupt peers' manifest views by
-   *  treating one device's CRDT state as vault content. Same
-   *  precedent as LiveSync's hard-coded `/obsidian-livesync/` in
-   *  `syncInternalFilesIgnorePatterns`. */
+   *  Self-exclusion of `${cd}/plugins/${manifest.id}/` covers two
+   *  things: (1) our own `data.json` settings, which contain device-
+   *  local state (actorId, server URL); (2) defense-in-depth for the
+   *  CRDT state cache, which since #94 lives in IndexedDB and is no
+   *  longer observable to the scanner — but if a future change ever
+   *  reintroduces an on-disk artifact under this dir, this rule
+   *  prevents an immediate self-sync loop. The
+   *  `ingestOrSyncHiddenFile` call site logs an error when this rule
+   *  is bypassed (the only way a path under our dir reaches it is via
+   *  a bug). */
   private hiddenIgnorePatterns(): string[] {
     const cd = this.app.vault.configDir;
     return [
@@ -1861,6 +1941,16 @@ export default class SynclinePlugin extends Plugin {
       `${cd}/cache/`,
       `${cd}/graph.json`,
     ];
+  }
+
+  /** True iff `path` lives inside this plugin's own folder. Used by
+   *  `ingestOrSyncHiddenFile` as a defense-in-depth check — the
+   *  ignore-pattern logic should keep us out, but if a regression
+   *  ever lets a path under our own folder slip through to the
+   *  ingest step, we want a loud error rather than a silent loop. */
+  private isOwnPluginPath(path: string): boolean {
+    const ownRoot = `${this.app.vault.configDir}/plugins/${this.manifest.id}`;
+    return path === ownRoot || path.startsWith(ownRoot + "/");
   }
 
   private isHiddenIgnored(rel: string): boolean {
@@ -2032,6 +2122,20 @@ export default class SynclinePlugin extends Plugin {
    *    via `recordModifyBinary`. */
   private async ingestOrSyncHiddenFile(path: string): Promise<void> {
     if (!this.client) return;
+    if (this.isOwnPluginPath(path)) {
+      // Should be unreachable: the ignore patterns in
+      // `hiddenIgnorePatterns` keep our own folder out of the
+      // scanner's `seen` list. Reaching this branch means the
+      // ignore logic regressed. Don't actually ingest — that would
+      // re-introduce the loop the IndexedDB relocation eliminated —
+      // and shout loudly so the regression gets noticed.
+      console.error(
+        `[Syncline] BUG: ingestOrSyncHiddenFile reached own plugin folder (${path}). ` +
+          "The hidden-file scanner's ignore rule should have filtered this out. " +
+          "Refusing to upload — please file an issue with reproduction steps.",
+      );
+      return;
+    }
     const adapter = this.app.vault.adapter;
     let data: ArrayBuffer;
     try {

--- a/obsidian-plugin/storage.ts
+++ b/obsidian-plugin/storage.ts
@@ -1,0 +1,238 @@
+// Storage abstraction for Syncline's CRDT state.
+//
+// The plugin used to write its state into the vault's hidden config
+// folder (`${configDir}/plugins/syncline/v1/manifest.bin` etc.). That
+// made the state visible to the hidden-file scanner introduced in
+// PR #89, requiring a self-exclusion ignore rule and a hash-equality
+// guard to prevent the plugin from re-uploading its own state in a
+// loop. Both were band-aids: the state remained physically observable.
+//
+// This module relocates the bulk of the state into IndexedDB, where
+// the watcher can't see it at all. LiveSync uses the same approach
+// (via PouchDB → IndexedDB). Cross-platform: works on desktop, iOS,
+// and Android.
+//
+// Layout:
+//
+//   IndexedDB ("syncline-<vaultId>")
+//     ├── store "manifest" — key "current"  → Uint8Array
+//     └── store "content"  — key <nodeId>   → Uint8Array
+//
+//   localStorage (per-vault via app.saveLocalStorage)
+//     ├── "syncline:vault-id"  → string (UUID, minted on first run)
+//     └── "syncline:lamport"   → number
+//
+//   ${configDir}/plugins/syncline/data.json
+//     → plugin settings (server URL, actorId, configSync flags)
+//
+// Settings stay on disk so they remain inspectable by the user and
+// reachable by Obsidian's standard `Plugin.loadData` / `saveData`.
+// Everything else is invisible to the vault adapter.
+
+import type { App } from "obsidian";
+
+const SCHEMA_VERSION = 1;
+const MANIFEST_STORE = "manifest";
+const CONTENT_STORE = "content";
+const MANIFEST_KEY = "current";
+
+export const VAULT_ID_LS_KEY = "syncline:vault-id";
+export const LAMPORT_LS_KEY = "syncline:lamport";
+
+/**
+ * Stable per-vault id used to namespace the IndexedDB database name.
+ *
+ * `app.loadLocalStorage` / `saveLocalStorage` are themselves scoped
+ * per-vault by Obsidian, so a UUID stored under those keys is
+ * naturally isolated. Generated on first access if absent.
+ *
+ * Why not `app.appId`? It's an undocumented private field — present
+ * today but no API guarantee. A self-managed UUID is bulletproof.
+ */
+export function getOrMintVaultId(app: App): string {
+  const existing: unknown = app.loadLocalStorage(VAULT_ID_LS_KEY);
+  if (typeof existing === "string" && existing.length > 0) return existing;
+  const fresh =
+    typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+      ? crypto.randomUUID()
+      : `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+  app.saveLocalStorage(VAULT_ID_LS_KEY, fresh);
+  return fresh;
+}
+
+/**
+ * Storage interface — narrow surface so callers don't depend on the
+ * IndexedDB specifics. Manifest and lamport are conceptually a pair
+ * (lamport tracks the most recent op in the manifest), but are stored
+ * separately because IndexedDB is the right place for opaque bytes
+ * and localStorage is the right place for tiny scalars. A small
+ * inconsistency window between the two writes is tolerable: lamport
+ * only gates an optimization (skipping a Step1 sync) and the manifest
+ * itself carries enough state to rebuild from.
+ */
+export interface SynclineStorage {
+  /** Most recent persisted manifest snapshot, or null if none yet. */
+  getManifest(): Promise<Uint8Array | null>;
+  /** Replace the manifest snapshot. */
+  setManifest(bytes: Uint8Array): Promise<void>;
+
+  /** Last persisted lamport counter, or 0 if none. */
+  getLamport(): number;
+  /** Replace the lamport counter. */
+  setLamport(n: number): void;
+
+  /** Per-nodeId content subdoc snapshot, or null if absent. */
+  getContent(nodeId: string): Promise<Uint8Array | null>;
+  /** Replace the content snapshot for a node. */
+  putContent(nodeId: string, bytes: Uint8Array): Promise<void>;
+  /** Remove a content snapshot. Idempotent. */
+  deleteContent(nodeId: string): Promise<void>;
+
+  /** Used by the migration code to wipe everything for a clean restart. */
+  reset(): Promise<void>;
+}
+
+/**
+ * IndexedDB-backed `SynclineStorage`. Manifest and content blobs go
+ * into IndexedDB; lamport counter goes into localStorage via the App
+ * helpers. Cross-platform — works on desktop Electron, iOS, and
+ * Android, all of which expose IndexedDB through the standard
+ * `globalThis.indexedDB`.
+ */
+export class IndexedDBSynclineStorage implements SynclineStorage {
+  private readonly dbName: string;
+  private readonly app: App;
+  private dbPromise: Promise<IDBDatabase> | null = null;
+
+  constructor(app: App, vaultId: string) {
+    this.app = app;
+    // Suffix with vault id so multiple vaults on the same machine
+    // (sharing a single Obsidian process on mobile, or separate
+    // BrowserWindows on desktop) don't collide.
+    this.dbName = `syncline-${vaultId}`;
+  }
+
+  /** Lazily open the database. Repeated callers share the connection. */
+  private openDB(): Promise<IDBDatabase> {
+    if (this.dbPromise) return this.dbPromise;
+    this.dbPromise = new Promise<IDBDatabase>((resolve, reject) => {
+      const req = indexedDB.open(this.dbName, SCHEMA_VERSION);
+      req.onupgradeneeded = () => {
+        const db = req.result;
+        if (!db.objectStoreNames.contains(MANIFEST_STORE)) {
+          db.createObjectStore(MANIFEST_STORE);
+        }
+        if (!db.objectStoreNames.contains(CONTENT_STORE)) {
+          db.createObjectStore(CONTENT_STORE);
+        }
+      };
+      req.onsuccess = () => {
+        const db = req.result;
+        // Drop the cached promise on close so a subsequent call
+        // re-opens cleanly. Fires on browser tab close, IndexedDB
+        // version-change events, etc.
+        db.onclose = () => {
+          this.dbPromise = null;
+        };
+        db.onversionchange = () => {
+          db.close();
+          this.dbPromise = null;
+        };
+        resolve(db);
+      };
+      req.onerror = () => reject(req.error ?? new Error("indexedDB request failed"));
+      req.onblocked = () =>
+        reject(new Error(`IndexedDB upgrade blocked for ${this.dbName}`));
+    });
+    return this.dbPromise;
+  }
+
+  private async getValue<T>(
+    store: string,
+    key: string,
+  ): Promise<T | null> {
+    const db = await this.openDB();
+    return new Promise<T | null>((resolve, reject) => {
+      const tx = db.transaction(store, "readonly");
+      const req = tx.objectStore(store).get(key);
+      req.onsuccess = () => resolve((req.result as T | undefined) ?? null);
+      req.onerror = () => reject(req.error ?? new Error("indexedDB request failed"));
+    });
+  }
+
+  private async putValue(
+    store: string,
+    key: string,
+    value: unknown,
+  ): Promise<void> {
+    const db = await this.openDB();
+    return new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(store, "readwrite");
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error ?? new Error("indexedDB transaction failed"));
+      tx.onabort = () =>
+        reject(tx.error || new Error("transaction aborted"));
+      tx.objectStore(store).put(value, key);
+    });
+  }
+
+  private async deleteValue(store: string, key: string): Promise<void> {
+    const db = await this.openDB();
+    return new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(store, "readwrite");
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error ?? new Error("indexedDB transaction failed"));
+      tx.onabort = () =>
+        reject(tx.error || new Error("transaction aborted"));
+      tx.objectStore(store).delete(key);
+    });
+  }
+
+  async getManifest(): Promise<Uint8Array | null> {
+    return this.getValue<Uint8Array>(MANIFEST_STORE, MANIFEST_KEY);
+  }
+
+  async setManifest(bytes: Uint8Array): Promise<void> {
+    return this.putValue(MANIFEST_STORE, MANIFEST_KEY, bytes);
+  }
+
+  getLamport(): number {
+    const raw: unknown = this.app.loadLocalStorage(LAMPORT_LS_KEY);
+    if (typeof raw === "number" && Number.isFinite(raw)) return raw;
+    if (typeof raw === "string") {
+      const n = Number.parseInt(raw, 10);
+      return Number.isFinite(n) ? n : 0;
+    }
+    return 0;
+  }
+
+  setLamport(n: number): void {
+    this.app.saveLocalStorage(LAMPORT_LS_KEY, n);
+  }
+
+  async getContent(nodeId: string): Promise<Uint8Array | null> {
+    return this.getValue<Uint8Array>(CONTENT_STORE, nodeId);
+  }
+
+  async putContent(nodeId: string, bytes: Uint8Array): Promise<void> {
+    return this.putValue(CONTENT_STORE, nodeId, bytes);
+  }
+
+  async deleteContent(nodeId: string): Promise<void> {
+    return this.deleteValue(CONTENT_STORE, nodeId);
+  }
+
+  async reset(): Promise<void> {
+    const db = await this.openDB();
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction([MANIFEST_STORE, CONTENT_STORE], "readwrite");
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error ?? new Error("indexedDB transaction failed"));
+      tx.onabort = () =>
+        reject(tx.error || new Error("transaction aborted"));
+      tx.objectStore(MANIFEST_STORE).clear();
+      tx.objectStore(CONTENT_STORE).clear();
+    });
+    this.app.saveLocalStorage(LAMPORT_LS_KEY, null);
+  }
+}


### PR DESCRIPTION
Closes #94. Will rebase onto main once #104 (#93) merges; the two PRs are mostly orthogonal but both touch \`main.ts\`.

## Why

Pre-#94 the plugin wrote its CRDT state cache to \`\${configDir}/plugins/syncline/v1/{manifest.bin,lamport.txt,content/<id>.bin}\`. That made the state visible to the vault adapter and therefore to the hidden-file scanner introduced in PR #89 — which we patched over with a self-exclusion ignore rule (Tier 1), a hash-equality write guard (Tier 1), and a self-write fs-event cookie (#91). All three were band-aids; the state remained physically observable, and any future code path that walked \`\${configDir}\` was one bug away from re-introducing the loop.

This PR puts the bulk of the state somewhere the watcher cannot see: IndexedDB. Same approach LiveSync takes (via PouchDB → IndexedDB). Cross-platform: works on desktop Electron, iOS, and Android.

## Layout

\`\`\`
IndexedDB ("syncline-<vaultId>")
  ├── store "manifest" — key "current"  → Uint8Array
  └── store "content"  — key <nodeId>   → Uint8Array

localStorage (per-vault via app.saveLocalStorage)
  ├── "syncline:vault-id"  → string (UUID, minted on first run)
  └── "syncline:lamport"   → number

\${configDir}/plugins/syncline/data.json
  → plugin settings (server URL, actorId, configSync flags)
\`\`\`

Settings stay on disk so they remain inspectable by the user and reachable via the standard \`Plugin.loadData/saveData\`. Everything else is invisible to the vault adapter.

## What

- New \`obsidian-plugin/storage.ts\` with the \`SynclineStorage\` interface + \`IndexedDBSynclineStorage\`. Lazy \`openDB()\`, drops the cached connection on \`onclose\`/\`onversionchange\` so the next call re-opens cleanly.
- All persistence call sites in \`main.ts\` rewritten to delegate to \`this.storage\`: \`loadManifestFromStorage\`, \`persistManifest\`, \`loadContentState\`, \`persistContentState\`, \`removeContentState\`. Removed \`ensureStateRoot\` and the path getters.
- One-time \`migrateOnDiskStateToIndexedDB\` runs in \`onload\` after the existing \`migrateLegacyStateRoot()\`. Copies leftover \`manifest.bin\` / \`lamport.txt\` / \`content/*.bin\` into IndexedDB and removes the on-disk artifacts. Idempotent.
- Manifest bytes copied off the WASM heap before the IDB write. The structured-clone happens later on the IDB side, but the WASM-backed \`Uint8Array\` view becomes invalid the moment WASM reallocates its memory.
- The Tier-1 self-exclusion ignore rule (\`\${configDir}/plugins/\${manifest.id}/\`) is kept — it now protects \`data.json\` (settings) rather than the CRDT cache. Added a **defense-in-depth check** in \`ingestOrSyncHiddenFile\` that logs a loud error and refuses to upload if a path under our own folder ever reaches it (would indicate a regression in the ignore logic; fail loudly rather than loop).

## Test

New \`e2e/test/specs/issue94.e2e.ts\`, 4 phases:

| Phase | Asserts |
|---|---|
| A | Storage roundtrip: manifest, content (put/get/delete), lamport |
| B | Fresh install: no on-disk state files (\`v1/\` directory never created) |
| C | Migration: plant fake on-disk state → \`migrateOnDiskStateToIndexedDB\` moves it to storage and removes the disk artifacts; second pass is no-op |
| D | Defense-in-depth: \`ingestOrSyncHiddenFile\` called with own-folder path → error logged, no upload, settings file untouched |

Updated tests:
- **issue57**: pre-#94 wiped \`\${stateDir}/content/*.bin\` via Node fs to trigger the "STEP_1 dropped before WS handshake" race; after #94, content snapshots live in IndexedDB so the wipe goes through \`plugin.storage.deleteContent\` per nodeId.
- **issue58**: wipe the manifest snapshot via \`plugin.storage.setManifest(new Uint8Array(0))\` instead of \`fs.unlinkSync(manifest.bin)\`.

Local verification — all 9 spec files / 15 sub-tests pass:
- basic (7/7), issue56, issue57, issue58, issue63, issue90, issue91, issue92, issue94.

## Test plan

- [ ] CI green.
- [ ] Manual smoke: install on a vault that previously had \`\${configDir}/plugins/syncline/v1/manifest.bin\` etc. → on first load the migration runs, on-disk files vanish, plugin works normally.
- [ ] Manual smoke (mobile): IndexedDB writes confirmed via Obsidian developer console.

## Reinstall scenario

Clearing app data wipes IndexedDB. Plugin re-bootstraps from server on next connect — equivalent to a fresh client. Documented as acceptable in #94.

🤖 Generated with [Claude Code](https://claude.com/claude-code)