### PR TITLE
feat(plugin): device-local settings override — closes #95

### DIFF
--- a/e2e/test/specs/issue90.e2e.ts
+++ b/e2e/test/specs/issue90.e2e.ts
@@ -114,14 +114,12 @@ describe('Syncline #90 — onExternalSettingsChange', () => {
     it('reacts to external data.json changes correctly', async function () {
         this.timeout(2 * 60_000);
 
+        // Post-#95: actorId lives in localStorage, not data.json.
+        // Read it from in-memory settings (which loadSettings already
+        // populated from localStorage).
         const originalActorId: string = await browser.executeObsidian(async ({ app }) => {
-            const adapter = (app as any).vault.adapter;
-            const cd = (app as any).vault.configDir;
-            const path = `${cd}/plugins/syncline/data.json`;
-            const exists = await adapter.exists(path);
-            if (!exists) throw new Error(`data.json missing at ${path}`);
-            const cur = JSON.parse(await adapter.read(path));
-            return cur.actorId;
+            const plugin: any = (app as any).plugins.plugins['syncline'];
+            return plugin.settings.actorId;
         });
         if (!originalActorId) throw new Error('plugin has no actorId yet — connect before this test');
 
@@ -204,9 +202,12 @@ describe('Syncline #90 — onExternalSettingsChange', () => {
         }), 30_000, 100);
 
         // --------------------------------------------------------------
-        // Phase C — actorId mismatch is REJECTED; data.json is restored.
-        //   This is the highest-stakes assertion: silently accepting an
-        //   external actorId would corrupt Yrs history across devices.
+        // Phase C — actorId injected via data.json is REJECTED.
+        //   Post-#95 actorId lives in localStorage; if a buggy sync
+        //   tool puts the field back into data.json, the hook must
+        //   ignore it and rewrite data.json without it.
+        //   Silently accepting an external actorId would corrupt Yrs
+        //   history across devices.
         // --------------------------------------------------------------
         const fakeActorId = '00000000-0000-4000-8000-deadbeefcafe';
         await adapterRewriteDataJson({ kind: 'actorId', value: fakeActorId });
@@ -220,12 +221,14 @@ describe('Syncline #90 — onExternalSettingsChange', () => {
             const onDisk = JSON.parse(await adapter.read(path));
             return {
                 inMemoryActor: plugin.settings.actorId,
-                onDiskActor: onDisk.actorId,
+                actorIdFieldOnDisk: Object.prototype.hasOwnProperty.call(onDisk, 'actorId'),
             };
         });
         expect(phaseC.inMemoryActor).toBe(originalActorId);
-        expect(phaseC.onDiskActor).toBe(originalActorId);
-        console.log(`[#90] phase C: actorId mismatch rejected; on-disk file restored`);
+        // Post-#95: actorId is never persisted to data.json. The
+        // rewrite triggered by the rejection strips the leftover key.
+        expect(phaseC.actorIdFieldOnDisk).toBe(false);
+        console.log(`[#90] phase C: actorId injection rejected; data.json sanitized`);
 
         // --------------------------------------------------------------
         // Phase D — self-write echo within the cookie window is ignored.

--- a/e2e/test/specs/issue95.e2e.ts
+++ b/e2e/test/specs/issue95.e2e.ts
@@ -1,0 +1,248 @@
+// Regression test for #95 — device-local settings override.
+//
+// Pre-#95 every settings field — including `actorId` (this device's
+// CRDT identity) — lived in `data.json`. If the user ever opted
+// data.json into a sync surface (Obsidian Sync, LiveSync, syncline
+// itself), actorId would propagate, two devices would share one,
+// and Yrs history would corrupt permanently.
+//
+// #95 splits SynclineSettings into:
+//   - SharedSettings (data.json):  serverUrl, autoSync, configSync
+//   - LocalSettings  (localStorage): actorId
+//
+// What this test covers:
+//   A. Partitioned save: actorId never appears in data.json after
+//      saveSettings(); always lives in localStorage instead.
+//   B. Migration: pre-#95 data.json with actorId → after onload
+//      runs (or first saveSettings), actorId moves to localStorage,
+//      data.json drops the field, in-memory state preserved.
+//   C. Migration is idempotent: rerunning the migration path with
+//      already-migrated state is a no-op.
+//   D. Editing shared settings does not write actorId back into
+//      data.json. Simulates the "device A propagates settings to
+//      device B; device B's actorId stays untouched" scenario.
+//   E. onExternalSettingsChange ignores any actorId field that
+//      sneaks into data.json (e.g., from a buggy sync tool that
+//      restored the legacy field). In-memory + localStorage actorId
+//      stays put; data.json gets rewritten without it.
+
+import { spawn, ChildProcess } from 'child_process';
+import { join } from 'path';
+import * as fs from 'fs';
+import { expect, browser } from '@wdio/globals';
+
+describe('Syncline #95 — device-local settings override', () => {
+    const port = 3095;
+    const serverUrl = `ws://localhost:${port}/sync`;
+    const repoRoot = join(__dirname, '../../../');
+    const e2eDir = join(__dirname, '../../');
+    const dbPath = join(e2eDir, 'issue95.db');
+    const synclineBin = join(repoRoot, 'target/release/syncline');
+
+    const LOCAL_LS_KEY = 'syncline:local-settings';
+
+    let serverProc: ChildProcess;
+
+    async function waitFor<T>(label: string, fn: () => Promise<T | null | undefined | false | ''>, timeoutMs = 30_000, stepMs = 100): Promise<T> {
+        const deadline = Date.now() + timeoutMs;
+        while (Date.now() < deadline) {
+            try { const v = await fn(); if (v) return v as T; } catch {}
+            await new Promise((r) => setTimeout(r, stepMs));
+        }
+        throw new Error(`waitFor("${label}") timed out after ${timeoutMs}ms`);
+    }
+
+    before(async function () {
+        this.timeout(2 * 60_000);
+        if (!fs.existsSync(synclineBin)) throw new Error(`syncline binary missing at ${synclineBin}`);
+        if (fs.existsSync(dbPath)) fs.unlinkSync(dbPath);
+
+        let serverOut = '';
+        serverProc = spawn(synclineBin, ['server', '--port', String(port), '--db-path', dbPath], { stdio: 'pipe' });
+        serverProc.stdout?.on('data', (d) => { serverOut += d; });
+        serverProc.stderr?.on('data', (d) => { serverOut += d; });
+        await waitFor('server listening', async () => /listening/i.test(serverOut), 30_000, 100);
+
+        const obsidianPage = browser.getObsidianPage();
+        try { await obsidianPage.enablePlugin('syncline'); } catch {}
+        await browser.executeObsidian(async ({ app }, url) => {
+            const plugin: any = (app as any).plugins.plugins['syncline'];
+            if (!plugin) throw new Error('plugin not found');
+            plugin.settings.serverUrl = url;
+            plugin.settings.autoSync = true;
+            await plugin.saveSettings();
+            plugin.disconnect();
+            await plugin.connect();
+        }, serverUrl);
+        await waitFor('plugin connected', async () => browser.executeObsidian(async ({ app }) => {
+            const plugin: any = (app as any).plugins.plugins['syncline'];
+            return !!(plugin && plugin.client && plugin.client.isConnected());
+        }), 30_000, 100);
+    });
+
+    after(() => {
+        if (serverProc && !serverProc.killed) serverProc.kill();
+    });
+
+    it('partitions, migrates, and refuses external actorId injection', async function () {
+        this.timeout(2 * 60_000);
+
+        // --------------------------------------------------------------
+        // Phase A — partitioned save
+        // --------------------------------------------------------------
+        const phaseA: any = await browser.executeObsidian(async ({ app }, args) => {
+            const plugin: any = (app as any).plugins.plugins['syncline'];
+            await plugin.saveSettings();
+            const dataJson = await plugin.loadData();
+            const localBlob = (app as any).loadLocalStorage(args.lsKey);
+            return {
+                actorIdInMemory: plugin.settings.actorId,
+                actorIdInDataJson: dataJson?.actorId ?? null,
+                actorIdInLocalStorage:
+                    localBlob && typeof localBlob === 'object' ? localBlob.actorId ?? null : null,
+                dataJsonKeys: dataJson ? Object.keys(dataJson).sort() : [],
+            };
+        }, { lsKey: LOCAL_LS_KEY });
+        expect(typeof phaseA.actorIdInMemory).toBe('string');
+        expect(phaseA.actorIdInDataJson).toBeNull(); // stripped from data.json
+        expect(phaseA.actorIdInLocalStorage).toBe(phaseA.actorIdInMemory);
+        expect(phaseA.dataJsonKeys).toEqual(['autoSync', 'configSync', 'serverUrl']);
+        console.log(`[#95] phase A: actorId only in memory + localStorage; data.json keys = ${phaseA.dataJsonKeys.join(',')}`);
+
+        // --------------------------------------------------------------
+        // Phase B — pre-#95 migration: plant actorId back into data.json
+        // and clear localStorage, then run the migration path
+        // (loadSettings + the eager save in onload). Asserts:
+        //   - actorId moves out of data.json
+        //   - localStorage gets the actorId
+        //   - in-memory actorId is preserved
+        // --------------------------------------------------------------
+        const phaseB: any = await browser.executeObsidian(async ({ app }, args) => {
+            const plugin: any = (app as any).plugins.plugins['syncline'];
+            const originalActorId = plugin.settings.actorId;
+
+            // Set up the pre-#95 layout: actorId in data.json, nothing
+            // in localStorage. We use saveData directly to bypass
+            // saveSettings() (which would partition).
+            await plugin.saveData({
+                serverUrl: plugin.settings.serverUrl,
+                autoSync: plugin.settings.autoSync,
+                configSync: plugin.settings.configSync,
+                actorId: originalActorId, // legacy placement
+            });
+            (app as any).saveLocalStorage(args.lsKey, null);
+
+            // Trigger the migration path: loadSettings reads data.json,
+            // marks deviceLocalMigrationNeeded, and the eager
+            // saveSettings call (mirroring what onload does) partitions.
+            await plugin.loadSettings();
+            const migrationFlag = plugin.deviceLocalMigrationNeeded;
+            if (plugin.deviceLocalMigrationNeeded) {
+                await plugin.saveSettings();
+                plugin.deviceLocalMigrationNeeded = false;
+            }
+
+            const dataJson = await plugin.loadData();
+            const localBlob = (app as any).loadLocalStorage(args.lsKey);
+            return {
+                migrationFlagSet: migrationFlag,
+                inMemoryActorId: plugin.settings.actorId,
+                originalActorId,
+                actorIdInDataJson: dataJson?.actorId ?? null,
+                actorIdInLocalStorage:
+                    localBlob && typeof localBlob === 'object' ? localBlob.actorId ?? null : null,
+            };
+        }, { lsKey: LOCAL_LS_KEY });
+        expect(phaseB.migrationFlagSet).toBe(true);
+        expect(phaseB.inMemoryActorId).toBe(phaseB.originalActorId);
+        expect(phaseB.actorIdInDataJson).toBeNull();
+        expect(phaseB.actorIdInLocalStorage).toBe(phaseB.originalActorId);
+        console.log('[#95] phase B: migration moved actorId from data.json to localStorage');
+
+        // --------------------------------------------------------------
+        // Phase C — migration is idempotent
+        // --------------------------------------------------------------
+        const phaseC: any = await browser.executeObsidian(async ({ app }) => {
+            const plugin: any = (app as any).plugins.plugins['syncline'];
+            // Re-running loadSettings on already-partitioned state.
+            await plugin.loadSettings();
+            return {
+                migrationFlagSet: plugin.deviceLocalMigrationNeeded,
+                inMemoryActorId: plugin.settings.actorId,
+            };
+        });
+        expect(phaseC.migrationFlagSet).toBe(false); // localStorage is the source now
+        expect(typeof phaseC.inMemoryActorId).toBe('string');
+        console.log('[#95] phase C: migration idempotent (no flag, actorId preserved)');
+
+        // --------------------------------------------------------------
+        // Phase D — editing shared settings doesn't leak actorId.
+        //   Mimics device A pushing a settings change; on device B
+        //   the data.json that arrives must not contain actorId.
+        // --------------------------------------------------------------
+        const phaseD: any = await browser.executeObsidian(async ({ app }) => {
+            const plugin: any = (app as any).plugins.plugins['syncline'];
+            // Touch a shared field, save.
+            const before = plugin.settings.serverUrl;
+            plugin.settings.serverUrl = before + '?probe=1';
+            await plugin.saveSettings();
+            const dataJson = await plugin.loadData();
+            // Restore.
+            plugin.settings.serverUrl = before;
+            await plugin.saveSettings();
+            return {
+                hasActorIdField: dataJson
+                    ? Object.prototype.hasOwnProperty.call(dataJson, 'actorId')
+                    : false,
+                serverUrlInDataJson: dataJson?.serverUrl,
+            };
+        });
+        expect(phaseD.hasActorIdField).toBe(false);
+        expect(typeof phaseD.serverUrlInDataJson).toBe('string');
+        console.log('[#95] phase D: shared-settings edit does not leak actorId into data.json');
+
+        // --------------------------------------------------------------
+        // Phase E — onExternalSettingsChange refuses to honor an
+        //   external actorId injection. Plant a stale actorId into
+        //   data.json (as if a buggy sync tool restored the legacy
+        //   field), trigger the hook, confirm:
+        //     - in-memory actorId unchanged
+        //     - localStorage actorId unchanged
+        //     - data.json rewritten without actorId
+        // --------------------------------------------------------------
+        const phaseE: any = await browser.executeObsidian(async ({ app }, args) => {
+            const plugin: any = (app as any).plugins.plugins['syncline'];
+            const ourActor = plugin.settings.actorId;
+            const stalActor = '00000000-0000-4000-8000-deadbeefcafe';
+
+            // Inject the stale actorId via the adapter (so loadData()
+            // sees the new bytes coherently — same reason as the #90
+            // test).
+            const adapter = (app as any).vault.adapter;
+            const cd = (app as any).vault.configDir;
+            const path = `${cd}/plugins/syncline/data.json`;
+            const cur = JSON.parse(await adapter.read(path));
+            cur.actorId = stalActor;
+            await adapter.write(path, JSON.stringify(cur));
+
+            // Bypass the self-write cookie so the hook actually runs
+            // (the rapid-fire test cadence trips the 250 ms guard).
+            plugin.lastSelfSaveAt = 0;
+            await plugin.onExternalSettingsChange();
+
+            const dataJson = await plugin.loadData();
+            const localBlob = (app as any).loadLocalStorage(args.lsKey);
+            return {
+                inMemoryActorId: plugin.settings.actorId,
+                ourActor,
+                actorIdInDataJson: dataJson?.actorId ?? null,
+                actorIdInLocalStorage:
+                    localBlob && typeof localBlob === 'object' ? localBlob.actorId ?? null : null,
+            };
+        }, { lsKey: LOCAL_LS_KEY });
+        expect(phaseE.inMemoryActorId).toBe(phaseE.ourActor);
+        expect(phaseE.actorIdInLocalStorage).toBe(phaseE.ourActor);
+        expect(phaseE.actorIdInDataJson).toBeNull(); // stripped on rewrite
+        console.log('[#95] phase E: external actorId injection rejected; data.json sanitized');
+    });
+});

--- a/obsidian-plugin/main.ts
+++ b/obsidian-plugin/main.ts
@@ -66,11 +66,15 @@ const DEFAULT_CONFIG_SYNC: ConfigSyncCategories = {
   other: false,
 };
 
-interface SynclineSettings {
+/**
+ * Settings that are safe to share across devices via any sync
+ * mechanism (Obsidian Sync, LiveSync, syncline itself if the user
+ * ever opts data.json into the syncline-managed sync surface).
+ * Persisted to `${configDir}/plugins/syncline/data.json`.
+ */
+interface SharedSettings {
   serverUrl: string;
   autoSync: boolean;
-  /** Stable per-installation ActorId (UUIDv4, hyphenated). Minted on first run. */
-  actorId: string | null;
   /** Per-category opt-ins for syncing the Obsidian config folder.
    *  Replaces the single boolean from #92 — see ConfigSyncCategories
    *  for per-field defaults and rationale. Migrated on first load
@@ -79,12 +83,49 @@ interface SynclineSettings {
   configSync: ConfigSyncCategories;
 }
 
-const DEFAULT_SETTINGS: SynclineSettings = {
+/**
+ * Settings that are device-local and must NEVER propagate across
+ * devices. Persisted to `app.saveLocalStorage("syncline:local")`,
+ * which Obsidian shards per-vault and never includes in any sync
+ * surface. Future device-local fields (auth tokens, debug toggles,
+ * machine-specific paths) belong here.
+ *
+ * `actorId` is the most consequential of these: it's this device's
+ * CRDT identity. Two devices sharing one would corrupt Yrs history
+ * permanently.
+ */
+interface LocalSettings {
+  /** Stable per-device ActorId (UUIDv4). Minted on first run. */
+  actorId: string | null;
+}
+
+/**
+ * Flat in-memory shape used by the rest of the plugin. The split
+ * between shared and local only matters at persistence time: read in
+ * `loadSettings`, partition in `saveSettings`. Callers stay oblivious.
+ */
+interface SynclineSettings extends SharedSettings, LocalSettings {}
+
+const DEFAULT_SHARED_SETTINGS: SharedSettings = {
   serverUrl: "ws://localhost:3030/sync",
   autoSync: true,
-  actorId: null,
   configSync: DEFAULT_CONFIG_SYNC,
 };
+
+const DEFAULT_LOCAL_SETTINGS: LocalSettings = {
+  actorId: null,
+};
+
+const DEFAULT_SETTINGS: SynclineSettings = {
+  ...DEFAULT_SHARED_SETTINGS,
+  ...DEFAULT_LOCAL_SETTINGS,
+};
+
+/** localStorage key for the device-local settings blob. Obsidian's
+ *  `loadLocalStorage`/`saveLocalStorage` shard keys per-vault, so
+ *  this key namespaces only within a single vault — no further
+ *  vault-id suffix needed. */
+const LOCAL_SETTINGS_LS_KEY = "syncline:local-settings";
 
 /** Categories used by `classifyHiddenPath`. */
 type HiddenPathCategory =
@@ -902,6 +943,21 @@ export default class SynclinePlugin extends Plugin {
     );
     await this.migrateLegacyStateRoot();
     await this.migrateOnDiskStateToIndexedDB();
+
+    // #95: if loadSettings detected a pre-#95 install (actorId still
+    // in data.json, nothing in localStorage), eagerly partition now.
+    // The next saveSettings() would do this anyway when the user
+    // first toggles a setting or connects, but doing it up-front
+    // ensures the migration completes for users who never trigger
+    // either path.
+    if (this.deviceLocalMigrationNeeded) {
+      await this.saveSettings();
+      this.deviceLocalMigrationNeeded = false;
+      console.debug(
+        "[Syncline] migration: actorId moved from data.json to localStorage",
+      );
+    }
+
     this.addSettingTab(new SynclineSettingTab(this.app, this));
 
     this.statusBarItem = this.addStatusBarItem();
@@ -967,9 +1023,20 @@ export default class SynclinePlugin extends Plugin {
    *  the legacy field wasn't present. */
   private legacyBooleanValue: boolean | null = null;
 
+  /** Set in `loadSettings` if `data.json` still has an `actorId`
+   *  field (pre-#95 layout) AND localStorage doesn't yet have the
+   *  device-local settings blob. The next `saveSettings()` call
+   *  partitions naturally — writes data.json without actorId and
+   *  populates localStorage — but we also force one explicit save
+   *  in `onload()` so the migration completes even for users who
+   *  never edit settings or connect. */
+  private deviceLocalMigrationNeeded = false;
+
   async loadSettings() {
     const raw = (await this.loadData()) as
-      | (Partial<SynclineSettings> & { syncObsidianConfig?: boolean })
+      | (Partial<SynclineSettings> & {
+          syncObsidianConfig?: boolean;
+        })
       | null;
     const legacyValue =
       raw && typeof raw.syncObsidianConfig === "boolean"
@@ -1000,6 +1067,34 @@ export default class SynclinePlugin extends Plugin {
     // Drop the legacy field from the in-memory settings — the next
     // saveSettings() will write only the new shape.
     delete merged.syncObsidianConfig;
+
+    // #95: device-local subset lives in localStorage. Read order:
+    //   1. localStorage (post-migration, source of truth)
+    //   2. data.json's legacy `actorId` field (pre-#95, one-shot)
+    //   3. default (null — actorId minted on first connect)
+    const localRaw: unknown = this.app.loadLocalStorage(
+      LOCAL_SETTINGS_LS_KEY,
+    );
+    const localFromStorage =
+      localRaw && typeof localRaw === "object"
+        ? (localRaw as Partial<LocalSettings>)
+        : null;
+    if (
+      localFromStorage &&
+      typeof localFromStorage.actorId === "string"
+    ) {
+      // localStorage wins, even if data.json also has one (defensive
+      // posture against a buggy/external write that put actorId back
+      // into data.json).
+      merged.actorId = localFromStorage.actorId;
+    } else if (raw && typeof raw.actorId === "string") {
+      // Pre-#95 install: actorId in data.json. `merged.actorId`
+      // already reflects this via the Object.assign above; just
+      // mark the migration so onload eagerly saves the partitioned
+      // form.
+      this.deviceLocalMigrationNeeded = true;
+    }
+
     this.settings = merged;
   }
 
@@ -1013,7 +1108,20 @@ export default class SynclinePlugin extends Plugin {
 
   async saveSettings() {
     this.lastSelfSaveAt = Date.now();
-    await this.saveData(this.settings);
+    // #95: partition into shared (data.json) and local (localStorage).
+    // Shared gets `Plugin.saveData()`, eligible for cross-device sync
+    // if the user opts in. Local goes to `app.saveLocalStorage`,
+    // which Obsidian shards per-vault and never propagates.
+    const shared: SharedSettings = {
+      serverUrl: this.settings.serverUrl,
+      autoSync: this.settings.autoSync,
+      configSync: this.settings.configSync,
+    };
+    const local: LocalSettings = {
+      actorId: this.settings.actorId,
+    };
+    await this.saveData(shared);
+    this.app.saveLocalStorage(LOCAL_SETTINGS_LS_KEY, local);
   }
 
   /**
@@ -1047,12 +1155,19 @@ export default class SynclinePlugin extends Plugin {
       raw,
     ) as SynclineSettings;
 
+    // #95: actorId is device-local — lives in localStorage, never
+    // in data.json. Pin incoming.actorId to the in-memory value so
+    // a leftover `actorId` field in raw can't influence runtime
+    // state. If raw HAS the field (pre-#95 install or external write
+    // that added it back), we trigger a rewrite that strips it.
+    incoming.actorId = previous.actorId;
     let needsRewrite = false;
-    if (incoming.actorId !== previous.actorId) {
+    if (Object.prototype.hasOwnProperty.call(raw, "actorId")) {
+      const staleRaw = (raw as { actorId?: unknown }).actorId;
+      const stale = typeof staleRaw === "string" ? staleRaw : "(non-string)";
       console.warn(
-        `[Syncline] external data.json change tried to set actorId=${incoming.actorId} (current=${previous.actorId}) — keeping current; rewriting data.json`,
+        `[Syncline] external data.json carried actorId=${stale} — actorId now lives in localStorage. Rewriting data.json to drop the field.`,
       );
-      incoming.actorId = previous.actorId;
       needsRewrite = true;
     }
     this.settings = incoming;
@@ -2983,10 +3098,21 @@ class SynclineSettingTab extends PluginSettingTab {
       );
     }
 
-    new Setting(containerEl).setName("Identity").setHeading();
+    new Setting(containerEl).setName("This device").setHeading();
+    containerEl.createEl("p", {
+      cls: "setting-item-description",
+      text:
+        "Identifiers and state below are device-local. They live in this " +
+        "vault's localStorage, never in data.json, and are never propagated " +
+        "by any sync mechanism — including syncline itself if you opt " +
+        "data.json into the synced surface.",
+    });
     new Setting(containerEl)
       .setName("Actor ID")
-      .setDesc("Stable per-installation identifier used for sync authorship.")
+      .setDesc(
+        "Stable per-device CRDT identity. Two devices sharing one " +
+          "would corrupt history permanently, so this is never synced.",
+      )
       .addText((text) => {
         text
           .setPlaceholder("(minted on first connect)")


### PR DESCRIPTION
Closes #95. Completes Tier 3 of the post-#89 hardening plan (umbrella #96).

## Why

Pre-#95 every settings field — including \`actorId\` (this device's CRDT identity) — lived in \`data.json\`. If a user ever opted \`data.json\` into a sync surface (Obsidian Sync, LiveSync, syncline itself once #93's category allow-list lets them), \`actorId\` would propagate, two devices would share one, and Yrs history would corrupt permanently.

This PR splits the persistence layer so device-local state has a different home than shareable settings. LiveSync issue [#773](https://github.com/vrtmrz/obsidian-livesync/issues/773) proposes the same split citing obsidian-git's pattern; we adopt it cleanly now.

## Layout

\`\`\`
SharedSettings (data.json)            : serverUrl, autoSync, configSync
LocalSettings  (app.localStorage)     : actorId
\`\`\`

\`SynclineSettings extends SharedSettings, LocalSettings\` — the in-memory shape stays flat so callers don't have to think about the split. The partition only matters at \`loadSettings\` / \`saveSettings\` boundaries.

\`LocalSettings\` is an extension point: future device-local fields (auth tokens, debug toggles, machine-specific paths) belong there, no further refactoring needed.

## Migration (one-time, idempotent)

- \`loadSettings\` reads both \`data.json\` and \`app.loadLocalStorage("syncline:local-settings")\`.
- localStorage wins for \`actorId\` (post-migration source of truth).
- Fallback: if \`data.json\` has \`actorId\` but localStorage doesn't (pre-#95 install), capture into in-memory state and mark \`deviceLocalMigrationNeeded\`.
- \`onload\` eagerly calls \`saveSettings()\` after the flag is set, so the partition completes even for users who never edit settings or connect.

## \`onExternalSettingsChange\` hardening

Pins \`incoming.actorId\` to the in-memory value — never trusts \`actorId\` from raw \`data.json\`. If \`data.json\` carries an \`actorId\` field (buggy sync tool restored it, user hand-edit, etc.), log + rewrite to drop it.

## Settings UI

"Identity" section renamed to "This device" with a clear description: fields below are device-local, live in localStorage, and **are never synced — including by syncline itself**.

## Test

New \`e2e/test/specs/issue95.e2e.ts\`, 5 phases:

| Phase | Asserts |
|---|---|
| A | Partitioned save: \`actorId\` never in \`data.json\` after \`saveSettings\`; lives in localStorage |
| B | Pre-#95 migration: \`actorId\` in \`data.json\` → moves to localStorage, \`data.json\` stripped, in-memory preserved |
| C | Migration idempotent (re-run with already-partitioned state is a no-op) |
| D | Shared-settings edit doesn't leak \`actorId\` into \`data.json\` |
| E | External \`actorId\` injection via \`data.json\` rejected; \`data.json\` sanitized; in-memory + localStorage actorId untouched |

Updated:
- **issue90.e2e.ts**: pre-#95 it asserted that actorId stayed in \`data.json\` after rejection ("on-disk file restored to original"). Post-#95 actorId is never in \`data.json\` — the rejection path strips the leftover field and the test now asserts the \`actorId\` key is absent from \`data.json\` after the rewrite.

Local verification — all 10 spec files / 16 sub-tests pass:
- basic (7/7), issue56, issue57, issue58, issue63, issue90, issue91, issue93, issue94, issue95.

## Test plan

- [ ] CI green.
- [ ] Manual smoke: install on a vault that previously had \`actorId\` in \`data.json\` → on first load, \`actorId\` appears in localStorage and disappears from \`data.json\`; plugin behavior unchanged.
- [ ] Manual smoke: settings tab shows the "This device" section with an actorId that matches what's in localStorage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)