### PR TITLE
Manifest robustness fixes + Obsidian/wdio + container e2e

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5231,7 +5231,7 @@ dependencies = [
 
 [[package]]
 name = "syncline"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -22,3 +22,10 @@ test-vault/*
 issue*-cli-vault/
 phase*-cli-vault/
 profile-cli-vault/
+*-cli-vault/
+*-cli/
+
+# Per-spec server DBs spawned alongside *-cli/ folders.
+*.db
+*.db-shm
+*.db-wal

--- a/e2e/docker/.dockerignore
+++ b/e2e/docker/.dockerignore
@@ -1,0 +1,7 @@
+# The Dockerfile doesn't COPY anything from the build context (the
+# whole source tree comes in via the compose bind mount at runtime),
+# so the safest .dockerignore is one that ignores everything except
+# the Dockerfile itself. Keeps `docker build` instant even if a
+# future change widens the context.
+*
+!Dockerfile

--- a/e2e/docker/Dockerfile
+++ b/e2e/docker/Dockerfile
@@ -1,0 +1,89 @@
+# Headless test image for the Obsidian wdio e2e suite.
+#
+# Layout:
+#   - Debian 12 (bookworm) base for glibc compatibility with Obsidian
+#     AppImages (which target a recent Ubuntu/glibc).
+#   - Node.js 20 (matching the version the wdio service is exercised
+#     against in CI).
+#   - Rust toolchain so the syncline binary + the WASM plugin can be
+#     built from source inside the container.
+#   - Xvfb + Electron's GUI deps so real Obsidian can run headless.
+#   - p7zip so wdio-obsidian-service can extract the Linux AppImage
+#     without FUSE (the in-container path is `7z` -> extracted dir,
+#     no `fusermount` involved).
+#
+# The image is a self-contained build environment - it does not bake
+# in the source tree. The compose file mounts the repo into
+# /workspace and runs the build + tests there. That keeps iteration
+# fast (no rebuild on source changes) and lets the CI surface fail
+# loudly when the on-disk artifacts diverge from the source tree.
+
+FROM node:20-bookworm
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+# Single apt install. The package list is the union of:
+#   - build/utility: build-essential, pkg-config, libssl-dev, curl, ca-certificates,
+#                    git, jq, sqlite3, wget
+#   - AppImage extractor (no FUSE needed): p7zip-full
+#   - Xvfb + helpers: xvfb, dbus-x11, x11-utils, xdg-utils
+#   - Electron / Chromium 120 runtime: union of Puppeteer's "Chromium on Debian"
+#     deps doc + Obsidian AppImage's ldd on Bookworm + libsecret-1-0
+#     (Obsidian's safeStorage path).
+# Avoid putting `# comments` inside the backslash continuation: they
+# get joined into a single bash line and would silently swallow every
+# package name after them.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential pkg-config libssl-dev curl ca-certificates \
+        git jq sqlite3 wget \
+        p7zip-full \
+        xvfb xauth dbus-x11 x11-utils xdg-utils \
+        libgtk-3-0 libnss3 libxss1 libasound2 libgbm1 libdrm2 \
+        libxcomposite1 libxdamage1 libxrandr2 libpangocairo-1.0-0 \
+        libxshmfence1 libxkbcommon0 libxfixes3 libcurl4 libatspi2.0-0 \
+        libcups2 libxcb-dri3-0 libsecret-1-0 libnspr4 libdbus-1-3 \
+        libatk1.0-0 libatk-bridge2.0-0 libxext6 libxi6 libxtst6 \
+        libuuid1 fonts-liberation libpango-1.0-0 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Rust + wasm-pack at the system level so any user inside the
+# container can use them without re-downloading. CARGO_HOME is split
+# from RUSTUP_HOME so we can mount a writable $CARGO_HOME volume per
+# user further down.
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+        | sh -s -- -y --default-toolchain stable --profile minimal \
+    && rustup target add wasm32-unknown-unknown \
+    && cargo install --locked wasm-pack \
+    && chmod -R a+rX "$RUSTUP_HOME" "$CARGO_HOME"
+
+# Non-root user. Electron sandbox requires either dropping privileges
+# or `--no-sandbox` (which the wdio-obsidian-service already adds on
+# Linux), and a non-root user keeps file mode bits sane on bind-
+# mounted volumes from a Linux host. Mac/Windows hosts ignore uid.
+#
+# `node:20-bookworm` ships with `node` at UID/GID 1000. Strip it
+# first so the new `runner` user can take that UID cleanly when the
+# host requests it (the common Linux-host case).
+ARG USER_UID=1000
+ARG USER_GID=1000
+RUN (getent passwd node >/dev/null && userdel -r node 2>/dev/null) || true \
+    && (getent group node >/dev/null && groupdel node 2>/dev/null) || true \
+    && groupadd -g "$USER_GID" runner \
+    && useradd -m -u "$USER_UID" -g "$USER_GID" -s /bin/bash runner \
+    && mkdir -p /workspace \
+    && chown -R runner:runner /workspace /home/runner
+
+USER runner
+WORKDIR /workspace
+
+# Per-user cargo cache so cargo install / target builds inside the
+# container don't fight the system rustup install.
+ENV CARGO_HOME=/home/runner/.cargo \
+    PATH=/home/runner/.cargo/bin:/usr/local/cargo/bin:$PATH
+
+# Default command runs the pipeline. Override with `bash` for an
+# interactive shell, or pass extra arguments for wdio.
+CMD ["bash", "/workspace/e2e/docker/run-tests.sh"]

--- a/e2e/docker/README.md
+++ b/e2e/docker/README.md
@@ -1,0 +1,134 @@
+# Headless e2e in a container
+
+This directory packages the wdio + Obsidian e2e suite into a
+container so it can run on a CI server (or any machine without a
+display) without installing Rust, Node, Obsidian, or an X server on
+the host.
+
+The image and compose file work with both **Podman** (the local
+default - see commands below) and **Docker**. The Dockerfile is
+plain `node:20-bookworm` plus apt deps and a Rust toolchain; the
+compose file uses standard Compose v3 syntax.
+
+Verified working: both `pre-existing-vault.e2e.ts` and
+`plugin-cross-vault-install.e2e.ts` run inside the container under
+Xvfb and pass against a real Linux Obsidian extracted from the
+upstream AppImage.
+
+## What's inside
+
+- `Dockerfile` - Debian 12 + Node 20 + Rust toolchain (with the
+  `wasm32-unknown-unknown` target pre-installed) + Xvfb + xauth +
+  Electron's GUI deps + `p7zip-full` for AppImage extraction.
+- `docker-compose.yml` - convenience wrapper that bind-mounts the
+  repo and named volumes for `node_modules`, the cargo cache, and
+  the Obsidian download cache.
+- `run-tests.sh` - the entrypoint script: builds the syncline
+  binary release, builds the WASM plugin, then runs `wdio` under
+  Xvfb.
+- `.dockerignore` - keeps the build context to just the
+  Dockerfile (the source tree is bind-mounted at runtime, so the
+  build context never needs more).
+
+## One-time setup
+
+```bash
+podman compose -f e2e/docker/docker-compose.yml build
+```
+
+(`docker compose -f e2e/docker/docker-compose.yml build` works
+identically.)
+
+First build downloads ~1.5 GB (Debian base + Rust toolchain + apt
+packages) and pre-installs the `wasm32-unknown-unknown` Rust target
++ `wasm-pack`. Subsequent builds are cached.
+
+On a Linux host you usually want the in-container user to match your
+host UID so files written into the bind mount come out with the
+right owner:
+
+```bash
+USER_UID=$(id -u) USER_GID=$(id -g) \
+  podman compose -f e2e/docker/docker-compose.yml build
+```
+
+macOS / Windows hosts use the bind-mount file-server's translation
+layer and can ignore the UID args.
+
+## Running tests
+
+Full suite:
+
+```bash
+podman compose -f e2e/docker/docker-compose.yml run --rm e2e
+```
+
+Single spec (the recommended dev loop):
+
+```bash
+podman compose -f e2e/docker/docker-compose.yml run --rm e2e \
+  bash e2e/docker/run-tests.sh \
+  --spec test/specs/plugin-cross-vault-install.e2e.ts
+```
+
+Drop into an interactive shell:
+
+```bash
+podman compose -f e2e/docker/docker-compose.yml run --rm e2e bash
+```
+
+Both specs produce `Running: chrome (v120.0.6099.283) on linux` -
+real Obsidian, real chromedriver, headless via Xvfb.
+
+## What the container does on each run
+
+1. `cargo build --release --bin syncline` - incremental thanks to
+   the persisted `target/` volume.
+2. `obsidian-plugin/`: `npm ci` then `npm run build` (which calls
+   `wasm-pack build` and rolls the plugin up into `main.js`).
+3. `e2e/`: `npm ci` then `xvfb-run npx wdio run wdio.conf.ts`.
+
+The first run downloads Obsidian itself (the AppImage matching the
+test config's electron version) into `e2e/.obsidian-cache/`. That
+directory is a named volume, so subsequent runs are fast.
+
+## Why not run Obsidian on the host directly
+
+Host-direct works fine on a developer macOS/Windows/Linux desktop,
+but a CI runner usually has no display server, no Obsidian, and
+possibly no Rust toolchain. The container removes those assumptions
+and pins the Linux libraries Electron 28 wants (Chrome 120 era)
+which otherwise drift between distros.
+
+## Known caveats
+
+- `shm_size` is bumped to 2 GB. The Electron 28 / Chromium 120
+  stack inside Obsidian 1.5.x crashes with the Compose default of
+  64 MB.
+- `wdio-obsidian-service` automatically appends `--no-sandbox` on
+  Linux, so the container does not need extra Chromium flags. We
+  still run as a non-root `runner` user out of habit.
+- The plugin and the Rust binary are built **inside** the container
+  every run. That's deliberate: a CI image baked at build time
+  would go stale within minutes of any source change, and bake-time
+  builds hide the test's "does this actually rebuild from source"
+  guarantee.
+- `init: true` is set so the wdio + chromedriver + Obsidian
+  subprocess tree gets reaped cleanly when a test container exits.
+- **Apple Silicon hosts via Docker / Podman**: the
+  `obsidian-versions.json` cache contains both arm64 and x64
+  AppImages, but `node:20-bookworm` is multi-arch so an arm64 host
+  may pull the arm64 base. If your host arch and the cached
+  Obsidian arch ever disagree, force the platform:
+  ```bash
+  DOCKER_DEFAULT_PLATFORM=linux/amd64 \
+    podman compose -f e2e/docker/docker-compose.yml run --rm e2e
+  ```
+- **SELinux hosts (Fedora/RHEL/CentOS)**: bind-mounts need a
+  `:z` (or `:Z`) relabel. If the build inside the container fails
+  with `Permission denied` on `/workspace`, edit the volume entry
+  in `docker-compose.yml`:
+  ```yaml
+  volumes:
+    - ../..:/workspace:z
+  ```

--- a/e2e/docker/docker-compose.yml
+++ b/e2e/docker/docker-compose.yml
@@ -1,0 +1,65 @@
+# Convenience wrapper around the Dockerfile so callers don't have to
+# remember the volume layout. Usage from repo root:
+#
+#   # Build the image once (~5-10 min the first time, cached afterwards):
+#   docker compose -f e2e/docker/docker-compose.yml build
+#
+#   # Run the full wdio suite:
+#   docker compose -f e2e/docker/docker-compose.yml run --rm e2e
+#
+#   # Run a single spec:
+#   docker compose -f e2e/docker/docker-compose.yml run --rm e2e \
+#       bash e2e/docker/run-tests.sh \
+#       --spec test/specs/plugin-cross-vault-install.e2e.ts
+#
+#   # Drop into a shell:
+#   docker compose -f e2e/docker/docker-compose.yml run --rm e2e bash
+
+services:
+  e2e:
+    build:
+      # The Dockerfile builds a self-contained toolchain (Rust + Node
+      # + Xvfb + Electron deps) and never COPYs anything from the
+      # repo - the source tree comes in via the bind mount below.
+      # So we keep the build context as small as possible: just the
+      # docker/ subdir. This keeps `docker build` from sending the
+      # entire repo (target/, node_modules/, .git/) to the daemon.
+      context: .
+      dockerfile: Dockerfile
+      args:
+        # Match host UID/GID so files written into the bind mount don't
+        # come back owned by root on Linux hosts. macOS / Windows hosts
+        # ignore this; Linux hosts can override with:
+        #   USER_UID=$(id -u) USER_GID=$(id -g) docker compose build
+        USER_UID: ${USER_UID:-1000}
+        USER_GID: ${USER_GID:-1000}
+    # Bind-mount the repo so iteration is fast.
+    volumes:
+      - ../..:/workspace
+      # Linux node_modules differ from macOS; keep them out of the
+      # bind mount via named volumes.
+      - obsidian-plugin-node-modules:/workspace/obsidian-plugin/node_modules
+      - e2e-node-modules:/workspace/e2e/node_modules
+      # Cargo cache + target/ — survive across runs so incremental
+      # `cargo build` is fast.
+      - cargo-cache:/home/runner/.cargo
+      - cargo-target:/workspace/target
+      # Obsidian / chromedriver downloads — don't redownload every run.
+      - obsidian-cache:/workspace/e2e/.obsidian-cache
+    # Electron / Chromium needs more shared memory than the Docker
+    # default (64 MB) or it crashes mid-launch with "Out of memory".
+    shm_size: "2gb"
+    # Xvfb screen-rendering needs no IPC namespace, but be defensive.
+    init: true
+    # Stable hostname helps when reading container logs.
+    hostname: syncline-e2e
+    # No ports exposed by default — server / CLI / wdio all live in
+    # the container. If you want to attach a host browser to the
+    # session for debugging, add `ports: ["57195:57195"]` etc.
+
+volumes:
+  obsidian-plugin-node-modules:
+  e2e-node-modules:
+  cargo-cache:
+  cargo-target:
+  obsidian-cache:

--- a/e2e/docker/run-tests.sh
+++ b/e2e/docker/run-tests.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Containerised version of the wdio e2e flow used in the README.
+# Pass any wdio CLI args after `--`, e.g.:
+#
+#   docker compose run --rm e2e bash e2e/docker/run-tests.sh \
+#     --spec test/specs/plugin-cross-vault-install.e2e.ts
+#
+# Steps:
+#   1. cargo build --release --bin syncline   (Rust binary the spec spawns)
+#   2. obsidian-plugin: npm install, build (wasm-pack + rollup)
+#   3. e2e: npm install, run wdio under Xvfb
+#
+# Re-running is fast: the host-mounted target/, cargo cache, and the
+# two node_modules volumes mean only changed files are recompiled.
+
+set -euo pipefail
+
+cd /workspace
+
+echo "=== [1/3] cargo build --release --bin syncline ==="
+cargo build --release --bin syncline
+
+echo "=== [2/3] obsidian-plugin build (wasm-pack + rollup) ==="
+pushd obsidian-plugin >/dev/null
+# Prefer ci when a lockfile is present so we don't rewrite the host's
+# package-lock.json on Linux (would diff vs. macOS host install).
+if [[ -f package-lock.json ]]; then
+    npm ci --no-audit --no-fund
+else
+    npm install --no-audit --no-fund
+fi
+npm run build
+popd >/dev/null
+
+echo "=== [3/3] wdio under Xvfb ==="
+pushd e2e >/dev/null
+if [[ -f package-lock.json ]]; then
+    npm ci --no-audit --no-fund
+else
+    npm install --no-audit --no-fund
+fi
+
+# wdio-obsidian-service appends `--no-sandbox` on Linux automatically,
+# so we don't need to set chromiumFlags here. We just need a $DISPLAY.
+# `xvfb-run -a` picks an unused server number; the screen size is
+# generous enough that Obsidian's onboarding modals don't clip.
+exec xvfb-run -a --server-args='-screen 0 1280x900x24' \
+    npx wdio run wdio.conf.ts "$@"

--- a/e2e/test/specs/community-plugin-sync.e2e.ts
+++ b/e2e/test/specs/community-plugin-sync.e2e.ts
@@ -1,0 +1,325 @@
+// Community-plugin sync via configSync.communityPluginData.
+//
+// Realistic flow: the user has a community plugin installed in their
+// Obsidian vault (say "dataview"), and wants its files - main.js,
+// manifest.json, data.json - synced across devices via Syncline.
+// They opt in by toggling that plugin's checkbox in the Syncline
+// settings, which sets `configSync.communityPluginData[id] = true`.
+//
+// What this spec verifies, against real Obsidian + the WASM plugin:
+//   1. An opted-in plugin's full directory under `.obsidian/plugins/<id>/`
+//      lands on the CLI peer byte-identical.
+//   2. A second pre-seeded plugin that the user did NOT opt in to
+//      stays local - its files never reach the CLI peer.
+//   3. Edits made on the CLI side to the opted-in plugin's data.json
+//      propagate back into Obsidian's vault.
+//   4. `syncline verify` agrees with both peers.
+//
+// Side notes:
+//   - The plugin's hidden-file scanner runs on connect AND on a 30s
+//     interval; we never have to wait that long because the initial
+//     sweep happens immediately after the WS handshake.
+//   - The Syncline plugin self-excludes its own directory
+//     (`${configDir}/plugins/syncline/`) - this is enforced by
+//     `classifyHiddenPath` returning "self" - so we don't worry
+//     about its data.json racing into our test corpus.
+
+import { spawn, ChildProcess } from 'child_process';
+import { join, dirname } from 'path';
+import * as fs from 'fs';
+import * as crypto from 'crypto';
+import { expect, browser } from '@wdio/globals';
+
+describe('Syncline - community plugin syncs via configSync.communityPluginData', () => {
+    const port = 3071;
+    const serverUrl = `ws://localhost:${port}/sync`;
+    const repoRoot = join(__dirname, '../../../');
+    const e2eDir = join(__dirname, '../../');
+    const dbPath = join(e2eDir, 'community-plugin-sync.db');
+    const cliFolderPath = join(e2eDir, 'community-plugin-sync-cli');
+    const synclineBin = join(repoRoot, 'target/release/syncline');
+
+    // The user's "I want this synced" plugin.
+    const optedInId = 'fake-dataview';
+    // A second installed plugin the user has NOT opted in to. Its
+    // files must remain local.
+    const notOptedInId = 'private-plugin';
+
+    type Item = { rel: string; bytes: Buffer };
+    const optedInFiles: Item[] = [
+        {
+            rel: `.obsidian/plugins/${optedInId}/manifest.json`,
+            bytes: Buffer.from(
+                JSON.stringify({
+                    id: optedInId,
+                    name: 'Fake Dataview',
+                    version: '0.0.1',
+                    minAppVersion: '1.0.0',
+                    description: 'Test fixture',
+                    author: 'syncline-e2e',
+                }),
+            ),
+        },
+        {
+            rel: `.obsidian/plugins/${optedInId}/main.js`,
+            bytes: Buffer.from('module.exports = class {};\n// fake plugin source\n'),
+        },
+        {
+            rel: `.obsidian/plugins/${optedInId}/data.json`,
+            bytes: Buffer.from(JSON.stringify({ favoriteColor: 'syncline-cyan', counter: 0 })),
+        },
+    ];
+    const notOptedInFiles: Item[] = [
+        {
+            rel: `.obsidian/plugins/${notOptedInId}/manifest.json`,
+            bytes: Buffer.from(
+                JSON.stringify({
+                    id: notOptedInId,
+                    name: 'Private Plugin',
+                    version: '0.0.1',
+                    minAppVersion: '1.0.0',
+                    description: 'Should not sync',
+                    author: 'syncline-e2e',
+                }),
+            ),
+        },
+        {
+            rel: `.obsidian/plugins/${notOptedInId}/main.js`,
+            bytes: Buffer.from('module.exports = class { secret(){return 42;} };\n'),
+        },
+    ];
+
+    let serverProc: ChildProcess;
+    let cliProc: ChildProcess;
+
+    function fileSha(p: string): string {
+        return crypto.createHash('sha256').update(fs.readFileSync(p)).digest('hex');
+    }
+    function expectedSha(item: Item): string {
+        return crypto.createHash('sha256').update(item.bytes).digest('hex');
+    }
+
+    async function waitFor<T>(
+        label: string,
+        fn: () => Promise<T | null | undefined | false | ''>,
+        timeoutMs = 90_000,
+        stepMs = 500,
+    ): Promise<T> {
+        const deadline = Date.now() + timeoutMs;
+        let lastErr: unknown;
+        while (Date.now() < deadline) {
+            try {
+                const v = await fn();
+                if (v) return v as T;
+            } catch (e) {
+                lastErr = e;
+            }
+            await browser.pause(stepMs);
+        }
+        throw new Error(
+            `waitFor("${label}") timed out after ${timeoutMs}ms${lastErr ? `: ${String(lastErr)}` : ''}`,
+        );
+    }
+
+    before(async function () {
+        this.timeout(3 * 60_000);
+
+        if (!fs.existsSync(synclineBin)) {
+            throw new Error(
+                `syncline binary missing at ${synclineBin} - run "cargo build --release --bin syncline" from the repo root`,
+            );
+        }
+        if (fs.existsSync(dbPath)) fs.unlinkSync(dbPath);
+        if (fs.existsSync(cliFolderPath)) fs.rmSync(cliFolderPath, { recursive: true, force: true });
+        fs.mkdirSync(cliFolderPath, { recursive: true });
+
+        // Server.
+        let serverOut = '';
+        serverProc = spawn(
+            synclineBin,
+            ['server', '--port', String(port), '--db-path', dbPath, '--log-level', 'info'],
+            { stdio: 'pipe' },
+        );
+        serverProc.stdout?.on('data', (d) => {
+            serverOut += d;
+        });
+        serverProc.stderr?.on('data', (d) => {
+            serverOut += d;
+        });
+        await waitFor('server listening', async () => /listening/i.test(serverOut), 30_000, 100);
+
+        // CLI peer with empty folder.
+        let cliOut = '';
+        cliProc = spawn(
+            synclineBin,
+            ['sync', '-f', cliFolderPath, '-u', serverUrl, '--name', 'cli-peer', '--log-level', 'info'],
+            { stdio: 'pipe' },
+        );
+        cliProc.stdout?.on('data', (d) => {
+            cliOut += d;
+        });
+        cliProc.stderr?.on('data', (d) => {
+            cliOut += d;
+        });
+        await waitFor('CLI handshake', async () => /v1 handshake OK/.test(cliOut), 30_000, 100);
+
+        // Seed both plugins' files in Obsidian's vault before the
+        // plugin connects.
+        const vaultPath: string = await browser.executeObsidian(
+            async ({ app }) => (app as any).vault.adapter.basePath as string,
+        );
+        for (const item of [...optedInFiles, ...notOptedInFiles]) {
+            const dst = join(vaultPath, item.rel);
+            fs.mkdirSync(dirname(dst), { recursive: true });
+            fs.writeFileSync(dst, item.bytes);
+        }
+        await browser.pause(1500);
+
+        // Enable + configure the Syncline plugin: opt-in only the
+        // first plugin's data sync. The second one's
+        // communityPluginData entry stays falsy/unset, so its files
+        // must never propagate.
+        const obsidianPage = browser.getObsidianPage();
+        try {
+            await obsidianPage.enablePlugin('syncline');
+        } catch (e: any) {
+            console.error('Could not enable plugin or already enabled:', e?.message);
+        }
+        await browser.executeObsidian(
+            async ({ app }, [url, optedId]) => {
+                const plugin: any = (app as any).plugins.plugins['syncline'];
+                if (!plugin) throw new Error('Syncline plugin not found in app.plugins');
+                plugin.settings.serverUrl = url;
+                plugin.settings.configSync = {
+                    ...plugin.settings.configSync,
+                    communityPluginData: {
+                        ...(plugin.settings.configSync?.communityPluginData ?? {}),
+                        [optedId]: true,
+                    },
+                };
+                await plugin.saveSettings();
+                plugin.disconnect();
+                await plugin.connect();
+            },
+            [serverUrl, optedInId] as [string, string],
+        );
+        await waitFor(
+            'plugin connected',
+            async () =>
+                browser.executeObsidian(async ({ app }) => {
+                    const plugin: any = (app as any).plugins.plugins['syncline'];
+                    return !!(plugin && plugin.client && plugin.client.isConnected());
+                }),
+            30_000,
+            200,
+        );
+    });
+
+    after(() => {
+        if (cliProc && !cliProc.killed) cliProc.kill();
+        if (serverProc && !serverProc.killed) serverProc.kill();
+    });
+
+    it('opted-in plugin files arrive on the CLI peer byte-identical', async function () {
+        this.timeout(3 * 60_000);
+
+        await waitFor(
+            'all opted-in plugin files materialised on CLI peer',
+            async () => {
+                for (const item of optedInFiles) {
+                    const dst = join(cliFolderPath, item.rel);
+                    if (!fs.existsSync(dst)) return false;
+                    if (fileSha(dst) !== expectedSha(item)) return false;
+                }
+                return true;
+            },
+            150_000,
+            500,
+        );
+
+        for (const item of optedInFiles) {
+            const dst = join(cliFolderPath, item.rel);
+            expect(fs.existsSync(dst)).toBe(true);
+            expect(fileSha(dst)).toBe(expectedSha(item));
+        }
+    });
+
+    it('non-opted-in plugin stays local and never propagates', async () => {
+        // The previous test waited for the opted-in plugin's full
+        // arrival; by now anything racing through the same scan/push
+        // pipeline would already be visible. A short pause guards the
+        // hidden-file-scanner's interval tick (30s) wasn't able to
+        // sneak the un-opted-in plugin in afterwards.
+        await browser.pause(2000);
+        for (const item of notOptedInFiles) {
+            const dst = join(cliFolderPath, item.rel);
+            expect(fs.existsSync(dst)).toBe(
+                false,
+            );
+        }
+        // And the directory itself shouldn't have been materialised
+        // either - the parent ".obsidian/plugins/" can exist (it's
+        // shared with the opted-in plugin), but the un-opted-in
+        // subdir must not.
+        const privateDir = join(cliFolderPath, '.obsidian/plugins', notOptedInId);
+        expect(fs.existsSync(privateDir)).toBe(false);
+    });
+
+    it('CLI-side edit to opted-in plugin data.json round-trips into Obsidian', async function () {
+        this.timeout(60_000);
+
+        // Modify data.json on the CLI side and watch it land in the
+        // Obsidian vault.
+        const target = optedInFiles.find((i) => i.rel.endsWith('data.json'))!;
+        const newBody = JSON.stringify({ favoriteColor: 'syncline-cyan', counter: 7 });
+        fs.writeFileSync(join(cliFolderPath, target.rel), newBody);
+
+        const vaultPath: string = await browser.executeObsidian(
+            async ({ app }) => (app as any).vault.adapter.basePath as string,
+        );
+        const expectedHash = crypto.createHash('sha256').update(newBody).digest('hex');
+        await waitFor(
+            'data.json edit reaches Obsidian vault',
+            async () => {
+                const dst = join(vaultPath, target.rel);
+                if (!fs.existsSync(dst)) return false;
+                return fileSha(dst) === expectedHash;
+            },
+            45_000,
+            500,
+        );
+    });
+
+    it('`syncline verify` reports convergence on the CLI peer', async function () {
+        this.timeout(60_000);
+
+        if (cliProc && !cliProc.killed) cliProc.kill();
+        await browser.pause(1500);
+
+        await new Promise<void>((resolve, reject) => {
+            const verify = spawn(
+                synclineBin,
+                ['verify', '-f', cliFolderPath, '-u', serverUrl, '--timeout-secs', '10', '--log-level', 'info'],
+                { stdio: 'pipe' },
+            );
+            let buf = '';
+            verify.stdout?.on('data', (d) => {
+                buf += d;
+            });
+            verify.stderr?.on('data', (d) => {
+                buf += d;
+            });
+            verify.on('exit', (code) => {
+                if (code === 0 && /converged/i.test(buf)) {
+                    resolve();
+                } else {
+                    reject(
+                        new Error(
+                            `verify exited with code=${code}\nstdout/stderr:\n${buf}`,
+                        ),
+                    );
+                }
+            });
+        });
+    });
+});

--- a/e2e/test/specs/plugin-cross-vault-install.e2e.ts
+++ b/e2e/test/specs/plugin-cross-vault-install.e2e.ts
@@ -1,0 +1,354 @@
+// Cross-vault community-plugin installation via Syncline.
+//
+// Real user story:
+//   "I installed the Tasks plugin in my desktop vault. I want to open
+//    Obsidian on my laptop and have Tasks already there."
+//
+// What we drive end-to-end:
+//   1. Vault A (desktop) has the plugin's files on disk under
+//      `.obsidian/plugins/<id>/` and ticks the per-plugin
+//      `configSync.communityPluginData[<id>]` checkbox in the Syncline
+//      settings.
+//   2. Syncline pushes those files to the server.
+//   3. A separate CLI peer attached to the same server witnesses the
+//      upload byte-identical (proxy for "another always-on device").
+//   4. We reboot Obsidian into a brand-new empty vault B with Syncline
+//      pre-installed but no plugins or config carried over.
+//   5. Vault B's Syncline points at the same server with the same
+//      per-plugin opt-in. The plugin's files materialise on vault B's
+//      disk.
+//   6. Triggering `app.plugins.loadManifests()` on vault B surfaces
+//      the new plugin in `app.plugins.manifests` - the same registry
+//      Obsidian's "Installed plugins" list reads from. By Obsidian's
+//      own definition the plugin is now installed on vault B.
+//
+// Caveat: we use a synthesised "Tasks-like" plugin (id `e2e-fake-tasks`)
+// with a minimal but valid manifest.json + main.js + data.json. Using
+// the real Tasks bundle would tie the test to a network download and
+// to a specific upstream version - what we want to exercise is the
+// SYNC, not the plugin runtime. The shape of the files is exactly
+// what Obsidian's plugin loader expects.
+
+import { spawn, ChildProcess } from 'child_process';
+import { join, dirname } from 'path';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as crypto from 'crypto';
+import { expect, browser } from '@wdio/globals';
+
+describe('Syncline - community plugin installs cross-vault via the network', () => {
+    const port = 3072;
+    const serverUrl = `ws://localhost:${port}/sync`;
+    const repoRoot = join(__dirname, '../../../');
+    const e2eDir = join(__dirname, '../../');
+    const dbPath = join(e2eDir, 'plugin-cross-vault.db');
+    const cliFolderPath = join(e2eDir, 'plugin-cross-vault-cli');
+    const synclineBin = join(repoRoot, 'target/release/syncline');
+
+    // The plugin we are "installing" in vault A and expecting to see in vault B.
+    const PLUGIN_ID = 'e2e-fake-tasks';
+    type Item = { rel: string; bytes: Buffer };
+    const pluginFiles: Item[] = [
+        {
+            rel: `.obsidian/plugins/${PLUGIN_ID}/manifest.json`,
+            bytes: Buffer.from(
+                JSON.stringify({
+                    id: PLUGIN_ID,
+                    name: 'E2E Fake Tasks',
+                    version: '0.0.1',
+                    minAppVersion: '1.0.0',
+                    description: 'Synthesised stand-in for the Tasks plugin used by Syncline e2e.',
+                    author: 'syncline-e2e',
+                    isDesktopOnly: false,
+                }),
+            ),
+        },
+        {
+            rel: `.obsidian/plugins/${PLUGIN_ID}/main.js`,
+            // Minimal-but-valid Obsidian plugin body. We don't load it
+            // (loadManifests() only reads manifest.json), but ship it
+            // to mirror a real plugin's on-disk shape.
+            bytes: Buffer.from(
+                "'use strict';\nObject.defineProperty(exports, '__esModule', { value: true });\n" +
+                    "const obsidian = require('obsidian');\n" +
+                    'class FakeTasksPlugin extends obsidian.Plugin {\n' +
+                    '  async onload() {}\n' +
+                    '  async onunload() {}\n' +
+                    '}\n' +
+                    'module.exports = FakeTasksPlugin;\n',
+            ),
+        },
+        {
+            rel: `.obsidian/plugins/${PLUGIN_ID}/data.json`,
+            bytes: Buffer.from(JSON.stringify({ tasks: [], counter: 0 })),
+        },
+    ];
+
+    // A blank vault layout we'll feed to `reloadObsidian({ vault: ... })`
+    // for phase B. Has to be a real path on disk; wdio-obsidian-service
+    // copies it before opening, so anything we leave here stays
+    // unchanged across runs.
+    const vaultBSrc = fs.mkdtempSync(join(os.tmpdir(), 'syncline-vaultB-src-'));
+    fs.mkdirSync(join(vaultBSrc, '.obsidian'), { recursive: true });
+    // A throwaway note so Obsidian considers the vault non-empty.
+    fs.writeFileSync(
+        join(vaultBSrc, 'README.md'),
+        '# vault B\nthis is the laptop side\n',
+    );
+
+    let serverProc: ChildProcess;
+    let cliProc: ChildProcess;
+
+    function fileSha(p: string): string {
+        return crypto.createHash('sha256').update(fs.readFileSync(p)).digest('hex');
+    }
+    function expectedSha(item: Item): string {
+        return crypto.createHash('sha256').update(item.bytes).digest('hex');
+    }
+
+    async function waitFor<T>(
+        label: string,
+        fn: () => Promise<T | null | undefined | false | ''>,
+        timeoutMs = 90_000,
+        stepMs = 500,
+    ): Promise<T> {
+        const deadline = Date.now() + timeoutMs;
+        let lastErr: unknown;
+        while (Date.now() < deadline) {
+            try {
+                const v = await fn();
+                if (v) return v as T;
+            } catch (e) {
+                lastErr = e;
+            }
+            await browser.pause(stepMs);
+        }
+        throw new Error(
+            `waitFor("${label}") timed out after ${timeoutMs}ms${lastErr ? `: ${String(lastErr)}` : ''}`,
+        );
+    }
+
+    /** Set the Syncline plugin's serverUrl + per-plugin opt-in,
+     *  reconnect, and wait for `isConnected()`. Idempotent - safe to
+     *  call from both vault A and vault B's Obsidian. */
+    async function configureAndConnectSyncline(): Promise<void> {
+        const obsidianPage = browser.getObsidianPage();
+        try {
+            await obsidianPage.enablePlugin('syncline');
+        } catch (e: any) {
+            console.error('enablePlugin (syncline) said:', e?.message);
+        }
+        await browser.executeObsidian(
+            async ({ app }, [url, optedId]) => {
+                const plugin: any = (app as any).plugins.plugins['syncline'];
+                if (!plugin) throw new Error('Syncline plugin not loaded');
+                plugin.settings.serverUrl = url;
+                plugin.settings.configSync = {
+                    ...plugin.settings.configSync,
+                    communityPluginData: {
+                        ...(plugin.settings.configSync?.communityPluginData ?? {}),
+                        [optedId]: true,
+                    },
+                };
+                await plugin.saveSettings();
+                plugin.disconnect();
+                await plugin.connect();
+            },
+            [serverUrl, PLUGIN_ID] as [string, string],
+        );
+        await waitFor(
+            'Syncline plugin connected',
+            async () =>
+                browser.executeObsidian(async ({ app }) => {
+                    const plugin: any = (app as any).plugins.plugins['syncline'];
+                    return !!(plugin && plugin.client && plugin.client.isConnected());
+                }),
+            30_000,
+            200,
+        );
+    }
+
+    before(async function () {
+        this.timeout(3 * 60_000);
+
+        if (!fs.existsSync(synclineBin)) {
+            throw new Error(
+                `syncline binary missing at ${synclineBin} - run "cargo build --release --bin syncline"`,
+            );
+        }
+        if (fs.existsSync(dbPath)) fs.unlinkSync(dbPath);
+        if (fs.existsSync(cliFolderPath)) fs.rmSync(cliFolderPath, { recursive: true, force: true });
+        fs.mkdirSync(cliFolderPath, { recursive: true });
+
+        // Server.
+        let serverOut = '';
+        serverProc = spawn(
+            synclineBin,
+            ['server', '--port', String(port), '--db-path', dbPath, '--log-level', 'info'],
+            { stdio: 'pipe' },
+        );
+        serverProc.stdout?.on('data', (d) => {
+            serverOut += d;
+        });
+        serverProc.stderr?.on('data', (d) => {
+            serverOut += d;
+        });
+        await waitFor('server listening', async () => /listening/i.test(serverOut), 30_000, 100);
+
+        // Persistent CLI peer.
+        let cliOut = '';
+        cliProc = spawn(
+            synclineBin,
+            ['sync', '-f', cliFolderPath, '-u', serverUrl, '--name', 'cli-peer', '--log-level', 'info'],
+            { stdio: 'pipe' },
+        );
+        cliProc.stdout?.on('data', (d) => {
+            cliOut += d;
+        });
+        cliProc.stderr?.on('data', (d) => {
+            cliOut += d;
+        });
+        await waitFor('CLI handshake', async () => /v1 handshake OK/.test(cliOut), 30_000, 100);
+    });
+
+    after(() => {
+        if (cliProc && !cliProc.killed) cliProc.kill();
+        if (serverProc && !serverProc.killed) serverProc.kill();
+        try {
+            fs.rmSync(vaultBSrc, { recursive: true, force: true });
+        } catch {}
+    });
+
+    it('vault A pushes the plugin files to the server (CLI peer witnesses)', async function () {
+        this.timeout(3 * 60_000);
+
+        // Drop the plugin into vault A (the default vault Obsidian was
+        // launched with by the wdio config).
+        const vaultAPath: string = await browser.executeObsidian(
+            async ({ app }) => (app as any).vault.adapter.basePath as string,
+        );
+        for (const item of pluginFiles) {
+            const dst = join(vaultAPath, item.rel);
+            fs.mkdirSync(dirname(dst), { recursive: true });
+            fs.writeFileSync(dst, item.bytes);
+        }
+        await browser.pause(1500);
+
+        await configureAndConnectSyncline();
+
+        // CLI peer should now have the plugin files byte-identical.
+        await waitFor(
+            'plugin files visible on CLI peer',
+            async () => {
+                for (const item of pluginFiles) {
+                    const dst = join(cliFolderPath, item.rel);
+                    if (!fs.existsSync(dst)) return false;
+                    if (fileSha(dst) !== expectedSha(item)) return false;
+                }
+                return true;
+            },
+            150_000,
+            500,
+        );
+        for (const item of pluginFiles) {
+            expect(fileSha(join(cliFolderPath, item.rel))).toBe(expectedSha(item));
+        }
+    });
+
+    it('a fresh Obsidian vault sees the plugin appear via Syncline alone', async function () {
+        this.timeout(5 * 60_000);
+
+        // Reboot Obsidian into a fresh empty vault B with Syncline
+        // re-enabled. wdio-obsidian-service copies vaultBSrc, so vault
+        // A's files are out of the picture - the only path the plugin
+        // can reach vault B is through the server.
+        await browser.reloadObsidian({
+            vault: vaultBSrc,
+            plugins: ['syncline'],
+        });
+
+        const vaultBPath: string = await browser.executeObsidian(
+            async ({ app }) => (app as any).vault.adapter.basePath as string,
+        );
+
+        // Sanity: vault B starts without the plugin's directory.
+        expect(fs.existsSync(join(vaultBPath, '.obsidian/plugins', PLUGIN_ID))).toBe(false);
+
+        // Configure Syncline on vault B (same server, same opt-in).
+        await configureAndConnectSyncline();
+
+        // Plugin files materialise on vault B's disk via Syncline alone.
+        await waitFor(
+            'plugin files materialise on vault B',
+            async () => {
+                for (const item of pluginFiles) {
+                    const dst = join(vaultBPath, item.rel);
+                    if (!fs.existsSync(dst)) return false;
+                    if (fileSha(dst) !== expectedSha(item)) return false;
+                }
+                return true;
+            },
+            150_000,
+            500,
+        );
+
+        // Now ask Obsidian to rescan its plugins folder. The newly
+        // arrived plugin must show up in the same registry the
+        // "Installed plugins" UI reads from.
+        const installed: any = await browser.executeObsidian(
+            async ({ app }, id) => {
+                const p: any = (app as any).plugins;
+                if (typeof p.loadManifests === 'function') {
+                    await p.loadManifests();
+                } else if (typeof p.loadManifest === 'function') {
+                    // Older Obsidians used a singular form. Either is
+                    // fine for the test - we just need the new
+                    // manifest registered.
+                    await p.loadManifest();
+                }
+                const m = p.manifests?.[id];
+                return m
+                    ? { id: m.id, name: m.name, version: m.version }
+                    : null;
+            },
+            PLUGIN_ID,
+        );
+        expect(installed).not.toBeNull();
+        expect(installed.id).toBe(PLUGIN_ID);
+        expect(installed.version).toBe('0.0.1');
+        expect(installed.name).toBe('E2E Fake Tasks');
+    });
+
+    it('`syncline verify` reports convergence on the CLI peer', async function () {
+        this.timeout(60_000);
+
+        if (cliProc && !cliProc.killed) cliProc.kill();
+        await browser.pause(1500);
+
+        await new Promise<void>((resolve, reject) => {
+            const verify = spawn(
+                synclineBin,
+                ['verify', '-f', cliFolderPath, '-u', serverUrl, '--timeout-secs', '10', '--log-level', 'info'],
+                { stdio: 'pipe' },
+            );
+            let buf = '';
+            verify.stdout?.on('data', (d) => {
+                buf += d;
+            });
+            verify.stderr?.on('data', (d) => {
+                buf += d;
+            });
+            verify.on('exit', (code) => {
+                if (code === 0 && /converged/i.test(buf)) {
+                    resolve();
+                } else {
+                    reject(
+                        new Error(
+                            `verify exited code=${code}\nstdout/stderr:\n${buf}`,
+                        ),
+                    );
+                }
+            });
+        });
+    });
+});

--- a/e2e/test/specs/pre-existing-vault.e2e.ts
+++ b/e2e/test/specs/pre-existing-vault.e2e.ts
@@ -1,0 +1,316 @@
+// Pre-existing-vault onboarding (Obsidian).
+//
+// User flow under test (mirrors a real first install):
+//   1. `syncline server` runs.
+//   2. A CLI peer is already attached to the server with an empty folder
+//      (the user's "always on" backup peer).
+//   3. The user opens Obsidian on a vault that ALREADY contains notes
+//      and a binary attachment - all pre-existing on disk before the
+//      plugin is ever enabled.
+//   4. They install + enable the Syncline plugin and point it at the
+//      server.
+//   5. The plugin's first scan must push every pre-existing note + the
+//      binary to the server.
+//   6. The CLI peer must materialise everything byte-identical.
+//   7. `.obsidian/workspace.json` is device-local and must NEVER
+//      propagate, even though the plugin scans .obsidian/ for the
+//      coreConfig category.
+//   8. Bidirectional sync continues to work after onboarding.
+
+import { spawn, ChildProcess } from 'child_process';
+import { join, dirname } from 'path';
+import * as fs from 'fs';
+import * as crypto from 'crypto';
+import { expect, browser } from '@wdio/globals';
+
+describe('Syncline - Obsidian vault with pre-existing content joins server + CLI peer', () => {
+    const port = 3070;
+    const serverUrl = `ws://localhost:${port}/sync`;
+    const repoRoot = join(__dirname, '../../../');
+    const e2eDir = join(__dirname, '../../');
+    const dbPath = join(e2eDir, 'pre-existing-vault.db');
+    const cliFolderPath = join(e2eDir, 'pre-existing-vault-cli');
+    const synclineBin = join(repoRoot, 'target/release/syncline');
+
+    // The corpus the user is bringing to Syncline. We focus on the
+    // user-content surface (notes + attachments) and assert one
+    // negative case for `.obsidian/workspace.json` (device-local).
+    //
+    // We do NOT seed any other `.obsidian/*` files because the
+    // plugin's per-category configSync defaults are non-trivial
+    // (DEFAULT_CONFIG_SYNC in main.ts: themes:true, snippets:true,
+    // hotkeys:true, coreConfig:true, communityPluginList:false,
+    // other:false). Testing those paths belongs in its own spec.
+    type Item = { rel: string; bytes: Buffer };
+    const userContent: Item[] = [
+        { rel: 'welcome.md', bytes: Buffer.from('hello from pre-existing vault\n') },
+        {
+            rel: 'notes/daily/day1.md',
+            bytes: Buffer.from('# Day 1\nfirst entry\n'),
+        },
+        {
+            rel: 'assets/photo.jpg',
+            bytes: Buffer.concat([
+                Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]),
+                Buffer.from('JFIF pretend-jpeg-bytes-with-some-noise'),
+                Buffer.from([0xde, 0xad, 0xbe, 0xef]),
+            ]),
+        },
+    ];
+
+    // Device-local Obsidian state. Must never propagate.
+    const deviceLocal: Item = {
+        rel: '.obsidian/workspace.json',
+        bytes: Buffer.from('{"layout":"device-local-private"}'),
+    };
+
+    let serverProc: ChildProcess;
+    let cliProc: ChildProcess;
+
+    function fileSha(p: string): string {
+        return crypto.createHash('sha256').update(fs.readFileSync(p)).digest('hex');
+    }
+    function expectedSha(item: Item): string {
+        return crypto.createHash('sha256').update(item.bytes).digest('hex');
+    }
+
+    async function waitFor<T>(
+        label: string,
+        fn: () => Promise<T | null | undefined | false | ''>,
+        timeoutMs = 60_000,
+        stepMs = 250,
+    ): Promise<T> {
+        const deadline = Date.now() + timeoutMs;
+        let lastErr: unknown;
+        while (Date.now() < deadline) {
+            try {
+                const v = await fn();
+                if (v) return v as T;
+            } catch (e) {
+                lastErr = e;
+            }
+            await browser.pause(stepMs);
+        }
+        throw new Error(
+            `waitFor("${label}") timed out after ${timeoutMs}ms${lastErr ? `: ${String(lastErr)}` : ''}`,
+        );
+    }
+
+    before(async function () {
+        this.timeout(3 * 60_000);
+
+        if (!fs.existsSync(synclineBin)) {
+            throw new Error(
+                `syncline binary missing at ${synclineBin} - run "cargo build --release --bin syncline" from the repo root`,
+            );
+        }
+        if (fs.existsSync(dbPath)) fs.unlinkSync(dbPath);
+        if (fs.existsSync(cliFolderPath)) fs.rmSync(cliFolderPath, { recursive: true, force: true });
+        fs.mkdirSync(cliFolderPath, { recursive: true });
+
+        // -------- 1. server ----------------------------------------------
+        let serverOut = '';
+        serverProc = spawn(
+            synclineBin,
+            ['server', '--port', String(port), '--db-path', dbPath, '--log-level', 'info'],
+            { stdio: 'pipe' },
+        );
+        serverProc.stdout?.on('data', (d) => {
+            serverOut += d;
+        });
+        serverProc.stderr?.on('data', (d) => {
+            serverOut += d;
+        });
+        await waitFor('server listening', async () => /listening/i.test(serverOut), 30_000, 100);
+
+        // -------- 2. CLI peer with an empty folder -----------------------
+        let cliOut = '';
+        cliProc = spawn(
+            synclineBin,
+            ['sync', '-f', cliFolderPath, '-u', serverUrl, '--name', 'cli-peer', '--log-level', 'info'],
+            { stdio: 'pipe' },
+        );
+        cliProc.stdout?.on('data', (d) => {
+            cliOut += d;
+        });
+        cliProc.stderr?.on('data', (d) => {
+            cliOut += d;
+        });
+        await waitFor('CLI handshake', async () => /v1 handshake OK/.test(cliOut), 30_000, 100);
+
+        // -------- 3. seed Obsidian's vault BEFORE the plugin is enabled --
+        const vaultPath: string = await browser.executeObsidian(
+            async ({ app }) => (app as any).vault.adapter.basePath as string,
+        );
+        for (const item of userContent) {
+            const dst = join(vaultPath, item.rel);
+            fs.mkdirSync(dirname(dst), { recursive: true });
+            fs.writeFileSync(dst, item.bytes);
+        }
+        // Also seed the device-local file. Obsidian may overwrite it
+        // when it shuts down; doesn't matter, the assertion is just
+        // "this file never reached the CLI peer".
+        const dlDst = join(vaultPath, deviceLocal.rel);
+        fs.mkdirSync(dirname(dlDst), { recursive: true });
+        fs.writeFileSync(dlDst, deviceLocal.bytes);
+
+        // Give Obsidian's vault watcher a moment to register the new
+        // files. The plugin's scan also runs on connect, so even if
+        // the watcher missed an event, scan_once will pick everything
+        // up.
+        await browser.pause(1500);
+
+        // -------- 4. enable + connect plugin ----------------------------
+        const obsidianPage = browser.getObsidianPage();
+        try {
+            await obsidianPage.enablePlugin('syncline');
+        } catch (e: any) {
+            console.error('Could not enable plugin or already enabled:', e?.message);
+        }
+        await browser.executeObsidian(async ({ app }, url) => {
+            const plugin: any = (app as any).plugins.plugins['syncline'];
+            if (!plugin) throw new Error('Syncline plugin not found in app.plugins');
+            plugin.settings.serverUrl = url;
+            await plugin.saveSettings();
+            plugin.disconnect();
+            await plugin.connect();
+        }, serverUrl);
+        await waitFor(
+            'plugin connected',
+            async () =>
+                browser.executeObsidian(async ({ app }) => {
+                    const plugin: any = (app as any).plugins.plugins['syncline'];
+                    return !!(plugin && plugin.client && plugin.client.isConnected());
+                }),
+            30_000,
+            200,
+        );
+    });
+
+    after(() => {
+        if (cliProc && !cliProc.killed) cliProc.kill();
+        if (serverProc && !serverProc.killed) serverProc.kill();
+    });
+
+    it('plugin pushes pre-existing notes + attachments to the CLI peer', async function () {
+        // Plugin's first scan + WS push of three small files should
+        // settle in well under a minute, but Obsidian's launch is
+        // slow on cold runs - give it a roomy budget.
+        this.timeout(3 * 60_000);
+
+        await waitFor(
+            'all user-content items materialised on CLI peer',
+            async () => {
+                for (const item of userContent) {
+                    const dst = join(cliFolderPath, item.rel);
+                    if (!fs.existsSync(dst)) return false;
+                    if (fileSha(dst) !== expectedSha(item)) return false;
+                }
+                return true;
+            },
+            150_000,
+            500,
+        );
+
+        // Per-file byte assertions for clear failure messages.
+        for (const item of userContent) {
+            const dst = join(cliFolderPath, item.rel);
+            expect(fs.existsSync(dst)).toBe(true);
+            expect(fileSha(dst)).toBe(expectedSha(item));
+        }
+    });
+
+    it('device-local workspace.json never propagates', async () => {
+        // The previous test waited for full convergence on the user
+        // content, so by now any racy ".obsidian/workspace.json"
+        // sync would already have happened. A short extra pause
+        // guards against the unlikely case the plugin does a delayed
+        // configSync pass.
+        await browser.pause(2000);
+        const dst = join(cliFolderPath, deviceLocal.rel);
+        expect(fs.existsSync(dst)).toBe(false);
+    });
+
+    it('bidirectional sync still works after onboarding', async function () {
+        this.timeout(60_000);
+
+        // CLI side adds a fresh note. Plugin should pick it up via
+        // the manifest broadcast and reify it in Obsidian's vault.
+        const cliRel = 'notes/daily/from-cli.md';
+        const cliBytes = Buffer.from('# from CLI\nhi obsidian\n');
+        fs.mkdirSync(join(cliFolderPath, dirname(cliRel)), { recursive: true });
+        fs.writeFileSync(join(cliFolderPath, cliRel), cliBytes);
+
+        const vaultPath: string = await browser.executeObsidian(
+            async ({ app }) => (app as any).vault.adapter.basePath as string,
+        );
+
+        await waitFor(
+            'CLI add propagates into Obsidian vault',
+            async () => {
+                const dst = join(vaultPath, cliRel);
+                if (!fs.existsSync(dst)) return false;
+                return fileSha(dst) === crypto.createHash('sha256').update(cliBytes).digest('hex');
+            },
+            45_000,
+            500,
+        );
+
+        // Obsidian side modifies an existing pre-seeded note via the
+        // vault API (so it goes through Obsidian's own write path,
+        // matching what real users do via the editor).
+        const newBody = 'hello from pre-existing vault\nappended via Obsidian editor\n';
+        await browser.executeObsidian(async ({ app }, body) => {
+            const f = (app as any).vault.getAbstractFileByPath('welcome.md');
+            if (!f) throw new Error('welcome.md not found in vault');
+            await (app as any).vault.modify(f, body);
+        }, newBody);
+
+        const expectedHash = crypto.createHash('sha256').update(newBody).digest('hex');
+        await waitFor(
+            'Obsidian edit propagates back to CLI peer',
+            async () => {
+                const dst = join(cliFolderPath, 'welcome.md');
+                if (!fs.existsSync(dst)) return false;
+                return fileSha(dst) === expectedHash;
+            },
+            45_000,
+            500,
+        );
+    });
+
+    it('`syncline verify` reports convergence on the CLI peer', async function () {
+        this.timeout(60_000);
+
+        // Stop the live sync so verify can read the local state without
+        // contention. Reuse the syncline binary in `verify` mode.
+        if (cliProc && !cliProc.killed) cliProc.kill();
+        await browser.pause(1500);
+
+        await new Promise<void>((resolve, reject) => {
+            const verify = spawn(
+                synclineBin,
+                ['verify', '-f', cliFolderPath, '-u', serverUrl, '--timeout-secs', '10', '--log-level', 'info'],
+                { stdio: 'pipe' },
+            );
+            let buf = '';
+            verify.stdout?.on('data', (d) => {
+                buf += d;
+            });
+            verify.stderr?.on('data', (d) => {
+                buf += d;
+            });
+            verify.on('exit', (code) => {
+                if (code === 0 && /converged/i.test(buf)) {
+                    resolve();
+                } else {
+                    reject(
+                        new Error(
+                            `verify exited with code=${code}\nstdout/stderr:\n${buf}`,
+                        ),
+                    );
+                }
+            });
+        });
+    });
+});

--- a/prompt.md
+++ b/prompt.md
@@ -1,0 +1,639 @@
+# Syncline testing playbook
+
+This document is the long-form testing reference for Syncline. Hand
+it to a new engineer (or a future LLM) and they should be able to
+exercise every layer of the system - the Rust library, the server,
+the CLI client, the Obsidian plugin (via wdio), and the on-disk /
+in-database state - without first having to grep their way through
+the source tree.
+
+It is not a tutorial. It is an exhaustive map: for every component,
+how do you start it, how do you observe it, how do you tear it
+down, and how do you assert against it.
+
+---
+
+## 1. The system in one minute
+
+Three processes, one CRDT, one append-only DB, one CAS:
+
+```
+   Obsidian (plugin: WASM)         CLI sync (native)
+        │                                 │
+        │ MSG_VERSION + MSG_MANIFEST_*    │
+        │ MSG_SYNC_STEP_1/2 + MSG_UPDATE  │
+        │ MSG_BLOB_REQUEST/UPDATE         │
+        ▼                                 ▼
+                  syncline server (axum + tokio)
+                                ▼
+                        SQLite: updates, blobs
+```
+
+- **Manifest** (`__manifest__`): one Yrs Y.Doc per vault listing
+  every node (file/dir) by stable `NodeId`. Owns the vault's
+  namespace.
+- **Content subdocs** (`content:<NodeId>`): one Yrs Y.Doc per text
+  file, holding a `Y.Text` named `text`.
+- **Blobs**: SHA-256-keyed binary chunks (FastCDC-split for files
+  > 1 MiB; small files are a length-1 chunk list).
+
+Reference docs in the repo:
+- `docs/DESIGN_DOC_V1.md` - protocol + LWW rules.
+- `docs/PROTOCOL.md` - wire format.
+- `docs/KNOWN_BUGS.md` - historical fault list (v0 era).
+
+---
+
+## 2. Library tests (Rust, no I/O or in-process subprocess)
+
+Three layers, all under `cargo test -p syncline`:
+
+| File / module                              | Coverage                                            |
+| ------------------------------------------ | --------------------------------------------------- |
+| `src/v1/*` `#[cfg(test)] mod tests`        | Per-module unit tests (manifest, projection, ops, sync, ids, chunker, …) |
+| `src/client_v1.rs` `tests` module          | ContentStore disk roundtrips, reconcile, watcher batching, conflict-sibling recogniser |
+| `src/server/server.rs` `tests` module      | WS handshake, manifest sync, blob upload (uses `axum::serve` on an ephemeral port) |
+| `tests/v1_protocol_e2e.rs`                 | Bidirectional manifest sync between two `Manifest`s in-process; verify heartbeat |
+| `tests/v1_robustness.rs`                   | Concurrent rename/delete/modify scenarios, fuzz, conflict suffixes, lamport overflow, build_path is_live, etc. |
+| `tests/e2e.rs`                             | Subprocess-based: spawns real `syncline server` + `syncline sync` binaries via tokio::process |
+
+Run patterns:
+
+```bash
+# Whole crate (slow because of e2e):
+cargo test -p syncline
+
+# Just the lib units (~5s):
+cargo test -p syncline --lib
+
+# Just one integration test file:
+cargo test -p syncline --test v1_robustness
+cargo test -p syncline --test v1_protocol_e2e
+cargo test -p syncline --test e2e
+cargo test -p syncline --test e2e test_obsidian_like_onboarding
+
+# Module filter:
+cargo test -p syncline --lib v1::projection
+cargo test -p syncline --lib client_v1::tests::reconcile_
+
+# Single test:
+cargo test -p syncline --test v1_robustness directory_resurrected
+```
+
+`tests/e2e.rs` uses an atomic counter for ports starting at 18000 -
+each test gets a fresh port. The other test files don't touch the
+network.
+
+### Adding a manifest-CRDT scenario
+
+Pure-portable scenarios (no fs, no network) belong in
+`tests/v1_robustness.rs`. There's an `Xs` PRNG + `random_op` helper
+and a `full_mesh_sync` helper for N-peer convergence. Pattern:
+
+```rust
+let mut a = Manifest::new(ActorId::new());
+let id = create_text(&mut a, "f.md", 0)?;
+let mut b = Manifest::from_update(
+    ActorId::new(), a.lamport(), &a.encode_state_as_update(),
+)?;
+
+a.set_name(id, "renamed.md");
+delete_path(&mut b, "f.md")?;
+
+sync(&mut a, &mut b);
+assert_converged("rename-vs-delete", &[&a, &b]);
+```
+
+`assert_converged` compares `projection_hash`. For per-path
+assertions, use `project(m).by_path.contains_key("…")`.
+
+### Adding a subprocess-based scenario
+
+Subprocess scenarios go in `tests/e2e.rs`. Helpers:
+
+```rust
+let env = TestEnv::new(2).await;          // server + 2 CLI clients
+fs::write(env.client_path(0).join("foo.md"), "hi")?;
+assert!(wait_for_convergence(&env.dirs(), Duration::from_secs(10)).await);
+```
+
+`TestEnv` builds the workspace, picks a port, spawns
+`target/debug/syncline server`, then N `syncline sync` clients into
+TempDirs. `Drop` order matters - tokio's `Child::kill_on_drop` does
+the cleanup.
+
+`compare_directories` walks every non-`.syncline` file under each
+client folder and asserts identical bytes plus identical Yrs state
+(it only reads `.syncline/data` if v0 layout exists; in v1 the
+on-disk file content is the source of truth).
+
+---
+
+## 3. Running the server manually
+
+```bash
+cargo build --release --bin syncline
+./target/release/syncline server \
+    --port 3030 \
+    --db-path ./syncline.db \
+    --log-level info        # error / warn / info / debug / trace
+```
+
+What to expect on stdout (info-level):
+
+```
+🚀 Starting Syncline server...
+🔌 Port: 3030
+💾 Database: ./syncline.db
+Migrated server DB to v1: 0 text + 0 binary + 0 skipped (actor <uuid>)
+Server listening on 0.0.0.0:3030
+v1 handshake OK (peer 1.0)            # one line per client connect
+```
+
+To redirect logs to a file rotate-friendly format, pass
+`--log-file /var/log/syncline.log`. The CLI uses
+`tracing-subscriber` + `tracing-appender::never` rotation.
+
+To kill cleanly, send `SIGINT` (Ctrl-C). The axum `serve` task
+catches it and shuts down.
+
+---
+
+## 4. Running the CLI client manually
+
+```bash
+./target/release/syncline sync \
+    --folder /path/to/vault \
+    --url ws://127.0.0.1:3030/sync \
+    --name laptop \              # optional friendly tag for conflict files
+    --log-level info             # try debug for protocol detail
+```
+
+First connect prints a banner and:
+```
+📂 Folder: /path/to/vault
+🌐 Server URL: ws://127.0.0.1:3030/sync
+Migrated local vault: N text, M binary, K directories
+v1 handshake OK (server 1.0)
+Starting debounced watcher on directory: "/path/to/vault"
+```
+
+`Ctrl-C` stops both the watcher and the WS connection.
+
+Useful env knobs (also work in tests):
+- `RUST_LOG=syncline=debug,info` overrides `--log-level`.
+- `SYNCLINE_URL=…` is read by the CLI as the default for `--url`.
+
+### What the CLI writes on disk
+
+```
+<vault>/
+├── .syncline/
+│   ├── version              # "1\n"
+│   ├── actor_id             # UUIDv4 for this peer (stable across restarts)
+│   ├── manifest.bin         # encoded Yrs update of the manifest doc
+│   ├── content/             # per-text-file subdoc snapshots
+│   │   └── ab/              # sharded by first 2 hex of NodeId
+│   │       └── <NodeId>.bin
+│   └── blobs/               # CAS — hex SHA-256 keyed
+│       └── ab/cd/<sha256>
+└── <user-visible files>
+```
+
+Inspect manifest from the host without going through Obsidian:
+
+```bash
+# Decode `.syncline/manifest.bin` with a small Rust shim, OR
+# point the WASM-free `syncline verify` at it (next section).
+```
+
+---
+
+## 5. `syncline verify`
+
+```bash
+./target/release/syncline verify \
+    --folder /path/to/vault \
+    --url ws://127.0.0.1:3030/sync \
+    --timeout-secs 5
+echo $?  # 0 = converged, 1 = diverged
+```
+
+Sends a single `MSG_MANIFEST_VERIFY` (the SHA-256 of the projection)
+and reads the server's reply. Silence past the timeout = converged.
+
+This is the cheapest convergence check you can run in CI / scripts -
+no full state download.
+
+---
+
+## 6. Observing what's actually in the SQLite DB
+
+The server stores everything in two tables:
+
+```sql
+-- Append-only log of yrs updates, keyed by doc_id.
+CREATE TABLE updates (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    doc_id      TEXT NOT NULL,            -- '__manifest__' or 'content:<NodeId>'
+    update_data BLOB NOT NULL             -- yrs::Update::encode_v1()
+);
+
+-- Content-addressed blob store for binary chunks.
+CREATE TABLE blobs (
+    hash       TEXT PRIMARY KEY,          -- 64-char lowercase SHA-256 hex
+    data       BLOB NOT NULL,
+    size       INTEGER NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+```
+
+### sqlite3 cheat sheet
+
+```bash
+sqlite3 ./syncline.db
+sqlite> .headers on
+sqlite> .mode column
+
+-- How many docs do we have?
+sqlite> SELECT doc_id, COUNT(*) AS updates, SUM(LENGTH(update_data)) AS bytes
+        FROM updates GROUP BY doc_id ORDER BY bytes DESC LIMIT 20;
+
+-- Manifest bytes (one row per manifest update applied):
+sqlite> SELECT id, LENGTH(update_data) FROM updates
+        WHERE doc_id = '__manifest__' ORDER BY id;
+
+-- All content subdoc IDs (= NodeIds):
+sqlite> SELECT DISTINCT substr(doc_id, 9) AS node_id
+        FROM updates WHERE doc_id LIKE 'content:%';
+
+-- Blob inventory:
+sqlite> SELECT COUNT(*) AS n, SUM(size) AS total_bytes,
+               SUM(size)/1024/1024 AS total_mib FROM blobs;
+sqlite> SELECT hash, size FROM blobs ORDER BY size DESC LIMIT 10;
+
+-- Find blobs not referenced by any manifest entry: (manual; needs
+-- decoding the manifest BLOBs above with the syncline binary or a
+-- small yrs-aware script — there is no SQL-only way).
+```
+
+### Decoding a yrs blob from SQL
+
+The `updates.update_data` column is a `yrs::Update` v1 binary. To
+inspect it, write a tiny Rust binary or Node script that:
+
+1. `let update = yrs::Update::decode_v1(bytes)?;`
+2. `let doc = yrs::Doc::new();`
+3. `doc.transact_mut().apply_update(update);`
+4. For the manifest, walk `doc.get_or_insert_map("nodes")`.
+5. For a content subdoc, read `doc.get_or_insert_text("text").get_string(&txn)`.
+
+The cleanest in-tree way: temporarily add a `#[test]` to
+`server::tests` that takes the bytes from a fixture file and prints
+the decoded structure. For one-off ops, the WASM client's
+`update_content_text` / `manifestSnapshot` round-trips via the
+plugin sidebar.
+
+### Verifying a SQL state matches a peer's disk
+
+Two ways:
+
+1. Run `syncline verify` from a peer's vault against the server.
+   Identical projection hash → SQLite ↔ peer disk agree on the
+   namespace. This does **not** prove per-file content agreement;
+   for that, force a `MSG_SYNC_STEP_1` per content subdoc (the WASM
+   client's "reconnect" button, or restart `syncline sync`).
+2. Pipe `compare_directories` over two CLI peers' folders. If both
+   show identical SHAs and the server hasn't broadcast since, the
+   server's SQLite is the same as both.
+
+### Resetting / wiping a server DB
+
+```bash
+rm -f /path/to/syncline.db /path/to/syncline.db-shm /path/to/syncline.db-wal
+```
+
+Server is stateless beyond this DB. Restart and clients will push
+their state on first connect.
+
+---
+
+## 7. Driving the Obsidian plugin manually
+
+### Build
+
+```bash
+cd obsidian-plugin
+npm ci
+npm run build       # = wasm-pack build + rollup
+```
+
+Outputs:
+- `obsidian-plugin/main.js` (compiled plugin)
+- `obsidian-plugin/manifest.json`
+- `obsidian-plugin/wasm/syncline_bg.wasm` (~480 KB)
+
+### Install into a vault
+
+```bash
+mkdir -p /path/to/vault/.obsidian/plugins/syncline
+cp obsidian-plugin/{main.js,manifest.json,styles.css} \
+   /path/to/vault/.obsidian/plugins/syncline/
+cp -r obsidian-plugin/wasm /path/to/vault/.obsidian/plugins/syncline/
+```
+
+Open Obsidian → Settings → Community Plugins → enable "Syncline
+(live sync)". Configure server URL in the Syncline settings panel
+and click Connect.
+
+### Inspect plugin state at runtime
+
+In Obsidian's developer console (`Ctrl-Shift-I`):
+
+```js
+// Raw plugin handle:
+const p = app.plugins.plugins['syncline'];
+
+// Are we connected?
+p.client.isConnected();
+
+// Manifest snapshot (for diffing):
+new Uint8Array(p.client.manifestSnapshot()).slice(0, 32);
+
+// Per-node projection (matches `projection_json()`):
+JSON.parse(p.client.projectionJson()).slice(0, 5);
+
+// Bytes of a content subdoc by node id:
+new Uint8Array(p.client.contentSnapshot('<uuid>'));
+
+// Force a verify heartbeat:
+p.client.sendVerify(); p.client.lastVerifyResult();
+
+// Settings (configSync categories etc.):
+p.settings.configSync;
+```
+
+### configSync defaults
+
+`DEFAULT_CONFIG_SYNC` in `obsidian-plugin/main.ts`:
+
+| Field                  | Default | What it controls                                   |
+| ---------------------- | ------- | -------------------------------------------------- |
+| `themes`               | true    | `.obsidian/themes/`                                |
+| `snippets`             | true    | `.obsidian/snippets/`                              |
+| `hotkeys`              | true    | `.obsidian/hotkeys.json`                           |
+| `coreConfig`           | true    | `app.json`, `appearance.json`, `core-plugins.json` |
+| `communityPluginList`  | false   | `.obsidian/community-plugins.json`                 |
+| `communityPluginData`  | `{}`    | Per-plugin opt-in: `{ '<id>': true }`              |
+| `other`                | false   | Anything under `.obsidian/` not covered above      |
+
+`.obsidian/workspace.json`, `.obsidian/workspace-mobile.json`,
+`.obsidian/cache/`, `.obsidian/graph.json` are **always ignored** -
+device-local Obsidian state.
+
+### Reload the plugin's manifest list (after Syncline drops new
+plugins on disk)
+
+```js
+await app.plugins.loadManifests();
+console.log(Object.keys(app.plugins.manifests).filter(id => id !== 'syncline'));
+```
+
+This is what the wdio cross-vault spec uses to assert "the new
+plugin is now installed" on vault B.
+
+---
+
+## 8. wdio (Obsidian) e2e
+
+Real Obsidian, real chromedriver, drives the plugin end-to-end.
+
+### Layout
+
+```
+e2e/
+├── wdio.conf.ts                        # service config
+├── test/specs/*.e2e.ts                 # the specs
+├── test-vault/                         # default vault (gitignored)
+├── .obsidian-cache/                    # downloaded Obsidian + chromedriver
+└── docker/                             # podman/docker harness (§9)
+```
+
+Key existing specs:
+
+| Spec                                | What it covers                                                |
+| ----------------------------------- | ------------------------------------------------------------- |
+| `basic.e2e.ts`                      | Empty vault + empty CLI → roundtrips Obsidian↔CLI             |
+| `phase1/2/3/4.e2e.ts`               | Big-vault rsync + cross-host (claw.krej.ci)                   |
+| `issue56/57/58/63/90/91/93/94/95.e2e.ts` | Per-bug regressions                                       |
+| `pre-existing-vault.e2e.ts`         | Vault has notes BEFORE plugin enabled                         |
+| `community-plugin-sync.e2e.ts`      | configSync.communityPluginData[<id>] opt-in                   |
+| `plugin-cross-vault-install.e2e.ts` | Install in vault A → reloadObsidian into vault B → see it     |
+
+### Run
+
+```bash
+cd e2e
+npm ci
+PATH=/usr/bin:$PATH npm test                                  # all
+PATH=/usr/bin:$PATH npm test -- --spec test/specs/basic.e2e.ts  # one
+```
+
+(`PATH=/usr/bin:$PATH` is in the package.json `test` script - it
+prevents brew's `mocha` from shadowing wdio's bundled mocha
+worker.)
+
+### Driving Obsidian from a spec
+
+`browser.executeObsidian` runs a closure inside the Obsidian
+renderer process. Pass primitives in/out only - functions don't
+serialise:
+
+```ts
+const id = await browser.executeObsidian(async ({ app }, path) => {
+    const f = app.vault.getAbstractFileByPath(path);
+    return f ? f.path : null;
+}, 'note.md');
+```
+
+Common ops:
+
+| Action                         | Snippet                                                       |
+| ------------------------------ | ------------------------------------------------------------- |
+| Read a vault file (text)       | `await app.vault.read(file)`                                  |
+| Read a vault file (binary)     | `await app.vault.readBinary(file)`                            |
+| Write a vault file             | `await app.vault.modify(file, body)`                          |
+| Create a vault file            | `await app.vault.create(path, body)`                          |
+| Rename via Obsidian's API      | `await app.fileManager.renameFile(file, newPath)`             |
+| Get the vault's root path      | `app.vault.adapter.basePath`                                  |
+| List installed plugin manifests| `app.plugins.manifests`                                       |
+| Trigger plugin rescan          | `await app.plugins.loadManifests()`                           |
+| Enable/disable Syncline        | `await app.plugins.enablePlugin('syncline')`                  |
+
+The wdio service also exposes an `obsidianPage` helper:
+
+```ts
+const obsidianPage = browser.getObsidianPage();
+await obsidianPage.write('test.md', '# hi');     // create / overwrite
+await obsidianPage.enablePlugin('syncline');
+await obsidianPage.resetVault();                  // reset to original vault
+await browser.reloadObsidian({ vault, plugins }); // reboot on a different vault
+```
+
+### Polling helper
+
+Every spec defines a `waitFor(label, fn, timeoutMs, stepMs)` because
+sync is asynchronous. Use generous timeouts on first-bootstrap waits
+(content has to stream through WS).
+
+### Debugging a wdio failure
+
+- The spec output streams `[chrome] ...` lines from Obsidian's
+  console.
+- Add `console.log` inside `executeObsidian` closures - they tee to
+  stderr.
+- Re-run with `--logLevel debug` to see every webdriver round-trip
+  (very chatty).
+- The spec's `before()` hook usually prints the syncline binary's
+  stdout via `cliProc.stdout?.on('data', ...)`. Keep that.
+- Examine the spec's CLI sync folder (`<spec>-cli/`) and the
+  in-flight `.syncline/manifest.bin` to confirm the manifest matches
+  expectations.
+
+---
+
+## 9. Containerised tests (podman / docker)
+
+`e2e/docker/` packages all of §8 into a Debian 12 image with Xvfb,
+xauth, p7zip (for AppImage extraction), the Rust toolchain, and the
+electron/chromium runtime libs.
+
+```bash
+# One-time:
+podman compose -f e2e/docker/docker-compose.yml build
+
+# Run a spec:
+podman compose -f e2e/docker/docker-compose.yml run --rm e2e \
+  bash e2e/docker/run-tests.sh \
+  --spec test/specs/plugin-cross-vault-install.e2e.ts
+```
+
+Same flags work for `docker compose`. See `e2e/docker/README.md`
+for the full doc, including SELinux relabel + arm64 vs amd64 notes.
+
+What runs inside the container:
+1. `cargo build --release --bin syncline`
+2. `obsidian-plugin/`: `npm ci` + `npm run build`
+3. `e2e/`: `npm ci` + `xvfb-run npx wdio run wdio.conf.ts`
+
+Artifacts persist across runs via named volumes
+(`cargo-cache`, `cargo-target`, `obsidian-cache`,
+`obsidian-plugin-node-modules`, `e2e-node-modules`).
+
+---
+
+## 10. Cross-cutting test scenarios worth knowing about
+
+These are scenarios that catch a class of regressions; mention them
+to anyone designing new features.
+
+| Scenario                                              | Where it lives                                          |
+| ----------------------------------------------------- | ------------------------------------------------------- |
+| Cycle via concurrent moves                            | `v1_robustness::concurrent_moves_into_each_other_*`     |
+| Concurrent rename of same node                        | `v1_robustness::concurrent_rename_of_same_node_*`       |
+| Rename + delete race                                  | `v1_robustness::concurrent_rename_and_delete_*`         |
+| Modify-wins-over-delete (file)                        | `v1_robustness::rename_after_observed_delete_*`         |
+| Modify-wins-over-delete (directory)                   | `v1_robustness::directory_resurrected_via_modify_wins_*`|
+| Same-path collision (binary)                          | `v1_robustness::binary_file_same_path_collision_*`      |
+| 4-peer same-path collision                            | `v1_robustness::four_peer_same_path_collision_*`        |
+| Conflict suffix uniqueness across many peers          | `v1_robustness::conflict_suffixes_are_pairwise_distinct`|
+| Lamport overflow at u64::MAX                          | `v1::ids::tests::lamport_observe_does_not_overflow_*`   |
+| Empty binary file (size=0) materialises               | `client_v1::tests::reconcile_materialises_truly_empty_*`|
+| File/directory same-name collision in projection      | `client_v1::tests::reconcile_does_not_bail_when_*`      |
+| Two-leading-dots filename in conflict path            | `client_v1::tests::conflict_sibling_path_double_dot_*`  |
+| v0→v1 migration with malformed paths                  | `v1::migration::tests::migrate_drops_paths_with_*`      |
+| Pre-existing vault joins server with CLI peer         | `e2e::test_obsidian_like_onboarding_*`                  |
+| Real Obsidian with pre-existing notes                 | `e2e/test/specs/pre-existing-vault.e2e.ts`              |
+| Real Obsidian community-plugin opt-in                 | `e2e/test/specs/community-plugin-sync.e2e.ts`           |
+| Cross-vault plugin install via Syncline               | `e2e/test/specs/plugin-cross-vault-install.e2e.ts`      |
+
+---
+
+## 11. Multi-peer scenarios
+
+For interactive bug repro, spin up:
+
+```bash
+# Terminal 1: server
+./target/release/syncline server --port 3030 --db-path /tmp/syncline.db
+
+# Terminal 2: peer A
+mkdir -p /tmp/vault-a && \
+  ./target/release/syncline sync \
+    -f /tmp/vault-a -u ws://127.0.0.1:3030/sync --name peer-a
+
+# Terminal 3: peer B
+mkdir -p /tmp/vault-b && \
+  ./target/release/syncline sync \
+    -f /tmp/vault-b -u ws://127.0.0.1:3030/sync --name peer-b
+
+# Terminal 4: drive edits
+echo "hi" > /tmp/vault-a/note.md
+ls /tmp/vault-b              # should show note.md within ~3s
+```
+
+Network partition repro: kill the server (`kill <pid>`), do edits
+on both peers, restart the server. They reconnect, push their
+diffs, projection_hash converges within a couple of seconds.
+
+Three peers + concurrent ops: `tests/v1_robustness.rs ::
+three_peers_rename_modify_delete_converge` is the in-process
+analogue. For an over-the-wire variant, just spawn a third
+`syncline sync` against the same server.
+
+---
+
+## 12. Known caveats and gotchas
+
+- **Case-insensitive filesystems** (macOS APFS, NTFS): two notes
+  named `Foo.md` and `foo.md` collide on disk. Syncline preserves
+  both NodeIds, but only one materialises. Documented as an open
+  issue.
+- **`.obsidian/community-plugins.json`** is **not** synced by
+  default - it's `communityPluginList: false`. Toggle it on
+  explicitly if you want the plugin enable-list to propagate.
+- **Self-exclusion**: the Syncline plugin never syncs its own
+  `${configDir}/plugins/syncline/` directory - that holds device-
+  local state (server URL, actor id).
+- **fsync**: the client skips fsync per file in bulk bootstrap.
+  Recovery is via re-sync from the server, not durable per-file
+  writes. If a CLI peer crashes mid-bootstrap, deleting `.syncline/`
+  and reconnecting is the recommended fix.
+- **AppImage in containers**: requires `7z` (no FUSE in the
+  container). The provided Dockerfile ships `p7zip-full`.
+- **Electron sandbox**: wdio-obsidian-service auto-injects
+  `--no-sandbox` on Linux. Don't add it again or you'll get
+  duplicate-flag warnings.
+
+---
+
+## 13. The "I just want to verify a fix" checklist
+
+When you land a change, the standard chain is:
+
+1. `cargo test -p syncline --lib` (5 s) - unit tests.
+2. `cargo test -p syncline --test v1_robustness` (~1 s) - manifest
+   scenarios.
+3. `cargo test -p syncline --test v1_protocol_e2e` (~0.1 s) -
+   protocol roundtrips.
+4. `cargo test -p syncline --test e2e` (~2 min) - subprocess
+   integration.
+5. `cd obsidian-plugin && npm run build` - rebuild the WASM bundle
+   so wdio specs run against current source.
+6. `cd e2e && PATH=/usr/bin:$PATH npm test -- --spec test/specs/<your-spec>.e2e.ts`
+   for whichever Obsidian path you touched.
+7. Optional: `podman compose -f e2e/docker/docker-compose.yml run --rm e2e`
+   to confirm the container build still boots.
+
+If steps 1-4 are green and the relevant wdio spec is green, you're
+in good shape.

--- a/syncline/src/client_v1.rs
+++ b/syncline/src/client_v1.rs
@@ -1623,121 +1623,182 @@ fn reconcile_projection_to_disk(
     let mut created_binary = 0usize;
     let mut pending_binary = 0usize;
     let mut conflicts_created = 0usize;
+    let mut skipped_failures = 0usize;
+
+    /// Per-entry materialisation outcome; tracks whatever the caller
+    /// has to bump in the surrounding counters. `Skip` is the
+    /// non-error variant for "nothing changed" / "deferred" cases
+    /// (e.g. binary placeholder with no chunks yet).
+    #[derive(Default)]
+    struct EntryDelta {
+        created_dirs: usize,
+        created_text: usize,
+        created_binary: usize,
+        pending_binary: usize,
+        conflicts_created: usize,
+    }
 
     for (path, entry) in &proj.by_path {
         if is_unsafe_relative_path(path) {
             warn!("skipping unsafe projection path {:?}", path);
             continue;
         }
-        let full = folder.join(path);
-        if let Some(parent) = full.parent() {
-            if !parent.exists() {
-                fs::create_dir_all(parent).with_context(|| {
-                    format!("mkdir -p {} for projected {:?}", parent.display(), path)
-                })?;
-                created_dirs += 1;
-            }
-        }
-        match entry.kind {
-            NodeKind::Text => {
-                if !full.exists() {
-                    // Use any subdoc content we already have so the
-                    // placeholder isn't empty when we're materialising a
-                    // conflict sibling whose bytes we ingested locally.
-                    // Missing / not-loaded / empty subdoc → empty file.
-                    let seed = content
-                        .and_then(|c| c.current_text(entry.id))
-                        .unwrap_or_default();
-                    if seed.is_empty() {
-                        fs::File::create(&full).with_context(|| {
-                            format!("create empty text placeholder {}", full.display())
-                        })?;
-                    } else {
-                        atomic_write(&full, seed.as_bytes()).with_context(|| {
-                            format!(
-                                "seed text placeholder {} with cached subdoc body",
-                                full.display()
-                            )
-                        })?;
-                    }
-                    created_text += 1;
-                }
-            }
-            NodeKind::Binary => {
-                let chunk_hashes = &entry.chunk_hashes;
-                if chunk_hashes.is_empty() {
-                    // Manifest entry with no chunks is a placeholder —
-                    // either the emitting peer hasn't written content
-                    // yet, or it's a truly empty file. Treat as
-                    // "nothing materialised yet" and try again later.
-                    debug!("binary {:?} has no chunks, skipping", path);
-                    continue;
-                }
-                // Need every chunk in local CAS before we can materialise.
-                let missing_chunks =
-                    chunk_hashes.iter().any(|h| !blobs.has(h));
-                if missing_chunks {
-                    pending_binary += 1;
-                    continue;
-                }
-
-                if full.exists() {
-                    let local_bytes = fs::read(&full)
-                        .with_context(|| format!("read local {}", full.display()))?;
-                    let local_chunk_hashes: Vec<String> =
-                        crate::v1::chunker::chunks_with_hashes(&local_bytes)
-                            .into_iter()
-                            .map(|c| c.hash)
-                            .collect();
-                    if &local_chunk_hashes == chunk_hashes {
-                        continue;
-                    }
-                    // Disk diverged from manifest. LWW: remote wins
-                    // (we reach this branch only after a remote
-                    // manifest update landed). Save local bytes as a
-                    // conflict sibling so nothing gets silently
-                    // clobbered.
-                    blobs.insert_bytes(&local_bytes).with_context(|| {
-                        format!("stash conflict bytes for {:?}", path)
+        let result: Result<EntryDelta> = (|| {
+            let mut delta = EntryDelta::default();
+            let full = folder.join(path);
+            if let Some(parent) = full.parent() {
+                if !parent.exists() {
+                    fs::create_dir_all(parent).with_context(|| {
+                        format!("mkdir -p {} for projected {:?}", parent.display(), path)
                     })?;
-                    let actor_short = manifest.actor().short();
-                    let conflict_rel =
-                        conflict_sibling_path(path, &actor_short, &today_ymd());
-                    let conflict_full = folder.join(&conflict_rel);
-                    atomic_write(&conflict_full, &local_bytes).with_context(
-                        || format!("write conflict copy {}", conflict_full.display()),
-                    )?;
-                    let remote_bytes =
-                        assemble_chunks(blobs, chunk_hashes).with_context(|| {
-                            format!("assemble remote chunks for {:?}", path)
-                        })?;
-                    atomic_write(&full, &remote_bytes).with_context(|| {
-                        format!("overwrite with remote {}", full.display())
-                    })?;
-                    warn!(
-                        path = %path,
-                        conflict_copy = %conflict_rel,
-                        local_chunks = local_chunk_hashes.len(),
-                        remote_chunks = chunk_hashes.len(),
-                        "binary conflict: local bytes preserved, remote applied"
-                    );
-                    conflicts_created += 1;
-                    continue;
+                    delta.created_dirs += 1;
                 }
-
-                let bytes = assemble_chunks(blobs, chunk_hashes)
-                    .with_context(|| format!("assemble chunks for {:?}", path))?;
-                atomic_write(&full, &bytes).with_context(|| {
-                    format!(
-                        "materialize binary {} from {} chunks",
-                        full.display(),
-                        chunk_hashes.len()
-                    )
-                })?;
-                created_binary += 1;
             }
-            NodeKind::Directory => {
-                // Emergent — directories never appear in projection.by_path.
+            match entry.kind {
+                NodeKind::Text => {
+                    if !full.exists() {
+                        // Use any subdoc content we already have so the
+                        // placeholder isn't empty when we're materialising a
+                        // conflict sibling whose bytes we ingested locally.
+                        // Missing / not-loaded / empty subdoc → empty file.
+                        let seed = content
+                            .and_then(|c| c.current_text(entry.id))
+                            .unwrap_or_default();
+                        if seed.is_empty() {
+                            fs::File::create(&full).with_context(|| {
+                                format!("create empty text placeholder {}", full.display())
+                            })?;
+                        } else {
+                            atomic_write(&full, seed.as_bytes()).with_context(|| {
+                                format!(
+                                    "seed text placeholder {} with cached subdoc body",
+                                    full.display()
+                                )
+                            })?;
+                        }
+                        delta.created_text += 1;
+                    }
+                }
+                NodeKind::Binary => {
+                    let chunk_hashes = &entry.chunk_hashes;
+                    if chunk_hashes.is_empty() {
+                        // Empty chunk list has two possible meanings,
+                        // disambiguated by `size`:
+                        //   • `size == 0` → a *truly empty* binary file
+                        //     (e.g. `.gitkeep`). Materialise as a 0-byte
+                        //     file so it shows up on every peer.
+                        //   • `size > 0`  → a placeholder whose chunks
+                        //     haven't been authored or fetched yet. Try
+                        //     again on the next reconcile.
+                        if entry.size == 0 {
+                            if !full.exists() {
+                                fs::File::create(&full).with_context(|| {
+                                    format!(
+                                        "create empty binary placeholder {}",
+                                        full.display()
+                                    )
+                                })?;
+                                delta.created_binary += 1;
+                            }
+                        } else {
+                            debug!(
+                                "binary {:?} has no chunks (size={}), skipping",
+                                path, entry.size
+                            );
+                        }
+                        return Ok(delta);
+                    }
+                    // Need every chunk in local CAS before we can materialise.
+                    let missing_chunks =
+                        chunk_hashes.iter().any(|h| !blobs.has(h));
+                    if missing_chunks {
+                        delta.pending_binary += 1;
+                        return Ok(delta);
+                    }
+
+                    if full.exists() {
+                        let local_bytes = fs::read(&full)
+                            .with_context(|| format!("read local {}", full.display()))?;
+                        let local_chunk_hashes: Vec<String> =
+                            crate::v1::chunker::chunks_with_hashes(&local_bytes)
+                                .into_iter()
+                                .map(|c| c.hash)
+                                .collect();
+                        if &local_chunk_hashes == chunk_hashes {
+                            return Ok(delta);
+                        }
+                        // Disk diverged from manifest. LWW: remote wins
+                        // (we reach this branch only after a remote
+                        // manifest update landed). Save local bytes as a
+                        // conflict sibling so nothing gets silently
+                        // clobbered.
+                        blobs.insert_bytes(&local_bytes).with_context(|| {
+                            format!("stash conflict bytes for {:?}", path)
+                        })?;
+                        let actor_short = manifest.actor().short();
+                        let conflict_rel =
+                            conflict_sibling_path(path, &actor_short, &today_ymd());
+                        let conflict_full = folder.join(&conflict_rel);
+                        atomic_write(&conflict_full, &local_bytes).with_context(
+                            || format!("write conflict copy {}", conflict_full.display()),
+                        )?;
+                        let remote_bytes =
+                            assemble_chunks(blobs, chunk_hashes).with_context(|| {
+                                format!("assemble remote chunks for {:?}", path)
+                            })?;
+                        atomic_write(&full, &remote_bytes).with_context(|| {
+                            format!("overwrite with remote {}", full.display())
+                        })?;
+                        warn!(
+                            path = %path,
+                            conflict_copy = %conflict_rel,
+                            local_chunks = local_chunk_hashes.len(),
+                            remote_chunks = chunk_hashes.len(),
+                            "binary conflict: local bytes preserved, remote applied"
+                        );
+                        delta.conflicts_created += 1;
+                        return Ok(delta);
+                    }
+
+                    let bytes = assemble_chunks(blobs, chunk_hashes)
+                        .with_context(|| format!("assemble chunks for {:?}", path))?;
+                    atomic_write(&full, &bytes).with_context(|| {
+                        format!(
+                            "materialize binary {} from {} chunks",
+                            full.display(),
+                            chunk_hashes.len()
+                        )
+                    })?;
+                    delta.created_binary += 1;
+                }
+                NodeKind::Directory => {
+                    // Emergent — directories never appear in projection.by_path.
+                }
+            }
+            Ok(delta)
+        })();
+        match result {
+            Ok(d) => {
+                created_dirs += d.created_dirs;
+                created_text += d.created_text;
+                created_binary += d.created_binary;
+                pending_binary += d.pending_binary;
+                conflicts_created += d.conflicts_created;
+            }
+            Err(e) => {
+                // Per-entry failures are typically caused by a
+                // local FS state that disagrees with the projection
+                // (e.g. file/dir name collision: a Text node and a
+                // Directory node share the same name, so a Unix
+                // filesystem cannot represent both). Skip the
+                // offender, log loudly, and let the rest of the
+                // projection materialise. Bailing out here would
+                // strand every subsequent entry.
+                warn!(
+                    path = %path,
+                    "skipping projection entry: {e:#}",
+                );
+                skipped_failures += 1;
             }
         }
     }
@@ -1764,6 +1825,7 @@ fn reconcile_projection_to_disk(
         + pending_binary
         + conflicts_created
         + removed_stale
+        + skipped_failures
         > 0
     {
         info!(
@@ -1773,6 +1835,7 @@ fn reconcile_projection_to_disk(
             pending_binary,
             conflicts_created,
             removed_stale,
+            skipped_failures,
             "reconciled projection → disk"
         );
     }
@@ -1791,17 +1854,14 @@ fn reconcile_projection_to_disk(
 /// multiple conflicts on the same file — whether from different peers or
 /// from a restart-induced re-detection — don't collide.
 fn conflict_sibling_path(path: &str, actor_short: &str, date_ymd: &str) -> String {
-    let last_slash = path.rfind('/').map(|i| i + 1).unwrap_or(0);
-    let dir_prefix = &path[..last_slash];
-    let last = &path[last_slash..];
-    let (stem, ext) = match last.rfind('.') {
-        // Hidden files like ".env" have no stem → keep the full name.
-        Some(dot) if dot > 0 => (&last[..dot], Some(&last[dot + 1..])),
-        _ => (last, None),
-    };
+    // Reuse the projection-layer helper so the rules for "what counts
+    // as an extension" stay in one place. In particular, leading dots
+    // are part of the basename — `..hidden` is not an extension on
+    // `.`. See `split_ext` for the full rationale.
+    let (stem, ext) = crate::v1::projection::split_ext(path);
     match ext {
-        Some(ext) => format!("{dir_prefix}{stem} (conflict {date_ymd} {actor_short}).{ext}"),
-        None => format!("{dir_prefix}{stem} (conflict {date_ymd} {actor_short})"),
+        Some(ext) => format!("{stem} (conflict {date_ymd} {actor_short}).{ext}"),
+        None => format!("{stem} (conflict {date_ymd} {actor_short})"),
     }
 }
 
@@ -1827,13 +1887,14 @@ fn conflict_sibling_path(path: &str, actor_short: &str, date_ymd: &str) -> Strin
 /// closes the watcher-driven trigger. This filter closes the
 /// periodic-scan and stale-on-disk triggers. Both are needed.
 fn looks_like_conflict_sibling_artifact(rel_path: &str) -> bool {
-    let last_slash = rel_path.rfind('/').map(|i| i + 1).unwrap_or(0);
-    let last = &rel_path[last_slash..];
-    // Strip optional extension.
-    let stem = match last.rfind('.') {
-        Some(dot) if dot > 0 => &last[..dot],
-        _ => last,
-    };
+    // Use the projection-layer split so we treat hidden / multi-dot
+    // basenames the same way `conflict_sibling_path` builds them. A
+    // path like `..hidden (conflict 2026-04-21 abcd1234)` has stem
+    // `..hidden (conflict 2026-04-21 abcd1234)` (no extension).
+    let (stem_full, _ext) = crate::v1::projection::split_ext(rel_path);
+    // Drop any directory prefix — we only care about the final segment's stem.
+    let last_slash = stem_full.rfind('/').map(|i| i + 1).unwrap_or(0);
+    let stem = &stem_full[last_slash..];
     // Stem must contain " (conflict YYYY-MM-DD HASH8)" as suffix.
     let Some(open) = stem.rfind(" (conflict ") else {
         return false;
@@ -2254,6 +2315,91 @@ mod tests {
         assert!(is_unsafe_relative_path("a/../b"));
         assert!(!is_unsafe_relative_path("a/b/c.md"));
         assert!(!is_unsafe_relative_path("file.md"));
+    }
+
+    #[test]
+    fn reconcile_materialises_truly_empty_binary_file() {
+        // Edge case from real users: a binary file that's literally
+        // 0 bytes (empty .png placeholders, an empty `.gitkeep`, etc.)
+        // chunks_with_hashes returns an empty list for empty input, so
+        // the manifest entry has chunk_hashes=[] AND size=0. The
+        // receiving peer's reconcile must understand "empty" vs
+        // "placeholder pending blob" — for an entry with size=0 and no
+        // chunks, materialise the file on disk as a 0-byte file.
+        let dir = tempfile::tempdir().unwrap();
+        let folder = dir.path();
+        let (_bs_tmp, blobs) = fresh_blob_store();
+
+        let mut m = Manifest::new(ActorId::new());
+        let proj = project(&m);
+        let outcome =
+            process_binary_file("empty.png", &[], &proj, &mut m, &blobs).unwrap();
+        assert!(
+            matches!(outcome, BinaryScanOutcome::Created { .. }),
+            "expected Created, got {outcome:?}"
+        );
+
+        reconcile_projection_to_disk(
+            folder,
+            &m,
+            &blobs,
+            &mut HashMap::new(),
+            None,
+        )
+        .unwrap();
+
+        let path = folder.join("empty.png");
+        assert!(
+            path.exists(),
+            "empty binary file should be materialised on receiving peer",
+        );
+        assert_eq!(
+            fs::metadata(&path).unwrap().len(),
+            0,
+            "materialised binary must be 0 bytes",
+        );
+    }
+
+    #[test]
+    fn reconcile_does_not_bail_when_file_and_dir_share_a_name() {
+        // Pathological-but-reachable manifest state: peer A creates
+        // text file "docs.md", peer B (concurrent, before sync)
+        // creates "docs.md/README.md", which materialises a Directory
+        // node also named "docs.md". After sync both nodes coexist.
+        // Reconcile cannot represent this on a Unix filesystem (a
+        // file and a directory cannot share a name), but it MUST
+        // NOT bail out with `?` — that strands every other manifest
+        // entry in pre-reconcile state. Skip the loser, log a
+        // warning, materialise the rest.
+        let dir = tempfile::tempdir().unwrap();
+        let folder = dir.path();
+        let (_bs_tmp, blobs) = fresh_blob_store();
+
+        let mut m = Manifest::new(ActorId::new());
+        crate::v1::ops::create_text(&mut m, "docs.md", 0).unwrap();
+        crate::v1::ops::create_text(&mut m, "docs.md/README.md", 0).unwrap();
+        // Add an unrelated file so we can confirm reconcile got past
+        // the conflict and processed later entries too.
+        crate::v1::ops::create_text(&mut m, "unrelated.md", 0).unwrap();
+
+        let result = reconcile_projection_to_disk(
+            folder,
+            &m,
+            &blobs,
+            &mut HashMap::new(),
+            None,
+        );
+        assert!(
+            result.is_ok(),
+            "reconcile must not bail on path conflict: {:?}",
+            result.err()
+        );
+        // Whichever arm wins on disk, the unrelated file must
+        // materialise — proves the loop kept going past the conflict.
+        assert!(
+            folder.join("unrelated.md").exists(),
+            "unrelated entry skipped by an early bail-out",
+        );
     }
 
     #[test]
@@ -2696,6 +2842,35 @@ mod tests {
         // without a leading stem.
         let got = conflict_sibling_path(".env", "aaaa1111", "2026-04-21");
         assert_eq!(got, ".env (conflict 2026-04-21 aaaa1111)");
+    }
+
+    #[test]
+    fn conflict_sibling_path_double_dot_filename_keeps_basename_intact() {
+        // `..hidden` had a bug where the second dot was treated as the
+        // extension separator, splitting into stem="." and ext="hidden"
+        // — so the conflict copy came out as
+        // `. (conflict …).hidden`, mangling the user-visible name.
+        // Now the entire `..hidden` is the stem.
+        let got = conflict_sibling_path("..hidden", "aaaa1111", "2026-04-21");
+        assert_eq!(got, "..hidden (conflict 2026-04-21 aaaa1111)");
+    }
+
+    #[test]
+    fn conflict_sibling_path_double_dot_with_extension() {
+        let got = conflict_sibling_path("..weird.txt", "aaaa1111", "2026-04-21");
+        assert_eq!(got, "..weird (conflict 2026-04-21 aaaa1111).txt");
+    }
+
+    #[test]
+    fn looks_like_conflict_recognises_double_dot_filename_artifact() {
+        // The recognizer must agree with `conflict_sibling_path`'s
+        // output: if it would be produced, it must be recognised.
+        assert!(looks_like_conflict_sibling_artifact(
+            "..hidden (conflict 2026-04-21 abcd1234)"
+        ));
+        assert!(looks_like_conflict_sibling_artifact(
+            "..weird (conflict 2026-04-21 abcd1234).txt"
+        ));
     }
 
     #[test]

--- a/syncline/src/v1/ids.rs
+++ b/syncline/src/v1/ids.rs
@@ -120,15 +120,29 @@ impl Lamport {
 
     /// Produce the next local timestamp and advance `self`. Used at the
     /// top of every local transaction.
+    ///
+    /// Saturates at `u64::MAX` rather than panicking (`+= 1` overflow
+    /// in debug, wraparound in release). Reaching that saturation
+    /// would require ~2^63 ops at 1 ns each — practically unreachable
+    /// — but the wraparound case in release builds would silently
+    /// corrupt every LWW comparison thereafter (a Lamport of 0 reads
+    /// as "the oldest stamp on every entry"), so saturating is
+    /// strictly safer than letting it wrap.
     pub fn tick(&mut self) -> Lamport {
-        self.0 += 1;
+        self.0 = self.0.saturating_add(1);
         *self
     }
 
     /// Observe a remote timestamp; self becomes `max(self, remote + 1)`.
+    ///
+    /// Saturates at `u64::MAX` for the same reason as [`tick`]: a
+    /// peer that synthesises `remote = u64::MAX` (intentionally or
+    /// not) must not be able to crash us in debug or wrap our
+    /// counter to 0 in release.
     pub fn observe(&mut self, remote: Lamport) {
-        if remote.0 + 1 > self.0 {
-            self.0 = remote.0 + 1;
+        let next = remote.0.saturating_add(1);
+        if next > self.0 {
+            self.0 = next;
         }
     }
 }
@@ -228,6 +242,34 @@ mod tests {
         let mut l = Lamport(100);
         l.observe(Lamport(5));
         assert_eq!(l, Lamport(100));
+    }
+
+    #[test]
+    fn lamport_observe_does_not_overflow_at_u64_max() {
+        // A peer with a maxed-out lamport must not crash us. The
+        // counter saturates instead of wrapping back to 0 (which would
+        // silently corrupt every subsequent LWW comparison: a
+        // Lamport(0) is "younger" than every existing stamp).
+        let mut l = Lamport::ZERO;
+        l.observe(Lamport(u64::MAX));
+        assert_eq!(l.get(), u64::MAX);
+    }
+
+    #[test]
+    fn lamport_observe_just_below_max_advances_to_max() {
+        let mut l = Lamport::ZERO;
+        l.observe(Lamport(u64::MAX - 1));
+        assert_eq!(l.get(), u64::MAX);
+    }
+
+    #[test]
+    fn lamport_tick_at_max_does_not_panic() {
+        let mut l = Lamport(u64::MAX);
+        // Tick past MAX must saturate (stay at MAX) rather than
+        // wrap to 0 — see overflow rationale above.
+        let next = l.tick();
+        assert_eq!(next.get(), u64::MAX);
+        assert_eq!(l.get(), u64::MAX);
     }
 
     #[test]

--- a/syncline/src/v1/migration.rs
+++ b/syncline/src/v1/migration.rs
@@ -70,6 +70,22 @@ pub fn migrate_v0_vault(vault_root: &Path, actor: ActorId) -> Result<Migration> 
                     ));
                     continue;
                 }
+                // Defend against malformed v0 paths — leading slash,
+                // double slashes, trailing slash. Without this, the
+                // parent-chain builder would create a Directory node
+                // with name="" (or several), which corrupts every
+                // projection that walks through it. v0 was supposed
+                // to store vault-relative paths but didn't always
+                // sanitise — drop these snapshots and surface a
+                // warning so the user knows.
+                if v0.rel_path.split('/').any(|s| s.is_empty()) {
+                    warnings.push(format!(
+                        "skipped snapshot {} — meta.path {:?} has empty path segments",
+                        snap.display(),
+                        v0.rel_path,
+                    ));
+                    continue;
+                }
                 // v0's "delete = empty text content" projection is also
                 // ghosted: if a text file has empty content AND no
                 // blob_hash (so isn't a binary), treat as deleted.
@@ -438,6 +454,33 @@ mod tests {
             p.by_path["folder/pic.png"].chunk_hashes,
             vec!["deadbeef".to_string()],
         );
+    }
+
+    #[test]
+    fn migrate_drops_paths_with_empty_segments() {
+        // v0 snapshots with malformed paths (leading slash, double
+        // slashes, trailing slash) shouldn't end up as Directory nodes
+        // with name="" — that would corrupt every projection that
+        // walks through them. Skip with a warning instead.
+        let vault = TempDir::new().unwrap();
+        let data = vault.path().join(".syncline/data");
+        make_v0_snapshot(&data, "/leading.md", "text", Some("oops"), None);
+        make_v0_snapshot(&data, "double//slash.md", "text", Some("oops2"), None);
+        make_v0_snapshot(&data, "valid.md", "text", Some("ok"), None);
+
+        let m = migrate_v0_vault(vault.path(), ActorId::new()).unwrap();
+
+        // No Directory entries with empty names should exist.
+        for entry in m.manifest.live_entries() {
+            assert!(
+                !entry.name.is_empty(),
+                "migration created an entry with empty name: {:?}",
+                entry,
+            );
+        }
+        // The valid entry still made it.
+        let p = crate::v1::projection::project(&m.manifest);
+        assert!(p.by_path.contains_key("valid.md"));
     }
 
     #[test]

--- a/syncline/src/v1/ops.rs
+++ b/syncline/src/v1/ops.rs
@@ -103,14 +103,34 @@ pub fn rename(manifest: &mut Manifest, from: &str, to: &str) -> Result<()> {
 
 /// Stamp a text-content modification on the entry at `path`. Used to
 /// beat a stale delete under the modify-wins-over-delete rule (§6.3).
+///
+/// Errors if the entry at `path` is not a Text node — calling
+/// `record_modify_text` on a binary file would otherwise silently
+/// stamp the binary entry's `mod_lamp`, masking that the caller meant
+/// to operate on text content. Force the caller to use the binary
+/// API or look up the right path.
 pub fn record_modify_text(manifest: &mut Manifest, path: &str) -> Result<()> {
     let id = resolve_path(manifest, path)?;
+    let entry = manifest
+        .get_entry(id)
+        .ok_or_else(|| anyhow!("entry vanished mid-record-modify for {:?}", path))?;
+    if entry.kind != NodeKind::Text {
+        return Err(anyhow!(
+            "record_modify_text: entry at {:?} is {:?}, not Text",
+            path,
+            entry.kind
+        ));
+    }
     manifest.record_modify(id);
     Ok(())
 }
 
 /// Update the chunk-hash list of a binary entry at `path`. Also stamps
 /// modify so a stale delete can't resurrect older content.
+///
+/// Errors if the entry at `path` is not a Binary node — without this
+/// check `set_chunk_hashes` would silently corrupt a Text node by
+/// adding binary-only fields (`chunks`, `blob`, `size`).
 pub fn record_modify_binary(
     manifest: &mut Manifest,
     path: &str,
@@ -118,6 +138,16 @@ pub fn record_modify_binary(
     size: u64,
 ) -> Result<()> {
     let id = resolve_path(manifest, path)?;
+    let entry = manifest
+        .get_entry(id)
+        .ok_or_else(|| anyhow!("entry vanished mid-record-modify for {:?}", path))?;
+    if entry.kind != NodeKind::Binary {
+        return Err(anyhow!(
+            "record_modify_binary: entry at {:?} is {:?}, not Binary",
+            path,
+            entry.kind
+        ));
+    }
     manifest.set_chunk_hashes(id, chunk_hashes, size);
     Ok(())
 }

--- a/syncline/src/v1/projection.rs
+++ b/syncline/src/v1/projection.rs
@@ -165,10 +165,12 @@ fn build_path(entry: &NodeEntry, all: &HashMap<NodeId, NodeEntry>) -> Option<Str
             return None;
         }
         let parent = all.get(&pid)?;
-        if parent.deleted && parent.kind == NodeKind::Directory {
-            // Parent directory is tombstoned → child is orphaned; drop.
-            // (Cascade delete is expressed explicitly in §5.6 so this is
-            // merely a safety net.)
+        // Cascade-safety net (§5.6): a parent directory whose tombstone
+        // wins over any modify_stamp orphans its children. Use the
+        // same `is_live` rule as the projection — without this, a
+        // directory that was deleted-then-modify-resurrected (legal
+        // per §6.3) would still drop its children at projection time.
+        if parent.kind == NodeKind::Directory && !is_live(parent) {
             return None;
         }
         segments.push(parent.name.clone());
@@ -194,16 +196,33 @@ fn conflict_path(base: &str, stamp: Stamp, id: NodeId) -> String {
     }
 }
 
-fn split_ext(path: &str) -> (&str, Option<&str>) {
+/// Split a path into (stem, ext) for conflict-suffix and artifact-
+/// recognition purposes. The split happens on the *last* `.` of the
+/// final path segment, with one important exception: leading dots are
+/// part of the basename, not an extension separator.
+///
+/// This means `.hidden` → (`.hidden`, None), `..hidden` → (`..hidden`,
+/// None), `.env.local` → (`.env`, Some("local")). Without the leading-
+/// dots exception, `..hidden` would split as (`.`, "hidden"), producing
+/// garbled conflict-copy paths like `.conflict-...-NNNN.hidden`.
+pub(crate) fn split_ext(path: &str) -> (&str, Option<&str>) {
     // Split on the last '.', but only in the final segment (don't
-    // corrupt "foo.bar/baz").
+    // corrupt "foo.bar/baz") — and only if there's a non-dot character
+    // BEFORE that last dot (so `..hidden` is not mis-split).
     let last_slash = path.rfind('/').map(|i| i + 1).unwrap_or(0);
     let last = &path[last_slash..];
-    if let Some(dot) = last.rfind('.') {
-        if dot == 0 {
-            return (path, None); // ".hidden" → no extension
-        }
-        let stem_end = last_slash + dot;
+
+    // Number of leading dots in `last`. These are part of the
+    // basename, not separators.
+    let leading_dots = last.bytes().take_while(|&b| b == b'.').count();
+    if leading_dots == last.len() {
+        // All dots — no extension to split off.
+        return (path, None);
+    }
+    let body = &last[leading_dots..];
+    if let Some(dot) = body.rfind('.') {
+        // Map `dot` (offset into `body`) back to an offset into `path`.
+        let stem_end = last_slash + leading_dots + dot;
         return (&path[..stem_end], Some(&path[stem_end + 1..]));
     }
     (path, None)
@@ -338,6 +357,22 @@ mod tests {
         let (stem, ext) = split_ext(".hidden");
         assert_eq!(stem, ".hidden");
         assert_eq!(ext, None);
+    }
+
+    #[test]
+    fn split_ext_treats_leading_dots_as_part_of_basename() {
+        // Two leading dots: not split — basename stays whole.
+        assert_eq!(split_ext("..hidden"), ("..hidden", None));
+        // Three leading dots, no trailing extension.
+        assert_eq!(split_ext("...weird"), ("...weird", None));
+        // All-dots filename: no extension.
+        assert_eq!(split_ext(".."), ("..", None));
+        assert_eq!(split_ext("..."), ("...", None));
+        // Leading dots + a real extension still split correctly.
+        assert_eq!(split_ext("..weird.txt"), ("..weird", Some("txt")));
+        // Leading dot in the directory part doesn't trigger the rule.
+        assert_eq!(split_ext("..hidden/foo.bar"), ("..hidden/foo", Some("bar")));
+        assert_eq!(split_ext("..d/..baz"), ("..d/..baz", None));
     }
 
     #[test]

--- a/syncline/tests/e2e.rs
+++ b/syncline/tests/e2e.rs
@@ -2688,3 +2688,190 @@ async fn test_chunked_binary_modify_propagates() {
         tokio::time::sleep(Duration::from_millis(500)).await;
     }
 }
+
+// =============================================================================
+// Obsidian-like onboarding scenarios
+// =============================================================================
+//
+// User flow under test:
+//   1. The user runs `syncline server` somewhere.
+//   2. They start a CLI client on a fresh, empty folder (their server proxy
+//      / "always on" peer) and let it connect.
+//   3. They start the Obsidian plugin pointed at the same server, except
+//      their vault folder ALREADY HAS a typical mix of pre-existing
+//      content: a couple of `.md` notes (one nested), a binary attachment,
+//      and the `.obsidian/` folder with both a "should-sync" plugin
+//      config AND the device-local `workspace.json` (which is in the
+//      default ignore list — must NOT propagate).
+//
+// The Obsidian plugin and the CLI client share the entire `v1::*`
+// portable layer; the WASM client mirrors the CLI's bootstrap path
+// (scan disk → manifest → push). So the CLI-vs-CLI test below is the
+// closest in-process proxy we have for "Obsidian onboarding into a
+// non-empty server" without spinning up real Obsidian. It exercises:
+//   - default ignore-list defaults (`.obsidian/workspace.json`)
+//   - nested directory creation on the receiving peer
+//   - binary blob upload + chunk fetch → byte-identical disk file
+//   - bidirectional sync after onboarding
+//   - cold-restart of the seeded peer with offline edits applied to
+//     the fresh peer in between
+async fn poll_until<F>(deadline: std::time::Instant, mut check: F) -> bool
+where
+    F: FnMut() -> bool,
+{
+    while std::time::Instant::now() < deadline {
+        if check() {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+    check()
+}
+
+#[tokio::test]
+async fn test_obsidian_like_onboarding_with_pre_existing_vault() {
+    build_workspace().await;
+    let port = get_available_port();
+    let server_dir = TempDir::new().unwrap();
+    let db_path = server_dir.path().join("test.db");
+    let mut server = spawn_server(port, &db_path).await;
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    // Step 2: empty/fresh client connects first.
+    let fresh_dir = TempDir::new().unwrap();
+    let mut client_fresh = spawn_client_with_name(fresh_dir.path(), port, "fresh").await;
+    tokio::time::sleep(Duration::from_millis(2000)).await;
+
+    // Step 3: pre-seed an "Obsidian-like" vault.
+    let seeded_dir = TempDir::new().unwrap();
+    let seeded = seeded_dir.path();
+    fs::create_dir_all(seeded.join("notes/daily")).unwrap();
+    fs::create_dir_all(seeded.join(".obsidian")).unwrap();
+    fs::write(seeded.join("welcome.md"), "hello from seeded\n").unwrap();
+    fs::write(
+        seeded.join("notes/daily/day1.md"),
+        "# Day 1\nfirst entry",
+    )
+    .unwrap();
+    let photo_bytes: Vec<u8> = b"\xff\xd8\xff\xe0\x00\x10JFIF\x00pretend-jpeg-bytes".to_vec();
+    fs::write(seeded.join("photo.jpg"), &photo_bytes).unwrap();
+    fs::write(
+        seeded.join(".obsidian/community-plugins.json"),
+        b"[\"dataview\",\"templater\"]",
+    )
+    .unwrap();
+    // workspace.json is in the default ignore list → MUST NOT sync.
+    fs::write(
+        seeded.join(".obsidian/workspace.json"),
+        b"{\"layout\":\"device-local\"}",
+    )
+    .unwrap();
+
+    let mut client_seeded = spawn_client_with_name(seeded, port, "seeded").await;
+
+    // Wait for all four user-visible files to land on the fresh peer.
+    let fresh = fresh_dir.path().to_path_buf();
+    let deadline = std::time::Instant::now() + Duration::from_secs(20);
+    let bootstrap_ok = poll_until(deadline, || {
+        fresh.join("welcome.md").is_file()
+            && fresh.join("notes/daily/day1.md").is_file()
+            && fresh.join("photo.jpg").is_file()
+            && fresh.join(".obsidian/community-plugins.json").is_file()
+    })
+    .await;
+    assert!(
+        bootstrap_ok,
+        "expected files did not arrive on fresh peer within 20s; \
+         present = {:?}",
+        walkdir::WalkDir::new(&fresh)
+            .into_iter()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().is_file())
+            .filter(|e| !e.path().to_string_lossy().contains(".syncline"))
+            .map(|e| e.path().strip_prefix(&fresh).unwrap().to_path_buf())
+            .collect::<Vec<_>>(),
+    );
+
+    // Byte-identical content — text, nested text, binary, and an
+    // un-ignored .obsidian config.
+    assert_eq!(
+        fs::read_to_string(fresh.join("welcome.md")).unwrap(),
+        "hello from seeded\n",
+    );
+    assert_eq!(
+        fs::read_to_string(fresh.join("notes/daily/day1.md")).unwrap(),
+        "# Day 1\nfirst entry",
+    );
+    assert_eq!(fs::read(fresh.join("photo.jpg")).unwrap(), photo_bytes);
+    assert_eq!(
+        fs::read(fresh.join(".obsidian/community-plugins.json")).unwrap(),
+        b"[\"dataview\",\"templater\"]",
+    );
+
+    // The default-ignored workspace.json must NOT have propagated.
+    assert!(
+        !fresh.join(".obsidian/workspace.json").exists(),
+        ".obsidian/workspace.json must be excluded by the default ignore list",
+    );
+
+    // Bidirectional: fresh appends to a synced file and creates a new
+    // one; seeded picks both up.
+    fs::write(
+        fresh.join("welcome.md"),
+        "hello from seeded\nappended on fresh\n",
+    )
+    .unwrap();
+    fs::write(fresh.join("notes/daily/day2.md"), "## Day 2\nfrom fresh\n").unwrap();
+
+    let seeded_path = seeded.to_path_buf();
+    let bidi_deadline = std::time::Instant::now() + Duration::from_secs(15);
+    let bidi_ok = poll_until(bidi_deadline, || {
+        seeded_path.join("notes/daily/day2.md").is_file()
+            && fs::read_to_string(seeded_path.join("welcome.md"))
+                .map(|s| s.contains("appended on fresh"))
+                .unwrap_or(false)
+    })
+    .await;
+    assert!(
+        bidi_ok,
+        "bidirectional propagation timed out: day2 exists? {}, welcome.md = {:?}",
+        seeded_path.join("notes/daily/day2.md").exists(),
+        fs::read_to_string(seeded_path.join("welcome.md")).ok(),
+    );
+
+    // Cold-restart the seeded client and apply offline edits on fresh
+    // in between. After restart, the offline edits must arrive.
+    client_seeded.kill().await.unwrap();
+    tokio::time::sleep(Duration::from_millis(400)).await;
+    fs::write(
+        fresh.join("notes/daily/day3.md"),
+        "offline edit from fresh\n",
+    )
+    .unwrap();
+    fs::write(
+        fresh.join("welcome.md"),
+        "hello from seeded\nappended on fresh\nedit while seeded was offline\n",
+    )
+    .unwrap();
+    tokio::time::sleep(Duration::from_millis(2000)).await;
+
+    let mut client_seeded2 = spawn_client_with_name(seeded, port, "seeded").await;
+    let restart_deadline = std::time::Instant::now() + Duration::from_secs(15);
+    let restart_ok = poll_until(restart_deadline, || {
+        seeded_path.join("notes/daily/day3.md").is_file()
+            && fs::read_to_string(seeded_path.join("welcome.md"))
+                .map(|s| s.contains("edit while seeded was offline"))
+                .unwrap_or(false)
+    })
+    .await;
+    assert!(
+        restart_ok,
+        "post-restart catch-up failed: day3 exists? {}, welcome.md = {:?}",
+        seeded_path.join("notes/daily/day3.md").exists(),
+        fs::read_to_string(seeded_path.join("welcome.md")).ok(),
+    );
+
+    client_fresh.kill().await.unwrap();
+    client_seeded2.kill().await.unwrap();
+    server.kill().await.unwrap();
+}

--- a/syncline/tests/v1_robustness.rs
+++ b/syncline/tests/v1_robustness.rs
@@ -1,0 +1,1351 @@
+//! Robustness scenarios for the v1 manifest CRDT layer.
+//!
+//! These are pure portable tests (no I/O, no real client) that drive
+//! the manifest API directly through ops/projection/sync to exercise
+//! awkward concurrent edits, rename + delete races, conflict resolution
+//! determinism, hidden-file path handling, and the parent-chain
+//! pathologies (cycles, deep nesting) that the projection has to tame.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use syncline::v1::ids::{Lamport, Stamp};
+use syncline::v1::projection::project;
+use syncline::v1::{
+    create_binary, create_text, delete_path, handle_manifest_payload, manifest_step1_payload,
+    projection_hash, record_modify_text, rename, ActorId, Manifest, NodeKind,
+};
+
+/// Drive a full bidirectional sync between two manifests until they
+/// converge (in practice two passes are enough for everything in this
+/// file).
+fn sync(a: &mut Manifest, b: &mut Manifest) {
+    for _ in 0..2 {
+        let s_a = manifest_step1_payload(a);
+        let s_b = manifest_step1_payload(b);
+        let r_for_a = handle_manifest_payload(b, &s_a).unwrap().unwrap();
+        let r_for_b = handle_manifest_payload(a, &s_b).unwrap().unwrap();
+        handle_manifest_payload(a, &r_for_a).unwrap();
+        handle_manifest_payload(b, &r_for_b).unwrap();
+    }
+}
+
+/// All peers must agree on the projection hash.
+fn assert_converged(label: &str, peers: &[&Manifest]) {
+    let head = projection_hash(peers[0]);
+    for (i, p) in peers.iter().enumerate().skip(1) {
+        assert_eq!(
+            projection_hash(p),
+            head,
+            "{label}: peer #{i} diverged from peer #0",
+        );
+    }
+}
+
+/// Helper that asserts the projection paths on `a` and `b` are
+/// identical (regardless of order).
+fn assert_same_paths(label: &str, a: &Manifest, b: &Manifest) {
+    let p_a = project(a);
+    let p_b = project(b);
+    let mut paths_a: Vec<_> = p_a.by_path.keys().cloned().collect();
+    let mut paths_b: Vec<_> = p_b.by_path.keys().cloned().collect();
+    paths_a.sort();
+    paths_b.sort();
+    assert_eq!(
+        paths_a, paths_b,
+        "{label}: peers diverged\n  A: {paths_a:?}\n  B: {paths_b:?}",
+    );
+}
+
+// ===========================================================================
+// Scenario 1: cycle introduced by concurrent moves
+// ===========================================================================
+
+#[test]
+fn concurrent_moves_into_each_other_do_not_crash_or_diverge() {
+    // Setup: both peers start synced with two empty top-level
+    // directories D1 and D2 plus a file in each so we can see whether
+    // children survive the cycle.
+    let mut a = Manifest::new(ActorId::new());
+    let d1 = a.create_node("D1", None, NodeKind::Directory, &[], 0);
+    let d2 = a.create_node("D2", None, NodeKind::Directory, &[], 0);
+    let _f1 = a.create_node("a.md", Some(d1), NodeKind::Text, &[], 0);
+    let _f2 = a.create_node("b.md", Some(d2), NodeKind::Text, &[], 0);
+
+    let mut b = Manifest::from_update(
+        ActorId::new(),
+        a.lamport(),
+        &a.encode_state_as_update(),
+    )
+    .unwrap();
+
+    // Concurrent moves: A puts D1 inside D2, B puts D2 inside D1.
+    a.set_parent(d1, Some(d2));
+    b.set_parent(d2, Some(d1));
+
+    // Sync — expected to converge despite the cycle.
+    sync(&mut a, &mut b);
+    assert_converged("cycle", &[&a, &b]);
+
+    // The projection must terminate (this would loop without MAX_HOPS).
+    let p_a = project(&a);
+    let p_b = project(&b);
+
+    // Whatever the resolution, both peers must agree on the live set.
+    let mut paths_a: Vec<_> = p_a.by_path.keys().cloned().collect();
+    let mut paths_b: Vec<_> = p_b.by_path.keys().cloned().collect();
+    paths_a.sort();
+    paths_b.sort();
+    assert_eq!(paths_a, paths_b, "diverged paths under cycle");
+
+    // The cycle must not surface a file that crosses the loop forever.
+    // Either the file rows are absent (build_path returns None on
+    // exceeding MAX_HOPS), or they appear under whichever parent the
+    // LWW resolved. Either way, no path string is unbounded.
+    for p in &paths_a {
+        assert!(
+            p.split('/').count() <= 1024,
+            "path {p:?} exceeds MAX_HOPS depth — cycle leaked into projection",
+        );
+    }
+}
+
+// ===========================================================================
+// Scenario 2: concurrent rename of the same node
+// ===========================================================================
+
+#[test]
+fn concurrent_rename_of_same_node_converges_deterministically() {
+    let mut a = Manifest::new(ActorId::new());
+    let id = create_text(&mut a, "f.md", 0).unwrap();
+    let mut b = Manifest::from_update(
+        ActorId::new(),
+        a.lamport(),
+        &a.encode_state_as_update(),
+    )
+    .unwrap();
+
+    // Concurrent rename to different names — both stamp mod_lamp.
+    a.set_name(id, "from-a.md");
+    b.set_name(id, "from-b.md");
+
+    sync(&mut a, &mut b);
+    assert_converged("rename-race", &[&a, &b]);
+    assert_same_paths("rename-race", &a, &b);
+
+    // Exactly one of the two names wins; the other is gone.
+    let p = project(&a);
+    let names: Vec<_> = p.by_path.keys().cloned().collect();
+    assert_eq!(names.len(), 1, "rename collision must collapse to 1 entry");
+    assert!(
+        names[0] == "from-a.md" || names[0] == "from-b.md",
+        "winner must be one of the candidates, got {:?}",
+        names[0]
+    );
+}
+
+// ===========================================================================
+// Scenario 3: concurrent rename + delete on same node
+// ===========================================================================
+
+#[test]
+fn concurrent_rename_and_delete_converges() {
+    // A renames f.md → g.md while B deletes f.md (same NodeId). After
+    // sync, the projection on both peers must agree; either the rename's
+    // mod_lamp beats the delete's del_lamp (file lives under new name)
+    // or the reverse (file is gone). In either case, both peers must
+    // see the same outcome.
+    let mut a = Manifest::new(ActorId::new());
+    let _id = create_text(&mut a, "f.md", 0).unwrap();
+    let mut b = Manifest::from_update(
+        ActorId::new(),
+        a.lamport(),
+        &a.encode_state_as_update(),
+    )
+    .unwrap();
+
+    rename(&mut a, "f.md", "g.md").unwrap();
+    delete_path(&mut b, "f.md").unwrap();
+
+    sync(&mut a, &mut b);
+    assert_converged("rename-vs-delete", &[&a, &b]);
+    assert_same_paths("rename-vs-delete", &a, &b);
+}
+
+#[test]
+fn rename_after_observed_delete_resurrects() {
+    // The intent here matches DESIGN_DOC_V1.md §6.3: a peer that
+    // already saw the delete and *then* explicitly renames the dead
+    // node must resurrect it (modify-wins-over-delete) on every peer.
+    let mut a = Manifest::new(ActorId::new());
+    let id = create_text(&mut a, "f.md", 0).unwrap();
+    let mut b = Manifest::from_update(
+        ActorId::new(),
+        a.lamport(),
+        &a.encode_state_as_update(),
+    )
+    .unwrap();
+
+    // A deletes; sync; B observes; B renames the (tombstoned) NodeId.
+    delete_path(&mut a, "f.md").unwrap();
+    sync(&mut a, &mut b);
+    assert!(b.get_entry(id).unwrap().deleted);
+
+    // B already holds the NodeId from the editor's perspective.
+    assert!(b.set_name(id, "renamed.md"));
+
+    sync(&mut a, &mut b);
+    assert_converged("modify-after-observed-delete", &[&a, &b]);
+
+    // The resurrected entry shows up at the new path on both peers.
+    for (label, m) in [("a", &a), ("b", &b)] {
+        let p = project(m);
+        assert!(
+            p.by_path.contains_key("renamed.md"),
+            "{label} should have resurrected as renamed.md, paths = {:?}",
+            p.by_path.keys().collect::<Vec<_>>()
+        );
+    }
+}
+
+// ===========================================================================
+// Scenario 4: rename target collides with concurrent create
+// ===========================================================================
+
+#[test]
+fn rename_target_collides_with_concurrent_create() {
+    let mut a = Manifest::new(ActorId::new());
+    let _src = create_text(&mut a, "X.md", 0).unwrap();
+    let mut b = Manifest::from_update(
+        ActorId::new(),
+        a.lamport(),
+        &a.encode_state_as_update(),
+    )
+    .unwrap();
+
+    // A: rename X.md → Y.md
+    rename(&mut a, "X.md", "Y.md").unwrap();
+    // B (independently): create a fresh Y.md.
+    let _b_y = create_text(&mut b, "Y.md", 0).unwrap();
+
+    sync(&mut a, &mut b);
+    assert_converged("rename-vs-create", &[&a, &b]);
+    assert_same_paths("rename-vs-create", &a, &b);
+
+    // Two distinct nodes both want path Y.md → projection must
+    // surface both (one wins the canonical name, the other gets a
+    // conflict suffix). On both peers, the same naming pair appears.
+    let p = project(&a);
+    assert_eq!(p.len(), 2, "both renamed and created entry must surface");
+    let mut paths: Vec<_> = p.by_path.keys().cloned().collect();
+    paths.sort();
+    assert!(paths.contains(&"Y.md".to_string()));
+    assert!(paths.iter().any(|p| p.contains(".conflict-")));
+}
+
+// ===========================================================================
+// Scenario 5: file created inside a directory that was concurrently deleted
+// ===========================================================================
+
+#[test]
+fn child_created_under_concurrently_deleted_directory_is_orphaned() {
+    // A creates a directory plus a child. Sync. Then concurrently:
+    // A deletes the directory; B creates another child file in that
+    // directory. After sync, the live status of the deleted directory
+    // and the orphan child must agree on both peers, and the child
+    // must not project to a path under the dead directory (cascade
+    // safety net in `build_path`).
+    let mut a = Manifest::new(ActorId::new());
+    let dir = a.create_node("docs", None, NodeKind::Directory, &[], 0);
+    let _existing = a.create_node("a.md", Some(dir), NodeKind::Text, &[], 0);
+
+    let mut b = Manifest::from_update(
+        ActorId::new(),
+        a.lamport(),
+        &a.encode_state_as_update(),
+    )
+    .unwrap();
+
+    // A deletes the dir; B creates a new child while still seeing it.
+    a.delete(dir);
+    let _new_child = b.create_node("b.md", Some(dir), NodeKind::Text, &[], 0);
+
+    sync(&mut a, &mut b);
+    assert_converged("dir-delete-vs-create-child", &[&a, &b]);
+    assert_same_paths("dir-delete-vs-create-child", &a, &b);
+
+    // No path under "docs/" can survive on either peer; both children
+    // are orphaned by the cascade-safety net (§5.6 / projection).
+    let p = project(&a);
+    for path in p.by_path.keys() {
+        assert!(
+            !path.starts_with("docs/"),
+            "child {path:?} survived under tombstoned directory",
+        );
+    }
+}
+
+// ===========================================================================
+// Scenario 6: hidden files & dotfile dirs project + sync correctly
+// ===========================================================================
+
+#[test]
+fn dotfiles_and_dotdirs_project_correctly() {
+    let mut a = Manifest::new(ActorId::new());
+
+    // Pure dotfile at root, no extension.
+    create_text(&mut a, ".gitignore", 0).unwrap();
+    // Dotfile *with* an extension.
+    create_text(&mut a, ".env.local", 0).unwrap();
+    // Hidden directory holding a regular file.
+    create_text(&mut a, ".config/secret.md", 0).unwrap();
+    // Hidden directory + nested hidden file.
+    create_text(&mut a, ".obsidian/.workspace.json", 0).unwrap();
+
+    let mut b = Manifest::new(ActorId::new());
+    sync(&mut a, &mut b);
+    assert_converged("dotfiles", &[&a, &b]);
+
+    let p = project(&a);
+    for path in [
+        ".gitignore",
+        ".env.local",
+        ".config/secret.md",
+        ".obsidian/.workspace.json",
+    ] {
+        assert!(
+            p.by_path.contains_key(path),
+            "missing dotfile path {path}, got {:?}",
+            p.by_path.keys().collect::<Vec<_>>()
+        );
+    }
+}
+
+#[test]
+fn hidden_file_collisions_use_proper_extension_split() {
+    // Two peers create the same dotfile-with-extension; conflict
+    // suffix must keep `.local` as the extension and prepend the
+    // suffix to the stem `.env`, not split between `.` and `env`.
+    let mut a = Manifest::new(ActorId::new());
+    let _ = create_text(&mut a, ".env.local", 0).unwrap();
+    let mut b = Manifest::new(ActorId::new());
+    let _ = create_text(&mut b, ".env.local", 0).unwrap();
+
+    sync(&mut a, &mut b);
+    assert_converged("dotfile-conflict", &[&a, &b]);
+
+    let p = project(&a);
+    let mut paths: Vec<_> = p.by_path.keys().cloned().collect();
+    paths.sort();
+    assert_eq!(paths.len(), 2);
+    assert!(paths.contains(&".env.local".to_string()));
+    let suffixed = paths
+        .iter()
+        .find(|p| p.contains(".conflict-"))
+        .expect("expected one conflict-suffixed sibling");
+    assert!(
+        suffixed.ends_with(".local"),
+        "conflict path must keep .local extension, got {suffixed}",
+    );
+    assert!(
+        suffixed.starts_with(".env."),
+        "conflict path must keep .env stem, got {suffixed}",
+    );
+}
+
+#[test]
+fn pure_dotfile_with_no_extension_collision() {
+    // ".gitignore" has no extension — split_ext should return (path, None).
+    // Conflict copy must therefore have no trailing `.<ext>` segment.
+    let mut a = Manifest::new(ActorId::new());
+    let _ = create_text(&mut a, ".gitignore", 0).unwrap();
+    let mut b = Manifest::new(ActorId::new());
+    let _ = create_text(&mut b, ".gitignore", 0).unwrap();
+
+    sync(&mut a, &mut b);
+    assert_converged("dotfile-noext-conflict", &[&a, &b]);
+
+    let p = project(&a);
+    let mut paths: Vec<_> = p.by_path.keys().cloned().collect();
+    paths.sort();
+    assert_eq!(paths.len(), 2);
+    assert!(paths.contains(&".gitignore".to_string()));
+    let suffixed = paths
+        .iter()
+        .find(|p| p.contains(".conflict-"))
+        .expect("expected one conflict-suffixed sibling");
+    // No trailing extension segment past the conflict marker.
+    assert!(
+        !suffixed.ends_with(".gitignore"),
+        "conflict path must not duplicate full name, got {suffixed}",
+    );
+    assert!(
+        suffixed.starts_with(".gitignore.conflict-"),
+        "conflict path must extend the dotfile name, got {suffixed}",
+    );
+}
+
+// ===========================================================================
+// Scenario 7: directory rename reflects on every descendant
+// ===========================================================================
+
+#[test]
+fn directory_rename_propagates_to_all_descendants_on_both_peers() {
+    let mut a = Manifest::new(ActorId::new());
+    let dir = a.create_node("docs", None, NodeKind::Directory, &[], 0);
+    let _f1 = a.create_node("a.md", Some(dir), NodeKind::Text, &[], 0);
+    let _f2 = a.create_node("b.md", Some(dir), NodeKind::Text, &[], 0);
+    let sub = a.create_node("sub", Some(dir), NodeKind::Directory, &[], 0);
+    let _f3 = a.create_node("deep.md", Some(sub), NodeKind::Text, &[], 0);
+
+    let mut b = Manifest::from_update(
+        ActorId::new(),
+        a.lamport(),
+        &a.encode_state_as_update(),
+    )
+    .unwrap();
+
+    // Rename the top directory: just updating its `name` field.
+    a.set_name(dir, "books");
+    sync(&mut a, &mut b);
+
+    assert_converged("dir-rename", &[&a, &b]);
+    let p_a = project(&a);
+    for path in ["books/a.md", "books/b.md", "books/sub/deep.md"] {
+        assert!(
+            p_a.by_path.contains_key(path),
+            "missing renamed path {path}, got {:?}",
+            p_a.by_path.keys().collect::<Vec<_>>()
+        );
+    }
+    for path in ["docs/a.md", "docs/b.md", "docs/sub/deep.md"] {
+        assert!(
+            !p_a.by_path.contains_key(path),
+            "stale path {path} survived directory rename",
+        );
+    }
+}
+
+// ===========================================================================
+// Scenario 8: three-peer mesh convergence under combined ops
+// ===========================================================================
+
+fn full_mesh_sync(peers: &mut [Manifest], passes: usize) {
+    for _ in 0..passes {
+        let n = peers.len();
+        for i in 0..n {
+            for j in 0..n {
+                if i == j {
+                    continue;
+                }
+                // i sends step1; j replies; i applies.
+                let step1 = manifest_step1_payload(&peers[i]);
+                let resp = handle_manifest_payload(&mut peers[j], &step1)
+                    .unwrap()
+                    .unwrap();
+                handle_manifest_payload(&mut peers[i], &resp).unwrap();
+            }
+        }
+    }
+}
+
+#[test]
+fn three_peers_rename_modify_delete_converge() {
+    let mut a = Manifest::new(ActorId::new());
+    let id = create_text(&mut a, "shared.md", 0).unwrap();
+    let mut b = Manifest::from_update(
+        ActorId::new(),
+        a.lamport(),
+        &a.encode_state_as_update(),
+    )
+    .unwrap();
+    let mut c = Manifest::from_update(
+        ActorId::new(),
+        a.lamport(),
+        &a.encode_state_as_update(),
+    )
+    .unwrap();
+
+    // Concurrently: A renames, B modifies, C deletes.
+    a.set_name(id, "renamed.md");
+    b.record_modify(id);
+    c.delete(id);
+
+    let mut peers = vec![a, b, c];
+    full_mesh_sync(&mut peers, 2);
+
+    let head = projection_hash(&peers[0]);
+    for (i, p) in peers.iter().enumerate().skip(1) {
+        assert_eq!(
+            projection_hash(p),
+            head,
+            "three-peer convergence: peer #{i} diverged from #0",
+        );
+    }
+}
+
+// ===========================================================================
+// Scenario 9: binary file same-path collision
+// ===========================================================================
+
+#[test]
+fn binary_file_same_path_collision_is_deterministic() {
+    let mut a = Manifest::new(ActorId::new());
+    let _ = create_binary(&mut a, "img.png", &["aaaaaaaa".to_string()], 100).unwrap();
+    let mut b = Manifest::new(ActorId::new());
+    let _ = create_binary(&mut b, "img.png", &["bbbbbbbb".to_string()], 100).unwrap();
+
+    sync(&mut a, &mut b);
+    assert_converged("binary-collision", &[&a, &b]);
+    assert_same_paths("binary-collision", &a, &b);
+
+    let p = project(&a);
+    assert_eq!(p.len(), 2, "both binary entries must survive");
+    let canonical = p.by_path.get("img.png").expect("canonical path remains");
+    assert_eq!(canonical.kind, NodeKind::Binary);
+    let conflicts: Vec<_> = p
+        .by_path
+        .iter()
+        .filter(|(k, _)| k.contains(".conflict-"))
+        .collect();
+    assert_eq!(conflicts.len(), 1, "exactly one conflict-suffixed sibling");
+    assert!(conflicts[0].0.ends_with(".png"));
+}
+
+// ===========================================================================
+// Scenario 10: delete then create same name produces a new NodeId
+// ===========================================================================
+
+#[test]
+fn delete_then_create_same_name_is_a_new_node() {
+    let mut a = Manifest::new(ActorId::new());
+    let id1 = create_text(&mut a, "f.md", 0).unwrap();
+    delete_path(&mut a, "f.md").unwrap();
+    let id2 = create_text(&mut a, "f.md", 0).unwrap();
+
+    assert_ne!(id1, id2, "fresh create after delete must mint a new NodeId");
+
+    let p = project(&a);
+    let row = p.by_path.get("f.md").expect("file is live");
+    assert_eq!(row.id, id2, "live entry must be the fresh node");
+}
+
+// ===========================================================================
+// Scenario 11: ordering invariance — applying updates in different orders
+// must yield byte-equal projections.
+// ===========================================================================
+
+#[test]
+fn merge_order_does_not_change_projection_hash() {
+    // Three independent peers each do a concurrent op; we then merge in
+    // two different orders and assert both arrive at the same hash.
+    let make_seed = || {
+        let mut m = Manifest::new(ActorId::new());
+        create_text(&mut m, "shared.md", 0).unwrap();
+        m
+    };
+
+    let seed = make_seed();
+
+    // Build A, B, C from the same starting state.
+    let mut a = Manifest::from_update(
+        ActorId::new(),
+        seed.lamport(),
+        &seed.encode_state_as_update(),
+    )
+    .unwrap();
+    let mut b = Manifest::from_update(
+        ActorId::new(),
+        seed.lamport(),
+        &seed.encode_state_as_update(),
+    )
+    .unwrap();
+    let mut c = Manifest::from_update(
+        ActorId::new(),
+        seed.lamport(),
+        &seed.encode_state_as_update(),
+    )
+    .unwrap();
+
+    // Each does a different op concurrently.
+    create_text(&mut a, "from_a.md", 1).unwrap();
+    create_text(&mut b, "from_b.md", 2).unwrap();
+    create_text(&mut c, "from_c.md", 3).unwrap();
+
+    // Path 1: merge order A → B → C
+    let mut order1 = Manifest::new(ActorId::new());
+    order1.apply_update(&a.encode_state_as_update()).unwrap();
+    order1.apply_update(&b.encode_state_as_update()).unwrap();
+    order1.apply_update(&c.encode_state_as_update()).unwrap();
+
+    // Path 2: merge order C → A → B
+    let mut order2 = Manifest::new(ActorId::new());
+    order2.apply_update(&c.encode_state_as_update()).unwrap();
+    order2.apply_update(&a.encode_state_as_update()).unwrap();
+    order2.apply_update(&b.encode_state_as_update()).unwrap();
+
+    // Path 3: merge order B → C → A
+    let mut order3 = Manifest::new(ActorId::new());
+    order3.apply_update(&b.encode_state_as_update()).unwrap();
+    order3.apply_update(&c.encode_state_as_update()).unwrap();
+    order3.apply_update(&a.encode_state_as_update()).unwrap();
+
+    let h1 = projection_hash(&order1);
+    let h2 = projection_hash(&order2);
+    let h3 = projection_hash(&order3);
+    assert_eq!(h1, h2, "merge-order ABC vs CAB must match");
+    assert_eq!(h1, h3, "merge-order ABC vs BCA must match");
+}
+
+// ===========================================================================
+// Scenario 12: a deeply nested but non-cyclic path syncs cleanly
+// ===========================================================================
+
+#[test]
+fn deeply_nested_path_with_many_levels_syncs() {
+    let mut deep = String::from("a");
+    for i in 1..50 {
+        deep.push('/');
+        deep.push_str(&format!("d{i}"));
+    }
+    deep.push_str("/leaf.md");
+
+    let mut a = Manifest::new(ActorId::new());
+    create_text(&mut a, &deep, 0).unwrap();
+    let mut b = Manifest::new(ActorId::new());
+    sync(&mut a, &mut b);
+    assert_converged("deep-nesting", &[&a, &b]);
+
+    let p = project(&b);
+    assert!(
+        p.by_path.contains_key(&deep),
+        "deep path {deep} not projected on the receiving peer",
+    );
+}
+
+// ===========================================================================
+// Scenario 13: lamport advance after observing a far-future remote
+// ===========================================================================
+
+// ===========================================================================
+// Scenario 14: stamp tiebreak — same lamport, actor cmp decides
+// ===========================================================================
+
+#[test]
+fn stamp_tiebreak_picks_higher_actor_on_lamport_equality() {
+    // Synthesise the lo / hi actor ids deterministically.
+    let (lo_actor, hi_actor) = {
+        let a1 = ActorId::new();
+        let a2 = ActorId::new();
+        if a1 < a2 { (a1, a2) } else { (a2, a1) }
+    };
+    let s_lo = Stamp::new(Lamport(7), lo_actor);
+    let s_hi = Stamp::new(Lamport(7), hi_actor);
+    assert!(s_hi.beats(&s_lo));
+    assert!(!s_lo.beats(&s_hi));
+
+    // Stamp ordering is symmetric & total under PartialOrd / Ord.
+    assert!(s_hi > s_lo);
+    let mut v = vec![s_hi, s_lo];
+    v.sort();
+    assert_eq!(v, vec![s_lo, s_hi]);
+}
+
+// ===========================================================================
+// Scenario 15: find_entry_by_path returns the live entry even with a
+// stale tombstone parked at the same path
+// ===========================================================================
+
+#[test]
+fn find_entry_by_path_returns_live_when_tombstones_exist() {
+    let mut m = Manifest::new(ActorId::new());
+    let dead1 = m.create_node("twin.md", None, NodeKind::Text, &[], 0);
+    m.delete(dead1);
+    let dead2 = m.create_node("twin.md", None, NodeKind::Text, &[], 0);
+    m.delete(dead2);
+    // Now create a live entry with the same name. find_entry_by_path
+    // must return *this one* regardless of HashMap iteration order.
+    let live = m.create_node("twin.md", None, NodeKind::Text, &[], 0);
+
+    let found = m.find_entry_by_path("twin.md").unwrap();
+    assert_eq!(found.id, live, "must prefer live over tombstoned");
+    assert!(!found.deleted);
+}
+
+// ===========================================================================
+// Scenario 16: deeply nested rename composition
+// ===========================================================================
+
+#[test]
+fn rename_chain_eventually_lands_at_target() {
+    let mut a = Manifest::new(ActorId::new());
+    create_text(&mut a, "f.md", 0).unwrap();
+    rename(&mut a, "f.md", "g.md").unwrap();
+    rename(&mut a, "g.md", "h.md").unwrap();
+    rename(&mut a, "h.md", "i.md").unwrap();
+    rename(&mut a, "i.md", "f.md").unwrap();
+
+    let p = project(&a);
+    assert!(p.by_path.contains_key("f.md"));
+    assert_eq!(p.len(), 1, "exactly one live entry");
+}
+
+// ===========================================================================
+// Scenario 17: parent-of-self loop is dropped from projection
+// ===========================================================================
+
+#[test]
+fn self_parent_loop_is_dropped_from_projection() {
+    let mut m = Manifest::new(ActorId::new());
+    let dir = m.create_node("loop", None, NodeKind::Directory, &[], 0);
+    let file = m.create_node("under.md", Some(dir), NodeKind::Text, &[], 0);
+    // Make the directory its own parent — pathological but the
+    // projection must terminate and drop the orphans.
+    m.set_parent(dir, Some(dir));
+
+    let p = project(&m);
+    assert!(p.get_by_id(file).is_none(), "file under self-loop must not project");
+    assert!(p.is_empty(), "projection should be empty");
+}
+
+// ===========================================================================
+// Scenario 18: rename to currently-tombstoned path succeeds
+// ===========================================================================
+
+#[test]
+fn rename_to_path_held_only_by_tombstone_succeeds() {
+    let mut a = Manifest::new(ActorId::new());
+    let _id = create_text(&mut a, "f.md", 0).unwrap();
+    delete_path(&mut a, "f.md").unwrap();
+    let _g = create_text(&mut a, "g.md", 0).unwrap();
+    // f.md is tombstoned (not in projection.by_path), so rename should succeed.
+    rename(&mut a, "g.md", "f.md").unwrap();
+
+    let p = project(&a);
+    assert!(p.by_path.contains_key("f.md"));
+    assert!(!p.by_path.contains_key("g.md"));
+}
+
+// ===========================================================================
+// Scenario 19: rename to currently-occupied path fails
+// ===========================================================================
+
+#[test]
+fn rename_to_occupied_path_fails_clean() {
+    let mut a = Manifest::new(ActorId::new());
+    create_text(&mut a, "a.md", 0).unwrap();
+    create_text(&mut a, "b.md", 0).unwrap();
+    let result = rename(&mut a, "a.md", "b.md");
+    assert!(result.is_err(), "should refuse to overwrite live entry");
+
+    let p = project(&a);
+    assert!(p.by_path.contains_key("a.md"));
+    assert!(p.by_path.contains_key("b.md"));
+}
+
+// ===========================================================================
+// Scenario 20: concurrent delete vs modify converges on both peers
+// ===========================================================================
+
+#[test]
+fn concurrent_delete_and_modify_converges_on_both_peers() {
+    let mut a = Manifest::new(ActorId::new());
+    let _id = create_text(&mut a, "f.md", 0).unwrap();
+    let mut b = Manifest::from_update(
+        ActorId::new(),
+        a.lamport(),
+        &a.encode_state_as_update(),
+    )
+    .unwrap();
+
+    // Concurrent: A deletes, B modifies. Both stamp at the same
+    // lamport (each just ticked from the same baseline).
+    delete_path(&mut a, "f.md").unwrap();
+    record_modify_text(&mut b, "f.md").unwrap();
+
+    sync(&mut a, &mut b);
+    assert_converged("delete-vs-modify", &[&a, &b]);
+    assert_same_paths("delete-vs-modify", &a, &b);
+}
+
+// ===========================================================================
+// Scenario 21: 4-peer same-path collision converges to 4 entries
+// ===========================================================================
+
+#[test]
+fn four_peer_same_path_collision_yields_four_distinct_paths() {
+    let mut peers = Vec::new();
+    for _ in 0..4 {
+        let mut m = Manifest::new(ActorId::new());
+        create_text(&mut m, "popular.md", 0).unwrap();
+        peers.push(m);
+    }
+
+    full_mesh_sync(&mut peers, 3);
+
+    let head = projection_hash(&peers[0]);
+    for (i, m) in peers.iter().enumerate().skip(1) {
+        assert_eq!(projection_hash(m), head, "peer #{i} diverged");
+    }
+    let p = project(&peers[0]);
+    assert_eq!(p.len(), 4, "all four creators surface as separate entries");
+    let canonical_count = p
+        .by_path
+        .values()
+        .filter(|e| !e.is_conflict_copy)
+        .count();
+    let conflict_count = p
+        .by_path
+        .values()
+        .filter(|e| e.is_conflict_copy)
+        .count();
+    assert_eq!(canonical_count, 1);
+    assert_eq!(conflict_count, 3);
+}
+
+// ===========================================================================
+// Scenario 22: rename ping-pong between two peers
+// ===========================================================================
+
+#[test]
+fn rename_ping_pong_eventually_converges() {
+    let mut a = Manifest::new(ActorId::new());
+    let id = create_text(&mut a, "f.md", 0).unwrap();
+    let mut b = Manifest::from_update(
+        ActorId::new(),
+        a.lamport(),
+        &a.encode_state_as_update(),
+    )
+    .unwrap();
+
+    for round in 0..5 {
+        let a_name = format!("a{round}.md");
+        let b_name = format!("b{round}.md");
+        a.set_name(id, &a_name);
+        b.set_name(id, &b_name);
+        sync(&mut a, &mut b);
+        assert_converged(&format!("ping-pong-r{round}"), &[&a, &b]);
+        // The shared file always projects to exactly one path on both peers.
+        let p_a = project(&a);
+        let p_b = project(&b);
+        assert_eq!(p_a.len(), 1);
+        assert_eq!(p_b.len(), 1);
+        assert_eq!(
+            p_a.by_id.get(&id).map(|e| &e.path),
+            p_b.by_id.get(&id).map(|e| &e.path),
+            "round {round}: peer-projected paths diverged",
+        );
+    }
+}
+
+// ===========================================================================
+// Scenario 23: deterministic random fuzz of two-peer ops
+// ===========================================================================
+
+/// Tiny PRNG so the test is reproducible without pulling in `rand`.
+struct Xs(u64);
+impl Xs {
+    fn next(&mut self) -> u64 {
+        self.0 ^= self.0 << 13;
+        self.0 ^= self.0 >> 7;
+        self.0 ^= self.0 << 17;
+        self.0
+    }
+    fn range(&mut self, n: u64) -> u64 {
+        self.next() % n
+    }
+}
+
+fn random_op(rng: &mut Xs, m: &mut Manifest, names: &[String]) {
+    // Pick a random op weighted toward creates/modifies. Skip invalid
+    // ones (e.g., rename on empty manifest); we don't care about every
+    // step succeeding, only that the manifest stays internally
+    // consistent.
+    let live: Vec<_> = m.live_entries().into_iter().filter(|e| e.kind == NodeKind::Text).collect();
+    let op = rng.range(5);
+    match op {
+        0 | 1 => {
+            // Create at a random name from the pool.
+            let name = &names[(rng.range(names.len() as u64)) as usize];
+            let _ = create_text(m, name, 0);
+        }
+        2 => {
+            // Modify a random live entry.
+            if let Some(e) = live.first() {
+                let _ = m.record_modify(e.id);
+            }
+        }
+        3 => {
+            // Rename a random live entry.
+            if let Some(e) = live.first() {
+                let new = &names[(rng.range(names.len() as u64)) as usize];
+                let cur_path = {
+                    let p = project(m);
+                    p.by_id.get(&e.id).map(|r| r.path.clone())
+                };
+                if let Some(cur) = cur_path {
+                    let _ = rename(m, &cur, new);
+                }
+            }
+        }
+        _ => {
+            // Delete a random live entry.
+            if let Some(e) = live.first() {
+                let cur_path = {
+                    let p = project(m);
+                    p.by_id.get(&e.id).map(|r| r.path.clone())
+                };
+                if let Some(cur) = cur_path {
+                    let _ = delete_path(m, &cur);
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn random_two_peer_fuzz_converges_for_many_seeds() {
+    for seed in [42u64, 7, 0xDEADBEEF, 9999, 314159] {
+        let mut rng_a = Xs(seed.wrapping_mul(0xA1));
+        let mut rng_b = Xs(seed.wrapping_mul(0xB2));
+        let names: Vec<String> = (0..8).map(|i| format!("file_{i}.md")).collect();
+        let names2 = names.clone();
+
+        // Synced starting point.
+        let mut a = Manifest::new(ActorId::new());
+        let mut b = Manifest::from_update(
+            ActorId::new(),
+            a.lamport(),
+            &a.encode_state_as_update(),
+        )
+        .unwrap();
+
+        for _ in 0..50 {
+            random_op(&mut rng_a, &mut a, &names);
+            random_op(&mut rng_b, &mut b, &names2);
+        }
+        sync(&mut a, &mut b);
+        assert_converged(&format!("fuzz-{seed}"), &[&a, &b]);
+        // Run another round and re-verify so we exercise post-sync state.
+        for _ in 0..30 {
+            random_op(&mut rng_a, &mut a, &names);
+            random_op(&mut rng_b, &mut b, &names2);
+        }
+        sync(&mut a, &mut b);
+        assert_converged(&format!("fuzz-{seed} round2"), &[&a, &b]);
+    }
+}
+
+#[test]
+fn random_n_peer_fuzz_converges() {
+    // Stress: 4 peers each apply 30 random ops, full-mesh sync, verify
+    // convergence. Repeat for several seeds.
+    for seed in [101u64, 202, 303, 404] {
+        let names: Vec<String> = (0..6).map(|i| format!("note_{i}.md")).collect();
+        let mut peers: Vec<Manifest> = (0..4).map(|_| Manifest::new(ActorId::new())).collect();
+        let mut rngs: Vec<Xs> = (0..peers.len())
+            .map(|i| Xs(seed.wrapping_add(i as u64).wrapping_mul(0xC3)))
+            .collect();
+
+        for _ in 0..30 {
+            for i in 0..peers.len() {
+                random_op(&mut rngs[i], &mut peers[i], &names);
+            }
+        }
+
+        full_mesh_sync(&mut peers, 4);
+        let head = projection_hash(&peers[0]);
+        for (i, m) in peers.iter().enumerate().skip(1) {
+            assert_eq!(
+                projection_hash(m),
+                head,
+                "n-peer fuzz seed={seed}: peer #{i} diverged",
+            );
+        }
+    }
+}
+
+// ===========================================================================
+// Scenario: conflict suffixes are pairwise distinct under heavy collision
+// ===========================================================================
+
+#[test]
+fn conflict_suffixes_are_pairwise_distinct() {
+    // 8 peers all create the same path. After full mesh sync, the 8
+    // resulting projection paths must all be distinct — no two
+    // entries can collide on the disk.
+    let mut peers: Vec<Manifest> = (0..8).map(|_| Manifest::new(ActorId::new())).collect();
+    for m in peers.iter_mut() {
+        create_text(m, "popular.md", 0).unwrap();
+    }
+
+    full_mesh_sync(&mut peers, 4);
+
+    let p = project(&peers[0]);
+    let paths: Vec<String> = p.by_path.keys().cloned().collect();
+    assert_eq!(paths.len(), 8, "all 8 entries must surface");
+    let unique: std::collections::HashSet<_> = paths.iter().collect();
+    assert_eq!(unique.len(), 8, "conflict suffixes must be pairwise distinct");
+
+    // And every other peer agrees with peer 0's projection.
+    for (i, m) in peers.iter().enumerate().skip(1) {
+        assert_eq!(
+            projection_hash(m),
+            projection_hash(&peers[0]),
+            "peer #{i} projection diverged from peer #0",
+        );
+    }
+}
+
+// ===========================================================================
+// Scenario: directory resurrection should keep its children visible
+// ===========================================================================
+
+#[test]
+fn directory_resurrected_via_modify_wins_keeps_children_visible() {
+    // A directory was deleted, but a subsequent record_modify on it
+    // beats the delete (modify-wins-over-delete §6.3 also applies to
+    // directories). Children of that directory must therefore project,
+    // not be silently orphaned by build_path's cascade-safety check.
+    let mut m = Manifest::new(ActorId::new());
+    let dir = m.create_node("docs", None, NodeKind::Directory, &[], 0);
+    let file = m.create_node("note.md", Some(dir), NodeKind::Text, &[], 0);
+    // Tombstone the directory (deletes don't cascade automatically;
+    // children stay alive but lose their parent-chain).
+    m.delete(dir);
+    // Resurrect via a modify that ticks past the delete's lamport.
+    assert!(m.record_modify(dir));
+
+    let p = project(&m);
+    assert!(
+        p.get_by_id(file).is_some(),
+        "child of resurrected directory must project; current paths = {:?}",
+        p.by_path.keys().collect::<Vec<_>>()
+    );
+    assert_eq!(p.get_by_id(file).unwrap().path, "docs/note.md");
+}
+
+// ===========================================================================
+// Scenario: record_modify_binary refuses to mutate Text entries
+// ===========================================================================
+
+#[test]
+fn record_modify_binary_refuses_text_entries() {
+    use syncline::v1::record_modify_binary;
+    let mut m = Manifest::new(ActorId::new());
+    create_text(&mut m, "note.md", 5).unwrap();
+
+    // record_modify_binary should refuse when the entry kind is Text,
+    // not silently overwrite size and stamp chunk hashes onto it.
+    let result = record_modify_binary(
+        &mut m,
+        "note.md",
+        &["abcdef0123456789".to_string()],
+        100,
+    );
+    assert!(
+        result.is_err(),
+        "record_modify_binary on a Text entry must error",
+    );
+
+    // Sanity: the original Text entry survived intact.
+    let p = project(&m);
+    let row = p.by_path.get("note.md").unwrap();
+    assert_eq!(row.kind, NodeKind::Text);
+    assert_eq!(row.size, 5, "size must not be overwritten by failed binary modify");
+    assert!(row.chunk_hashes.is_empty(), "chunks must not be set on Text entry");
+}
+
+#[test]
+fn record_modify_text_refuses_binary_entries() {
+    use syncline::v1::create_binary as v1_create_binary;
+    let mut m = Manifest::new(ActorId::new());
+    v1_create_binary(&mut m, "img.png", &["abcdef".to_string()], 10).unwrap();
+
+    let result = record_modify_text(&mut m, "img.png");
+    assert!(
+        result.is_err(),
+        "record_modify_text on a Binary entry must error",
+    );
+}
+
+// ===========================================================================
+// Scenario: every-op-then-sync convergence ladder
+// ===========================================================================
+
+#[test]
+fn every_op_followed_by_sync_keeps_peers_aligned() {
+    // Apply ops one-at-a-time on alternating peers, syncing after
+    // every step. Convergence must hold at every step, not just the
+    // end. Catches subtle "intermittently divergent" bugs.
+    let mut a = Manifest::new(ActorId::new());
+    let mut b = Manifest::new(ActorId::new());
+
+    let ops: Vec<Box<dyn Fn(&mut Manifest)>> = vec![
+        Box::new(|m| {
+            let _ = create_text(m, "f.md", 0);
+        }),
+        Box::new(|m| {
+            let _ = record_modify_text(m, "f.md");
+        }),
+        Box::new(|m| {
+            let _ = rename(m, "f.md", "g.md");
+        }),
+        Box::new(|m| {
+            let _ = create_text(m, "h.md", 5);
+        }),
+        Box::new(|m| {
+            let _ = delete_path(m, "h.md");
+        }),
+        Box::new(|m| {
+            let _ = rename(m, "g.md", "h.md");
+        }),
+    ];
+
+    for (i, op) in ops.iter().enumerate() {
+        if i % 2 == 0 {
+            op(&mut a);
+        } else {
+            op(&mut b);
+        }
+        sync(&mut a, &mut b);
+        assert_converged(&format!("ladder step {i}"), &[&a, &b]);
+    }
+}
+
+// ===========================================================================
+// Scenario 24: stamp + projection determinism through encode/apply
+// ===========================================================================
+
+#[test]
+fn projection_hash_matches_after_full_state_roundtrip() {
+    let mut a = Manifest::new(ActorId::new());
+    create_text(&mut a, "one.md", 1).unwrap();
+    create_text(&mut a, "two/three.md", 2).unwrap();
+    delete_path(&mut a, "one.md").unwrap();
+    create_text(&mut a, "phoenix.md", 3).unwrap();
+    record_modify_text(&mut a, "phoenix.md").unwrap();
+    rename(&mut a, "phoenix.md", "renamed.md").unwrap();
+
+    let h_a = projection_hash(&a);
+
+    // Roundtrip through encode_state_as_update.
+    let bytes = a.encode_state_as_update();
+    let b = Manifest::from_update(ActorId::new(), Lamport::ZERO, &bytes).unwrap();
+    let h_b = projection_hash(&b);
+    assert_eq!(h_a, h_b, "projection_hash must be stable across encode/apply roundtrip");
+
+    // Same projection paths.
+    let p_a = project(&a);
+    let p_b = project(&b);
+    let mut paths_a: Vec<_> = p_a.by_path.keys().cloned().collect();
+    let mut paths_b: Vec<_> = p_b.by_path.keys().cloned().collect();
+    paths_a.sort();
+    paths_b.sort();
+    assert_eq!(paths_a, paths_b);
+}
+
+// ===========================================================================
+// Scenario 26: UTF-8 / non-ASCII filenames sync deterministically
+// ===========================================================================
+
+#[test]
+fn unicode_filenames_sync_correctly() {
+    let mut a = Manifest::new(ActorId::new());
+    let names = [
+        "Привет.md",
+        "안녕.md",
+        "你好.md",
+        "🚀rocket.md",
+        "déjà-vu.md",
+        "a/にほんご/note.md",
+    ];
+    for n in names {
+        create_text(&mut a, n, 0).unwrap();
+    }
+    let mut b = Manifest::new(ActorId::new());
+    sync(&mut a, &mut b);
+    assert_converged("unicode-paths", &[&a, &b]);
+    let p = project(&b);
+    for n in names {
+        assert!(
+            p.by_path.contains_key(n),
+            "unicode path missing on B: {n}, paths = {:?}",
+            p.by_path.keys().collect::<Vec<_>>()
+        );
+    }
+}
+
+#[test]
+fn unicode_filename_collisions_use_correct_extension_split() {
+    // ".env" with cyrillic "локал" extension.
+    let mut a = Manifest::new(ActorId::new());
+    create_text(&mut a, ".cfg.локал", 0).unwrap();
+    let mut b = Manifest::new(ActorId::new());
+    create_text(&mut b, ".cfg.локал", 0).unwrap();
+    sync(&mut a, &mut b);
+    assert_converged("unicode-conflict", &[&a, &b]);
+
+    let p = project(&a);
+    let conflict = p
+        .by_path
+        .keys()
+        .find(|k| k.contains(".conflict-"))
+        .expect("must have a conflict-suffixed sibling");
+    assert!(
+        conflict.ends_with(".локал"),
+        "conflict path must keep cyrillic extension intact, got {conflict}",
+    );
+    assert!(
+        conflict.starts_with(".cfg."),
+        "conflict path must keep .cfg stem, got {conflict}",
+    );
+}
+
+// ===========================================================================
+// Scenario 27: state-vector roundtrip after many incremental updates
+// ===========================================================================
+
+#[test]
+fn manifest_rehydrates_after_many_incremental_updates() {
+    use yrs::{ReadTxn, Transact};
+
+    let mut original = Manifest::new(ActorId::new());
+    let mut snapshots = Vec::new();
+    let mut prev_sv = original.doc().transact().state_vector();
+
+    for i in 0..30 {
+        create_text(&mut original, &format!("note_{i}.md"), i as u64).unwrap();
+        if i % 3 == 0 && i > 0 {
+            // Sometimes also delete a previous one.
+            let _ = delete_path(&mut original, &format!("note_{}.md", i - 1));
+        }
+        let new_sv = original.doc().transact().state_vector();
+        let delta = original
+            .doc()
+            .transact()
+            .encode_state_as_update_v1(&prev_sv);
+        snapshots.push(delta);
+        prev_sv = new_sv;
+    }
+
+    // Rebuild fresh from incremental deltas, applied in reverse and
+    // mid-shuffle order — yrs is order-independent for valid updates.
+    let mut rebuilt = Manifest::new(ActorId::new());
+    for s in snapshots.iter().rev() {
+        rebuilt.apply_update(s).unwrap();
+    }
+    assert_eq!(
+        projection_hash(&original),
+        projection_hash(&rebuilt),
+        "rehydration via incremental deltas (reversed order) must match",
+    );
+
+    // Same again, applying every-other-then-the-rest.
+    let mut rebuilt2 = Manifest::new(ActorId::new());
+    for s in snapshots.iter().step_by(2) {
+        rebuilt2.apply_update(s).unwrap();
+    }
+    for s in snapshots.iter().skip(1).step_by(2) {
+        rebuilt2.apply_update(s).unwrap();
+    }
+    assert_eq!(
+        projection_hash(&original),
+        projection_hash(&rebuilt2),
+        "rehydration via interleaved deltas must match",
+    );
+}
+
+// ===========================================================================
+// Scenario 28: ops::rename rejects malformed input cleanly
+// ===========================================================================
+
+#[test]
+fn rename_rejects_malformed_targets() {
+    let mut a = Manifest::new(ActorId::new());
+    create_text(&mut a, "src.md", 0).unwrap();
+    // Empty target leaf.
+    assert!(rename(&mut a, "src.md", "").is_err());
+    assert!(rename(&mut a, "src.md", "dir/").is_err());
+    // Empty intermediate segment in target.
+    assert!(rename(&mut a, "src.md", "a//b.md").is_err());
+}
+
+// ===========================================================================
+// Scenario 29: broken parent reference is dropped from projection
+// ===========================================================================
+
+#[test]
+fn entry_with_dangling_parent_does_not_crash_projection() {
+    use syncline::v1::ids::NodeId;
+
+    let mut m = Manifest::new(ActorId::new());
+    let real_dir = m.create_node("real", None, NodeKind::Directory, &[], 0);
+    let f = m.create_node("file.md", Some(real_dir), NodeKind::Text, &[], 0);
+    // Re-parent the file to a NodeId that doesn't exist.
+    let ghost = NodeId::new();
+    m.set_parent(f, Some(ghost));
+
+    let p = project(&m);
+    assert!(
+        p.get_by_id(f).is_none(),
+        "dangling parent must drop the entry from projection",
+    );
+    // No live entries surface, so empty.
+    assert!(p.is_empty());
+}
+
+// ===========================================================================
+// Scenario 25: pathological filenames in conflict path
+// ===========================================================================
+
+/// Two-leading-dots filename: `..hidden` should produce a conflict
+/// sibling that *prefixes* the original name, not one that mangles
+/// `..hidden` into `.<conflict>.hidden`. The split_ext heuristic must
+/// treat leading dots as part of the stem.
+#[test]
+fn double_dot_filename_conflict_keeps_full_basename() {
+    let mut a = Manifest::new(ActorId::new());
+    let _ = create_text(&mut a, "..hidden", 0).unwrap();
+    let mut b = Manifest::new(ActorId::new());
+    let _ = create_text(&mut b, "..hidden", 0).unwrap();
+
+    sync(&mut a, &mut b);
+    assert_converged("double-dot-conflict", &[&a, &b]);
+
+    let p = project(&a);
+    assert_eq!(p.len(), 2, "both nodes survive — one canonical, one conflict");
+    assert!(
+        p.by_path.contains_key("..hidden"),
+        "canonical name preserved",
+    );
+    let conflict = p
+        .by_path
+        .keys()
+        .find(|k| k.contains(".conflict-"))
+        .expect("expected one conflict-suffixed sibling");
+    assert!(
+        conflict.starts_with("..hidden"),
+        "conflict path must keep entire `..hidden` basename intact, got {conflict}",
+    );
+}
+
+#[test]
+fn lamport_advances_past_observed_remote() {
+    let mut a = Manifest::new(ActorId::new());
+    // Tick A's lamport up to a high value.
+    for i in 0..50 {
+        create_text(&mut a, &format!("x{i}.md"), 0).unwrap();
+    }
+    let a_lamp = a.lamport().get();
+    assert!(a_lamp >= 50);
+
+    let mut b = Manifest::new(ActorId::new());
+    assert_eq!(b.lamport().get(), 0);
+    b.apply_update(&a.encode_state_as_update()).unwrap();
+    assert!(
+        b.lamport().get() >= a_lamp,
+        "B should have advanced past A's lamport, got {} vs {}",
+        b.lamport().get(),
+        a_lamp,
+    );
+}


### PR DESCRIPTION
## Summary

Three workstreams folded into one branch:

1. **8 manifest-CRDT robustness fixes** in the v1 layer, each surfaced via TDD and pinned with unit + scenario coverage.
2. **New e2e scenarios** at three altitudes: portable manifest (`tests/v1_robustness.rs`), subprocess (`tests/e2e.rs`), and real Obsidian via wdio-obsidian-service (three new specs under `e2e/test/specs/`).
3. **Containerised e2e harness** (`e2e/docker/`) so the wdio suite runs headlessly under Podman or Docker on a CI runner with no display server.

Plus a 13-section testing playbook at `prompt.md` covering every layer (library, server, CLI, plugin, wdio, container, SQLite interrogation).

### Bug fixes (commit 2bd6fdc)

| Fix | Where |
| --- | --- |
| `split_ext` mishandled multi-leading-dot basenames (`..hidden`) → garbled conflict paths | `v1/projection.rs`; `client_v1.rs::conflict_sibling_path` + `looks_like_conflict_sibling_artifact` now route through the canonical helper |
| `Lamport::tick` / `observe` overflowed at `u64::MAX` (panic in debug, wrap in release — silently corrupted every later LWW) | `v1/ids.rs` saturating arithmetic |
| `reconcile_projection_to_disk` bailed with `?` on per-entry failures, stranding every later entry | `client_v1.rs` per-entry IIFE + warn-and-continue |
| Empty binary files (size=0) never materialised on receiving peers | `client_v1.rs` reconcile distinguishes `size==0` from "blob pending" |
| v0→v1 migration created Directory nodes with empty names for malformed paths | `v1/migration.rs` skips snapshots with empty path segments |
| `record_modify_text` / `record_modify_binary` silently corrupted entries of the wrong kind | `v1/ops.rs` kind-mismatch errors |
| `build_path` used raw `deleted` flag → directory-resurrection orphaned children | `v1/projection.rs` uses `is_live(parent)` for cascade-safety |

### Test surface added

- `syncline/tests/v1_robustness.rs` — ~40 portable scenarios (cycles, rename/delete races, hidden filenames, conflict-suffix uniqueness, four-peer same-path collisions, ordering invariance, deterministic seeded fuzz, lamport saturation, directory resurrection, etc.).
- `syncline/tests/e2e.rs::test_obsidian_like_onboarding_*` — subprocess scenario: server + fresh CLI peer + a seeded peer joining with pre-existing notes + binary + ignored `.obsidian/workspace.json`.
- `e2e/test/specs/pre-existing-vault.e2e.ts` — real Obsidian opens a pre-populated vault and connects (verified: 4/4 passing in ~17s).
- `e2e/test/specs/community-plugin-sync.e2e.ts` — opt-in via `configSync.communityPluginData[id]=true` (4/4 passing).
- `e2e/test/specs/plugin-cross-vault-install.e2e.ts` — \"install plugin on desktop, see it on laptop\": vault A pushes plugin → `browser.reloadObsidian({ vault: B })` reboots fresh → plugin arrives via Syncline alone → `app.plugins.loadManifests()` registers it (3/3 passing).

### Container harness (`e2e/docker/`)

Verified end-to-end with `podman compose`:
- Both new wdio specs pass inside the container against a real Linux Obsidian extracted from the upstream AppImage.
- `Running: chrome (v120.0.6099.283) on linux` — headless via Xvfb, no FUSE needed (uses `7z` for AppImage extraction).
- Same compose file works with Docker.

## Test plan

- [x] `cargo test -p syncline --lib` — 259 passing
- [x] `cargo test -p syncline --test v1_robustness` — 39 passing
- [x] `cargo test -p syncline --test v1_protocol_e2e` — 11 passing
- [x] `cargo test -p syncline --test e2e` — 37 passing (new Obsidian-onboarding test included)
- [x] `cd obsidian-plugin && npm run build` — WASM + rollup green; produces fresh `main.js` + `wasm/`
- [x] `cd e2e && npm test -- --spec test/specs/pre-existing-vault.e2e.ts` — 4/4
- [x] `cd e2e && npm test -- --spec test/specs/community-plugin-sync.e2e.ts` — 4/4
- [x] `cd e2e && npm test -- --spec test/specs/plugin-cross-vault-install.e2e.ts` — 3/3
- [x] `podman compose -f e2e/docker/docker-compose.yml build` — image builds cleanly
- [x] `podman compose -f e2e/docker/docker-compose.yml run --rm e2e bash e2e/docker/run-tests.sh --spec test/specs/pre-existing-vault.e2e.ts` — 4/4 inside container
- [x] `podman compose -f e2e/docker/docker-compose.yml run --rm e2e bash e2e/docker/run-tests.sh --spec test/specs/plugin-cross-vault-install.e2e.ts` — 3/3 inside container
- [ ] CI runs the full container suite once merged
- [ ] Existing `e2e/test/specs/{phase,issue,basic}*` still pass on a host with the prebuilt obsidian-plugin/main.js (regenerated as part of the wdio specs in this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)